### PR TITLE
Add admin commands for roulette refresh and server XP

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1371,7 +1371,7 @@ async def rang(interaction: discord.Interaction):
     name="xp_serveur",
     description="Affiche l'XP de tous les membres du serveur",
 )
-@app_commands.check(is_xp_viewer)
+@app_commands.checks.has_permissions(manage_guild=True)
 async def xp_serveur(interaction: discord.Interaction):
     async with XP_LOCK:
         items = list(XP_CACHE.items())

--- a/cogs/roulette.py
+++ b/cogs/roulette.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 import discord
+from discord import app_commands
 from discord.ext import commands, tasks
 from zoneinfo import ZoneInfo
 
@@ -439,6 +440,22 @@ class RouletteCog(commands.Cog):
                     self.store.clear_role_assignment(uid)
         except Exception as e:
             logging.error(f"[Roulette] roles_cleanup_loop erreur: {e}")
+
+    # ── Slash command admin ──
+    group = app_commands.Group(
+        name="roulette",
+        description="Gestion de la roulette",
+    )
+
+    @group.command(
+        name="refresh",
+        description="Republier le message de la roulette",
+    )
+    @app_commands.checks.has_permissions(manage_guild=True)
+    async def refresh_roulette(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        await self._replace_poster_message()
+        await interaction.followup.send("✅ Message roulette rafraîchi.", ephemeral=True)
 
     async def cog_load(self):
         try:


### PR DESCRIPTION
## Summary
- Allow admins to republish the roulette message via `/roulette refresh`
- Restrict server XP list to admins via `xp_serveur`

## Testing
- `python -m py_compile cogs/roulette.py bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1ab9f2fb88324993ee71972505b3a