### PR TITLE
feat: make data directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,17 @@ ROLE_PC = 123456789012345678  # ID du rôle PC de votre serveur
 
 `bot.py` et `view.py` importent ces constantes afin d'éviter toute valeur
 en dur dans le code.
+
+## Données persistantes
+
+Certaines fonctionnalités (XP, roulette, salons temporaires…) écrivent des
+fichiers JSON pour conserver leur état.  Par défaut, ces fichiers sont
+stockés dans le dossier `/data`.  Vous pouvez modifier cet emplacement en
+définissant la variable d'environnement `DATA_DIR` :
+
+```bash
+export DATA_DIR=/chemin/vers/mes/données
+```
+
+Assurez-vous que ce dossier existe et est accessible en lecture/écriture par
+le bot.

--- a/cogs/roulette.py
+++ b/cogs/roulette.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 import random
 from datetime import datetime, timedelta
 from typing import Optional
@@ -179,7 +180,7 @@ class RouletteCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self.tz = ZoneInfo(PARIS_TZ)
-        self.store = RouletteStore(data_dir="/data")
+        self.store = RouletteStore(data_dir=os.getenv("DATA_DIR", "/data"))
         self.current_view_enabled = is_open_now(PARIS_TZ, 10, 22)
         self._last_announced_state: Optional[bool] = None
 

--- a/storage/temp_vc_store.py
+++ b/storage/temp_vc_store.py
@@ -1,8 +1,9 @@
 import json
+import os
 from pathlib import Path
 from typing import Iterable, Set
 
-DATA_FILE = Path("data/temp_vc_ids.json")
+DATA_FILE = Path(os.getenv("DATA_DIR", "/data")) / "temp_vc_ids.json"
 
 
 def load_temp_vc_ids() -> Set[int]:


### PR DESCRIPTION
## Summary
- make roulette store respect `DATA_DIR` env variable
- allow temp VC store to use `DATA_DIR`
- document `DATA_DIR` for persistent data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1f79f38d48324aae9d3e04bf4d956