### PR TITLE
feat: centralize interaction response handling

### DIFF
--- a/utils/interactions.py
+++ b/utils/interactions.py
@@ -1,0 +1,17 @@
+import logging
+
+import discord
+
+async def safe_respond(inter: discord.Interaction, content=None, **kwargs):
+    """Safely respond to an interaction.
+
+    If the initial response has already been sent, uses followup instead.
+    Defaults to sending a simple checkmark when no content is provided.
+    """
+    try:
+        if inter.response.is_done():
+            await inter.followup.send(content or "✅", **kwargs)
+        else:
+            await inter.response.send_message(content or "✅", **kwargs)
+    except Exception as e:
+        logging.error(f"Réponse interaction échouée: {e}")


### PR DESCRIPTION
## Summary
- add `safe_respond` helper to centralize interaction replies with fallback to followup
- refactor `VCButtonView.create_vc` to use helper for all responses

## Testing
- `python -m py_compile utils/interactions.py bot.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0fcf037fc832486826b299f825748