### PR TITLE
Cancel role reminder tasks on cog unload

### DIFF
--- a/cogs/role_reminder.py
+++ b/cogs/role_reminder.py
@@ -111,6 +111,10 @@ class RoleReminderCog(commands.Cog):
         self._scan_task = asyncio.create_task(self._scan_loop())
         self._cleanup_task = asyncio.create_task(self._cleanup_loop())
 
+    def cog_unload(self):
+        self._scan_task.cancel()
+        self._cleanup_task.cancel()
+
     # ── State ──
 
     def _load_state(self):

--- a/tests/test_role_reminder_unload.py
+++ b/tests/test_role_reminder_unload.py
@@ -1,0 +1,42 @@
+import asyncio
+from unittest.mock import patch
+from pathlib import Path
+import sys
+
+import pytest
+import discord
+from discord.ext import commands
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from cogs.role_reminder import RoleReminderCog
+
+
+class DummyTask:
+    def __init__(self):
+        self.cancelled = False
+
+    def cancel(self):
+        self.cancelled = True
+
+
+@pytest.mark.asyncio
+async def test_cog_unload_cancels_tasks():
+    created_tasks = []
+
+    def fake_create_task(coro, *args, **kwargs):
+        coro.close()
+        t = DummyTask()
+        created_tasks.append(t)
+        return t
+
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+
+    with patch("asyncio.create_task", fake_create_task):
+        cog = RoleReminderCog(bot)
+
+    await bot.add_cog(cog)
+    await bot.remove_cog(cog.__cog_name__)
+
+    assert all(t.cancelled for t in created_tasks)
+
+    await bot.close()


### PR DESCRIPTION
## Summary
- cancel background reminder tasks when RoleReminderCog is unloaded
- test that removing the cog cancels scan and cleanup tasks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1f14bd8bc8324a349c16bd88f9b72