### PR TITLE
Replace buffer size flag with ffmpeg nobuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `nixpacks.toml` build configuration already lists `libopus0` to ensure the l
 Audio playback relies on FFmpeg. Some useful parameters can be tuned in
 `bot.py`:
 
-- `-buffer_size 64k` : limite le tampon d'entrée pour réduire la latence.
+- `-fflags nobuffer` : désactive le tampon d'entrée pour réduire la latence.
 - `-probesize 32k` : diminue les données analysées afin d'accélérer le démarrage du flux.
 - `-filter:a loudnorm` : applique une normalisation du volume.
 

--- a/bot.py
+++ b/bot.py
@@ -877,13 +877,13 @@ def _ff_headers() -> str:
 def _before_opts() -> str:
     """FFmpeg arguments placed before the input URL.
 
-    -buffer_size 64k: limit the input buffer to reduce latency.
+    -fflags nobuffer: disable input buffering to reduce latency.
     -probesize 32k: lower probe size so the stream starts faster.
     """
     return (
         "-nostdin -reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5 "
         "-protocol_whitelist file,http,https,tcp,tls,crypto,pipe "
-        "-buffer_size 64k -probesize 32k "
+        "-fflags nobuffer -probesize 32k "
         f'-headers "{_ff_headers()}"'
     )
 


### PR DESCRIPTION
## Summary
- switch `-buffer_size 64k` to `-fflags nobuffer` in FFmpeg options for broader compatibility
- document the new flag in the README

## Testing
- `python -m py_compile bot.py`
- `DISCORD_TOKEN=dummy python bot.py` *(fails: Network is unreachable)*
- `/root/.pyenv/versions/3.11.12/lib/python3.11/site-packages/imageio_ffmpeg/binaries/ffmpeg-linux-x86_64-v7.0.2 -nostdin -protocol_whitelist file,http,https,tcp,tls,crypto,pipe -fflags nobuffer -probesize 32k -f lavfi -i anullsrc -t 1 -f null -`


------
https://chatgpt.com/codex/tasks/task_e_68a12827ceb88324977023c2faee6752