### PR TITLE
Ajoute temporisation pour la roulette

### DIFF
--- a/cogs/roulette.py
+++ b/cogs/roulette.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import random
 from datetime import datetime, timedelta
@@ -145,7 +146,10 @@ class RouletteView(discord.ui.View):
         except Exception as e:
             logging.error("[Roulette] announce_level_up échouée: %s", e)
 
-        await interaction.response.send_message(msg, ephemeral=True)
+        await interaction.response.defer(ephemeral=True)
+        await interaction.followup.send("🎰 La roulette tourne…", ephemeral=True)
+        await asyncio.sleep(10)
+        await interaction.edit_original_response(content=msg)
 
 
 class RouletteCog(commands.Cog):


### PR DESCRIPTION
## Summary
- ajoute l'import `asyncio`
- fait tourner la roulette avec un message différé et temporisation

## Testing
- `python -m py_compile cogs/roulette.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0ffe5f5048324b2fca6ac4648732b