### PR TITLE
refactor: centralize PlayerTypeView

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -18,6 +18,13 @@ from utils.discord_utils import ensure_channel_has_message
 from utils.temp_vc_cleanup import delete_untracked_temp_vcs
 from utils.interactions import safe_respond
 from storage.temp_vc_store import load_temp_vc_ids, save_temp_vc_ids
+from view import (
+    PlayerTypeView,
+    ROLE_PC,
+    ROLE_CONSOLE,
+    ROLE_MOBILE,
+    ROLE_NOTIFICATION,
+)
 
 
 # ─────────────────────── ENV & LOGGING ─────────────────────
@@ -49,10 +56,6 @@ LEVEL_ROLE_REWARDS = {
 }
 
 # ── Rôles plateformes + notifications
-ROLE_PC = 1400560541529018408
-ROLE_CONSOLE = 1400560660710162492
-ROLE_MOBILE = 1404791652085928008
-ROLE_NOTIFICATION = 1404882154370109450
 
 # (facultatif, pratique si tu veux itérer)
 PLATFORM_ROLE_IDS = {
@@ -184,164 +187,6 @@ if not TOKEN:
     raise RuntimeError(
         "DISCORD_TOKEN manquant. Ajoute la variable dans Railway > Service > Variables"
     )
-
-
-# ─────────────────────── ROLE ─────────────────────
-class PlayerTypeView(discord.ui.View):
-    """
-    Boutons de rôles :
-        - Plateformes (PC/Consoles/Mobile) : exclusifs entre eux
-        - Notifications : toggle indépendant (coexiste avec n'importe quelle plateforme)
-    """
-
-    def __init__(self):
-        super().__init__(timeout=None)  # Vue persistante
-
-    # ── Plateformes (exclusives) ─────────────────────────────────────────
-    @discord.ui.button(
-        label="💻 PC", style=discord.ButtonStyle.primary, custom_id="role_pc"
-    )
-    async def btn_pc(
-        self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
-        await self._set_platform_role(interaction, ROLE_PC, "PC")
-
-    @discord.ui.button(
-        label="🎮 Consoles",
-        style=discord.ButtonStyle.primary,
-        custom_id="role_console",
-    )
-    async def btn_console(
-        self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
-        await self._set_platform_role(interaction, ROLE_CONSOLE, "Consoles")
-
-    @discord.ui.button(
-        label="📱 Mobile",
-        style=discord.ButtonStyle.primary,
-        custom_id="role_mobile",
-    )
-    async def btn_mobile(
-        self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
-        await self._set_platform_role(interaction, ROLE_MOBILE, "Mobile")
-
-    # ── Notifications (toggle indépendant) ───────────────────────────────
-    @discord.ui.button(
-        label="🔔 Notifications",
-        style=discord.ButtonStyle.secondary,
-        custom_id="role_notifications",
-    )
-    async def btn_notify(
-        self, interaction: discord.Interaction, button: discord.ui.Button
-    ):
-        await self._toggle_role(
-            interaction, ROLE_NOTIFICATION, "Notifications"
-        )
-
-    # ── Helpers ──────────────────────────────────────────────────────────
-    async def _set_platform_role(
-        self, interaction: discord.Interaction, role_id: int, label: str
-    ):
-        """
-        Règle de gestion (nouvelle) :
-        - Si le membre a DÉJÀ cette plateforme -> ne rien faire (pas de toggle off).
-        - Sinon -> ajouter cette plateforme et retirer automatiquement les AUTRES plateformes.
-        - Le rôle 🔔 Notifications n’est JAMAIS touché ici.
-        """
-        guild = interaction.guild
-        if not guild:
-            return await interaction.response.send_message(
-                "❌ Action impossible en message privé.", ephemeral=True
-            )
-
-        role = guild.get_role(role_id)
-        if not role:
-            return await interaction.response.send_message(
-                f"❌ Rôle introuvable ({label}).", ephemeral=True
-            )
-
-        member = interaction.user
-        try:
-            # a) S'il a déjà cette plateforme -> NO-OP (aucun retrait)
-            if role in member.roles:
-                return await interaction.response.send_message(
-                    f"✅ Tu es déjà sur **{label}** (aucun changement).",
-                    ephemeral=True,
-                )
-
-            # b) Sinon -> ajouter cette plateforme et retirer les autres plateformes
-            other_platform_ids = {ROLE_PC, ROLE_CONSOLE, ROLE_MOBILE} - {
-                role_id
-            }
-            other_platform_roles = [
-                guild.get_role(rid) for rid in other_platform_ids
-            ]
-            remove_list = [
-                r for r in other_platform_roles if r and r in member.roles
-            ]
-
-            if remove_list:
-                await member.remove_roles(
-                    *remove_list, reason=f"Changement de plateforme -> {label}"
-                )
-
-            await member.add_roles(
-                role, reason=f"Ajout rôle plateforme {label}"
-            )
-
-            removed_txt = (
-                f" (retiré: {', '.join(f'**{r.name}**' for r in remove_list)})"
-                if remove_list
-                else ""
-            )
-            await interaction.response.send_message(
-                f"✅ Plateforme mise à jour : **{label}**{removed_txt}.\n"
-                f"🔔 *Le rôle Notifications est conservé.*",
-                ephemeral=True,
-            )
-
-        except Exception as e:
-            logging.error(f"Erreur set_platform {label}: {e}")
-            await interaction.response.send_message(
-                "❌ Impossible de modifier tes rôles.", ephemeral=True
-            )
-
-    async def _toggle_role(
-        self, interaction: discord.Interaction, role_id: int, label: str
-    ):
-        """
-        Toggle simple (utilisé pour 🔔 Notifications) : ajoute/retire UNIQUEMENT ce rôle.
-        """
-        guild = interaction.guild
-        if not guild:
-            return await interaction.response.send_message(
-                "❌ Action impossible en message privé.", ephemeral=True
-            )
-
-        role = guild.get_role(role_id)
-        if not role:
-            return await interaction.response.send_message(
-                f"❌ Rôle introuvable ({label}).", ephemeral=True
-            )
-
-        member = interaction.user
-        try:
-            if role in member.roles:
-                await member.remove_roles(role, reason=f"Retrait rôle {label}")
-                await interaction.response.send_message(
-                    f"🔕 Rôle **{label}** retiré.", ephemeral=True
-                )
-            else:
-                await member.add_roles(role, reason=f"Ajout rôle {label}")
-                await interaction.response.send_message(
-                    f"🔔 Rôle **{label}** ajouté.", ephemeral=True
-                )
-        except Exception as e:
-            logging.error(f"Erreur toggle rôle {label}: {e}")
-            await interaction.response.send_message(
-                "❌ Impossible de modifier tes rôles.", ephemeral=True
-            )
 
 
 # ─────────────────────── PERSISTANCE (VOLUME) ─────────────────────

--- a/view.py
+++ b/view.py
@@ -1,51 +1,143 @@
+import logging
 import discord
 
+
 # IDs des rôles
-ROLE_PC      = 1400560541529018408
+ROLE_PC = 1400560541529018408
 ROLE_CONSOLE = 1400560660710162492
+ROLE_MOBILE = 1404791652085928008
+ROLE_NOTIFICATION = 1404882154370109450
 
 
 class PlayerTypeView(discord.ui.View):
-    """Deux boutons : Console ou PC."""
+    """Boutons de rôles :
+        - Plateformes (PC/Consoles/Mobile) : exclusives entre elles
+        - Notifications : toggle indépendant (coexiste avec n'importe quelle plateforme)
+    """
 
-    def __init__(self):
-        super().__init__(timeout=60)      # 60 s pour cliquer
+    def __init__(self) -> None:
+        super().__init__(timeout=None)  # Vue persistante
 
-    # ---------- Bouton Console ----------
-    @discord.ui.button(label="🎮 Console", style=discord.ButtonStyle.primary)
-    async def console_button(self, interaction: discord.Interaction, _):
-        await self._assign_role(interaction, ROLE_CONSOLE, "Console")
+    # ── Plateformes (exclusives) ─────────────────────────────────────────
+    @discord.ui.button(label="💻 PC", style=discord.ButtonStyle.primary, custom_id="role_pc")
+    async def btn_pc(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await self._set_platform_role(interaction, ROLE_PC, "PC")
 
-    # ---------- Bouton PC ----------
-    @discord.ui.button(label="💻 PC", style=discord.ButtonStyle.secondary)
-    async def pc_button(self, interaction: discord.Interaction, _):
-        await self._assign_role(interaction, ROLE_PC, "PC")
+    @discord.ui.button(
+        label="🎮 Consoles",
+        style=discord.ButtonStyle.primary,
+        custom_id="role_console",
+    )
+    async def btn_console(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await self._set_platform_role(interaction, ROLE_CONSOLE, "Consoles")
 
-    # ---------- Logique commune ----------
-    async def _assign_role(self, interaction, role_id: int, label: str):
+    @discord.ui.button(
+        label="📱 Mobile",
+        style=discord.ButtonStyle.primary,
+        custom_id="role_mobile",
+    )
+    async def btn_mobile(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await self._set_platform_role(interaction, ROLE_MOBILE, "Mobile")
+
+    # ── Notifications (toggle indépendant) ───────────────────────────────
+    @discord.ui.button(
+        label="🔔 Notifications",
+        style=discord.ButtonStyle.secondary,
+        custom_id="role_notifications",
+    )
+    async def btn_notify(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:
+        await self._toggle_role(interaction, ROLE_NOTIFICATION, "Notifications")
+
+    # ── Helpers ──────────────────────────────────────────────────────────
+    async def _set_platform_role(
+        self, interaction: discord.Interaction, role_id: int, label: str
+    ) -> None:
+        """Gère les rôles de plateformes (exclusifs)."""
         guild = interaction.guild
-        member = interaction.user
+        if not guild:
+            return await interaction.response.send_message(
+                "❌ Action impossible en message privé.", ephemeral=True
+            )
 
         role = guild.get_role(role_id)
-        other_role = guild.get_role(
-            ROLE_PC if role_id == ROLE_CONSOLE else ROLE_CONSOLE
-        )
+        if not role:
+            return await interaction.response.send_message(
+                f"❌ Rôle introuvable ({label}).", ephemeral=True
+            )
 
-        # Ajout / retrait des rôles
-        roles = set(member.roles)
-        roles.discard(other_role)
-        roles.add(role)
-        await member.edit(roles=list(roles), reason="Choix type joueur")
-
-        # Confirmation éphémère
-        await interaction.response.send_message(
-            f"✅ Tu es maintenant classé **{label}** !",
-            ephemeral=True
-        )
-
-        # Suppression du message public (nécessite Manage Messages)
+        member = interaction.user
         try:
-            await interaction.message.delete()
-        except discord.Forbidden:
-            # On ignore si le bot n'a pas la permission
-            pass
+            # a) S'il a déjà cette plateforme -> NO-OP (aucun retrait)
+            if role in member.roles:
+                return await interaction.response.send_message(
+                    f"✅ Tu es déjà sur **{label}** (aucun changement).",
+                    ephemeral=True,
+                )
+
+            # b) Sinon -> ajouter cette plateforme et retirer les autres plateformes
+            other_platform_ids = {ROLE_PC, ROLE_CONSOLE, ROLE_MOBILE} - {role_id}
+            other_platform_roles = [
+                guild.get_role(rid) for rid in other_platform_ids
+            ]
+            remove_list = [r for r in other_platform_roles if r and r in member.roles]
+
+            if remove_list:
+                await member.remove_roles(
+                    *remove_list, reason=f"Changement de plateforme -> {label}"
+                )
+
+            await member.add_roles(
+                role, reason=f"Ajout rôle plateforme {label}"
+            )
+
+            removed_txt = (
+                f" (retiré: {', '.join(f'**{r.name}**' for r in remove_list)})"
+                if remove_list
+                else ""
+            )
+            await interaction.response.send_message(
+                f"✅ Plateforme mise à jour : **{label}**{removed_txt}.\n"
+                f"🔔 *Le rôle Notifications est conservé.*",
+                ephemeral=True,
+            )
+
+        except Exception as e:  # pragma: no cover - log pour débogage
+            logging.error(f"Erreur set_platform {label}: {e}")
+            await interaction.response.send_message(
+                "❌ Impossible de modifier tes rôles.", ephemeral=True
+            )
+
+    async def _toggle_role(
+        self, interaction: discord.Interaction, role_id: int, label: str
+    ) -> None:
+        """Ajoute ou retire le rôle donné (utilisé pour 🔔 Notifications)."""
+        guild = interaction.guild
+        if not guild:
+            return await interaction.response.send_message(
+                "❌ Action impossible en message privé.", ephemeral=True
+            )
+
+        role = guild.get_role(role_id)
+        if not role:
+            return await interaction.response.send_message(
+                f"❌ Rôle introuvable ({label}).", ephemeral=True
+            )
+
+        member = interaction.user
+        try:
+            if role in member.roles:
+                await member.remove_roles(role, reason=f"Retrait rôle {label}")
+                await interaction.response.send_message(
+                    f"🔕 Rôle **{label}** retiré.", ephemeral=True
+                )
+            else:
+                await member.add_roles(role, reason=f"Ajout rôle {label}")
+                await interaction.response.send_message(
+                    f"🔔 Rôle **{label}** ajouté.", ephemeral=True
+                )
+        except Exception as e:  # pragma: no cover - log pour débogage
+            logging.error(f"Erreur toggle rôle {label}: {e}")
+            await interaction.response.send_message(
+                "❌ Impossible de modifier tes rôles.", ephemeral=True
+            )
+


### PR DESCRIPTION
## Summary
- centralize PlayerTypeView in `view.py` and expose role IDs
- import consolidated PlayerTypeView and constants in bot setup

## Testing
- `python -m py_compile view.py bot.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a10574ae4883249e209231c4bbd629