### PR TITLE
Rendre le renommage des salons plus réactif

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -94,7 +94,8 @@ AUTO_RENAME_ENABLED = True
 # Format du nom : {base} = PC/Crossplay/Consoles/Chat | {game} = nom du jeu détecté
 AUTO_RENAME_FORMAT = "{base} • {game}"
 # Fréquence min entre deux renames pour un même salon (anti-spam)
-AUTO_RENAME_COOLDOWN_SEC = 45
+# Valeur réduite pour rendre le renommage plus réactif
+AUTO_RENAME_COOLDOWN_SEC = 15
 
 # ─────────────────────── CONFIG ─────────────────────────────
 LEVEL_UP_CHANNEL = 1402419913716531352
@@ -1855,7 +1856,7 @@ async def auto_rename_poll():
                     await maybe_rename_channel_by_game(ch)
         except Exception as e:
             logging.debug(f"auto_rename_poll error: {e}")
-        await asyncio.sleep(20)  # toutes les 20s
+        await asyncio.sleep(5)  # toutes les 5s pour une réaction plus rapide
 
 
 async def vc_buttons_watchdog(interval_seconds: int = 120):


### PR DESCRIPTION
## Summary
- reduce channel auto-rename cooldown to 15 seconds
- poll temporary channels every 5 seconds for game-based rename updates

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a1157e1dd88324b698056d860873f4