### PR TITLE
style: order imports and include os

### DIFF
--- a/cogs/role_reminder.py
+++ b/cogs/role_reminder.py
@@ -1,12 +1,12 @@
 # cogs/role_reminder.py
-import os
-import json
 import asyncio
+import json
 import logging
+import os
 import random
-from pathlib import Path
 from datetime import datetime
-from typing import Dict, Any
+from pathlib import Path
+from typing import Any, Dict
 
 import discord
 from discord import app_commands


### PR DESCRIPTION
## Summary
- order imports in role_reminder to include os

## Testing
- `python -m py_compile cogs/role_reminder.py`
- `DATA_DIR=/tmp python - <<'PY'
from cogs import role_reminder
print(role_reminder.DATA_DIR)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68a104946204832480694432ba97dbb1