### PR TITLE
Rebuild temporary VC tracking and cleanup

### DIFF
--- a/storage/temp_vc_store.py
+++ b/storage/temp_vc_store.py
@@ -1,0 +1,21 @@
+import json
+from pathlib import Path
+from typing import Iterable, Set
+
+DATA_FILE = Path("data/temp_vc_ids.json")
+
+
+def load_temp_vc_ids() -> Set[int]:
+    """Charge la liste des salons temporaires persistés."""
+    try:
+        with DATA_FILE.open("r", encoding="utf-8") as fp:
+            return set(json.load(fp))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return set()
+
+
+def save_temp_vc_ids(ids: Iterable[int]) -> None:
+    """Persiste ``ids`` vers le fichier de stockage."""
+    DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with DATA_FILE.open("w", encoding="utf-8") as fp:
+        json.dump(sorted(set(ids)), fp, ensure_ascii=False, indent=2)

--- a/utils/temp_vc_cleanup.py
+++ b/utils/temp_vc_cleanup.py
@@ -1,0 +1,32 @@
+import logging
+import re
+from typing import Iterable
+
+import discord
+from discord.ext import commands
+
+TEMP_VC_NAME_RE = re.compile(r"^(PC|Crossplay|Consoles|Chat)(?:\b.*)?$", re.I)
+
+
+async def delete_untracked_temp_vcs(
+    bot: commands.Bot, category_id: int, tracked_ids: Iterable[int]
+) -> None:
+    """Supprime les salons temporaires non répertoriés.
+
+    Parcourt la catégorie ``category_id`` et supprime tout salon vocal dont le
+    nom correspond au schéma temporaire mais dont l'identifiant n'est pas dans
+    ``tracked_ids``. Les erreurs HTTP sont journalisées sans interrompre le
+    traitement.
+    """
+    category = bot.get_channel(category_id)
+    if not isinstance(category, discord.CategoryChannel):
+        return
+
+    tracked = set(tracked_ids)
+    for ch in list(category.voice_channels):
+        base = ch.name.split("•", 1)[0].strip()
+        if TEMP_VC_NAME_RE.match(base) and ch.id not in tracked:
+            try:
+                await ch.delete(reason="Salon temporaire orphelin")
+            except discord.HTTPException as exc:
+                logging.warning("Suppression salon %s échouée: %s", ch.id, exc)


### PR DESCRIPTION
## Summary
- rebuild TEMP_VC_IDS from the configured category at startup
- add utility to purge orphan temporary voice channels
- persist TEMP_VC_IDS to disk and update on create/delete

## Testing
- `python -m py_compile bot.py utils/temp_vc_cleanup.py storage/temp_vc_store.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0f946d9d08324a619d224f6bef2ff