### PR TITLE
Use supported FFmpeg buffer_size option

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `nixpacks.toml` build configuration already lists `libopus0` to ensure the l
 Audio playback relies on FFmpeg. Some useful parameters can be tuned in
 `bot.py`:
 
-- `-bufsize 64k` : limite le tampon interne pour réduire la latence.
+- `-buffer_size 64k` : limite le tampon d'entrée pour réduire la latence.
 - `-probesize 32k` : diminue les données analysées afin d'accélérer le démarrage du flux.
 - `-filter:a loudnorm` : applique une normalisation du volume.
 

--- a/bot.py
+++ b/bot.py
@@ -877,13 +877,13 @@ def _ff_headers() -> str:
 def _before_opts() -> str:
     """FFmpeg arguments placed before the input URL.
 
-    -bufsize 64k: limit the internal buffer to reduce latency.
+    -buffer_size 64k: limit the input buffer to reduce latency.
     -probesize 32k: lower probe size so the stream starts faster.
     """
     return (
         "-nostdin -reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5 "
         "-protocol_whitelist file,http,https,tcp,tls,crypto,pipe "
-        "-bufsize 64k -probesize 32k "
+        "-buffer_size 64k -probesize 32k "
         f'-headers "{_ff_headers()}"'
     )
 


### PR DESCRIPTION
## Summary
- replace deprecated `-bufsize` with `-buffer_size` in `_before_opts`
- update comments and README to describe the new FFmpeg buffer flag

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a124ab7a308324856c13c06e15ec77