### PR TITLE
Persist roles message via stored ID and component detection

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -94,19 +94,30 @@ VC_PROFILES = {
 
 VOC_PATTERN = re.compile(r"^(PC|Crossplay|Consoles|Chat)(?: (\d+))?$", re.I)
 PERMA_MESSAGE_MARK = "[VC_BUTTONS_PERMANENT]"
-ROLES_PERMA_MESSAGE_MARK = "[ROLES_BUTTONS_PERMANENT]"
 
 
 def _is_roles_permanent_message(msg: discord.Message) -> bool:
-    """Reconnaît le message permanent Rôles soit par contenu (legacy), soit par footer d'embed (nouveau)."""
+    """Détecte le message permanent des rôles via l'ID mémorisé ou la présence des boutons rôles."""
     if msg.author != bot.user:
         return False
-    if ROLES_PERMA_MESSAGE_MARK in (msg.content or ""):
+
+    remembered_id = _load_roles_perma_msg_id()
+    if remembered_id and msg.id == remembered_id:
         return True
-    for e in msg.embeds or []:
-        if e.footer and e.footer.text == ROLES_PERMA_MESSAGE_MARK:
-            return True
-    return False
+
+    required = {
+        "role_pc",
+        "role_console",
+        "role_mobile",
+        "role_notifications",
+    }
+    seen: set[str] = set()
+    for comp in msg.components:
+        for child in getattr(comp, "children", []):
+            cid = getattr(child, "custom_id", None)
+            if cid:
+                seen.add(cid)
+    return required.issubset(seen)
 
 
 # ─────────────────────── ETATS RUNTIME ──────────────────────
@@ -208,7 +219,7 @@ class PlayerTypeView(discord.ui.View):
     @discord.ui.button(
         label="🔔 Notifications",
         style=discord.ButtonStyle.secondary,
-        custom_id="role_notify",
+        custom_id="role_notifications",
     )
     async def btn_notify(
         self, interaction: discord.Interaction, button: discord.ui.Button
@@ -2316,8 +2327,6 @@ async def ensure_roles_buttons_message():
         "• 🔔 Notifications *(ajout/retrait **indépendant**, conservé quand tu changes de plateforme)*"
     )
     embed = discord.Embed(description=display_text, color=0x00C896)
-    # 🔴 IMPORTANT: footer-marquage pour que le détecteur retrouve le message
-    embed.set_footer(text=ROLES_PERMA_MESSAGE_MARK)
 
     # 1) D'abord: essayer par ID mémorisé
     remembered_id = _load_roles_perma_msg_id()
@@ -2329,6 +2338,7 @@ async def ensure_roles_buttons_message():
                 await msg.pin(reason="Message rôles permanent")
             except Exception:
                 pass
+            _save_roles_perma_msg_id(msg.id)
             logging.info(
                 "🔁 [roles] Message permanent réattaché via ID mémorisé."
             )
@@ -2338,7 +2348,7 @@ async def ensure_roles_buttons_message():
                 "[roles] ID mémorisé introuvable — on va rechercher dans l'historique."
             )
 
-    # 2) Chercher dans l'historique un message existant (footer ou legacy)
+    # 2) Chercher dans l'historique un message existant (legacy ou composants)
     found = None
     try:
         async for m in channel.history(limit=100):


### PR DESCRIPTION
## Summary
- remove footer marker from roles message
- detect existing roles message via stored ID or role button custom_ids
- rename notifications button id to `role_notifications`

## Testing
- `python -m py_compile bot.py view.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a057a455a08324a5634ffca88d8645