### PR TITLE
Ensure roulette channel has startup message

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -13,6 +13,7 @@ from discord.ext import commands
 from dotenv import load_dotenv
 from imageio_ffmpeg import get_ffmpeg_exe
 import yt_dlp
+from utils.discord_utils import ensure_channel_has_message
 
 
 # ─────────────────────── ENV & LOGGING ─────────────────────
@@ -83,6 +84,7 @@ CHANNEL_WELCOME = 1400550333796716574
 LOBBY_TEXT_CHANNEL = 1402258805533970472
 TIKTOK_ANNOUNCE_CH = 1400552164979507263
 ACTIVITY_SUMMARY_CH = 1400552164979507263
+ROULETTE_CHANNEL_ID = 1405170020748755034
 
 PARIS_TZ = ZoneInfo("Europe/Paris")
 OWNER_ID: int = int(os.getenv("OWNER_ID", "541417878314942495"))
@@ -2095,6 +2097,12 @@ async def on_ready():
         )
     except Exception as e:
         logging.debug(f"presence failed: {e}")
+
+    await ensure_channel_has_message(
+        bot,
+        ROULETTE_CHANNEL_ID,
+        "Premier message dans ce salon !",
+    )
 
     # ─ DÉMARRAGE RADIO ─
     global _radio_task

--- a/utils/discord_utils.py
+++ b/utils/discord_utils.py
@@ -1,0 +1,33 @@
+import logging
+import discord
+from discord.ext import commands
+
+async def ensure_channel_has_message(
+    bot: commands.Bot,
+    channel_id: int,
+    content: str,
+) -> None:
+    """
+    Ensure the text channel with ``channel_id`` contains at least one message.
+
+    If the channel has no history, send ``content``. Useful to guarantee
+    that a channel isn't empty when the bot starts.
+    """
+    channel = bot.get_channel(channel_id)
+    if channel is None:
+        try:
+            channel = await bot.fetch_channel(channel_id)
+        except discord.HTTPException as exc:
+            logging.warning(
+                "Impossible de récupérer le salon %s: %s", channel_id, exc
+            )
+            return
+
+    try:
+        async for _ in channel.history(limit=1):
+            return
+        await channel.send(content)
+    except discord.Forbidden:
+        logging.warning("Permissions insuffisantes dans %s", channel_id)
+    except discord.HTTPException as exc:
+        logging.warning("Erreur HTTP lors de l'envoi: %s", exc)


### PR DESCRIPTION
## Summary
- add utility to ensure a text channel has at least one message
- check roulette channel at startup and send placeholder message if empty

## Testing
- `python -m py_compile utils/discord_utils.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0dc4564788324874dea3d5c3f4d34