### PR TITLE
Remove redundant io import in rank card generator

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -440,7 +440,6 @@ async def generate_rank_card(
     user: discord.User, level: int, xp: int, xp_needed: int
 ):
     from PIL import Image, ImageDraw
-    import io
 
     img = Image.new("RGB", (460, 140), color=(30, 41, 59))
     draw = ImageDraw.Draw(img)


### PR DESCRIPTION
## Summary
- remove inner `io` import inside `generate_rank_card`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a119cec13483249edde247fc7ce627