### PR TITLE
fix: ensure single argument in roulette send_message

### DIFF
--- a/cogs/roulette.py
+++ b/cogs/roulette.py
@@ -56,8 +56,8 @@ class RouletteView(discord.ui.View):
                 (
                     "⏳ La roulette est ouverte "
                     "**de 10:00 à 22:00 (Europe/Paris)**.\n"
+                    f"🔔 Prochaine ouverture/fermeture : **{_fmt(nxt)}**."
                 ),
-                f"🔔 Prochaine ouverture/fermeture : **{_fmt(nxt)}**.",
                 ephemeral=True,
             )
 


### PR DESCRIPTION
## Summary
- combine roulette shutdown notice into a single content string to avoid multiple positional arguments

## Testing
- `python -m py_compile cogs/roulette.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1eee0bc648324a4f049a2b11dbfe4