### PR TITLE
Ensure discord utils imports are defined

### DIFF
--- a/utils/discord_utils.py
+++ b/utils/discord_utils.py
@@ -1,5 +1,5 @@
-import logging
 import discord
+import logging
 from discord.ext import commands
 
 async def ensure_channel_has_message(


### PR DESCRIPTION
## Summary
- Reorder `discord_utils` imports to ensure `discord` and `logging` are explicitly imported before the commands extension

## Testing
- `python -m pyflakes utils/discord_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68a1053854dc83248c8a9cb6039e95ee