### PR TITLE
Restrict voice auto-rename to temporary channels and ignore bot in stats

### DIFF
--- a/utils/interactions.py
+++ b/utils/interactions.py
@@ -9,9 +9,15 @@ async def safe_respond(inter: discord.Interaction, content=None, **kwargs):
     Defaults to sending a simple checkmark when no content is provided.
     """
     try:
+        if inter.is_expired():
+            logging.debug("Interaction expirée, aucune réponse envoyée.")
+            return
         if inter.response.is_done():
             await inter.followup.send(content or "✅", **kwargs)
         else:
             await inter.response.send_message(content or "✅", **kwargs)
+    except discord.NotFound:
+        # Interaction inconnue ou expirée : on ignore silencieusement
+        return
     except Exception as e:
         logging.error(f"Réponse interaction échouée: {e}")


### PR DESCRIPTION
## Summary
- avoid renaming lobby or other permanent voice channels
- exclude bots from game detection and server stats
- silently ignore expired or unknown interactions to prevent debug spam

## Testing
- `python -m py_compile utils/interactions.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a12e2dea9883248d72a0facd528c54