### PR TITLE
style: normalize spacing around operators

### DIFF
--- a/view.py
+++ b/view.py
@@ -23,11 +23,11 @@ class PlayerTypeView(discord.ui.View):
 
     # ---------- Logique commune ----------
     async def _assign_role(self, interaction, role_id: int, label: str):
-        guild   = interaction.guild
-        member  = interaction.user
+        guild = interaction.guild
+        member = interaction.user
 
-        role        = guild.get_role(role_id)
-        other_role  = guild.get_role(
+        role = guild.get_role(role_id)
+        other_role = guild.get_role(
             ROLE_PC if role_id == ROLE_CONSOLE else ROLE_CONSOLE
         )
 


### PR DESCRIPTION
## Summary
- enforce single spaces around assignment operators in `_assign_role`

## Testing
- `python -m py_compile view.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a04f98acbc8324861fee349cc0aefb