### PR TITLE
feat: dynamic temp vc naming

### DIFF
--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -1,20 +1,33 @@
-import asyncio
 import logging
-from typing import Set
+from typing import Dict, Set
 
 import discord
 from discord.ext import commands, tasks
 
-from utils.temp_vc_cleanup import delete_untracked_temp_vcs
+from config import (
+    LOBBY_VC_ID,
+    ROLE_CONSOLE,
+    ROLE_MOBILE,
+    ROLE_PC,
+    TEMP_VC_CATEGORY,
+    TEMP_VC_LIMITS,
+)
 from storage.temp_vc_store import load_temp_vc_ids, save_temp_vc_ids
-from config import TEMP_VC_CATEGORY
+from utils.temp_vc_cleanup import delete_untracked_temp_vcs
 
 # IDs des salons vocaux temporaires connus
 TEMP_VC_IDS: Set[int] = set(load_temp_vc_ids())
 
+# Mapping « rôle principal → nom de base du salon »
+ROLE_NAMES: Dict[int, str] = {
+    ROLE_PC: "PC",
+    ROLE_CONSOLE: "Console",
+    ROLE_MOBILE: "Mobile",
+}
+
 
 class TempVCCog(commands.Cog):
-    """Maintenance des salons vocaux temporaires."""
+    """Création et maintenance des salons vocaux temporaires."""
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
@@ -22,6 +35,104 @@ class TempVCCog(commands.Cog):
 
     def cog_unload(self) -> None:
         self.cleanup.cancel()
+
+    # ---------- outils internes ----------
+
+    def _base_name_for(self, member: discord.Member) -> str:
+        """Retourne le nom de base du salon selon le rôle principal."""
+        for rid, name in ROLE_NAMES.items():
+            if member.get_role(rid):
+                return name
+        return "Chat"
+
+    async def _update_channel_name(self, channel: discord.VoiceChannel) -> None:
+        """Renomme le salon selon l'activité ou le statut du membre."""
+        if not channel.members:
+            return
+        base = channel.name.split("•", 1)[0].strip()
+        status = "Chat"
+        for m in channel.members:
+            if m.voice and m.voice.self_mute:
+                status = "Endormie"
+                break
+            for act in m.activities:
+                if isinstance(act, discord.Game):
+                    status = act.name
+                    break
+            if status not in {"Chat", "Endormie"}:
+                break
+        new = f"{base} • {status}"
+        if channel.name != new:
+            try:
+                await channel.edit(name=new)
+            except discord.HTTPException:
+                logging.exception("Renommage du salon %s échoué", channel.id)
+
+    async def _create_temp_vc(self, member: discord.Member) -> discord.VoiceChannel:
+        """Crée un salon vocal temporaire et l’enregistre."""
+        category = self.bot.get_channel(TEMP_VC_CATEGORY)
+        if not isinstance(category, discord.CategoryChannel):
+            raise RuntimeError("TEMP_VC_CATEGORY invalide")
+
+        base = self._base_name_for(member)
+        limit = TEMP_VC_LIMITS.get(TEMP_VC_CATEGORY)
+        channel = await category.create_voice_channel(base, user_limit=limit)
+
+        TEMP_VC_IDS.add(channel.id)
+        save_temp_vc_ids(TEMP_VC_IDS)
+        return channel
+
+    # ----------- événements Discord -----------
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(
+        self,
+        member: discord.Member,
+        before: discord.VoiceState,
+        after: discord.VoiceState,
+    ) -> None:
+        # 1) Création quand on rejoint le lobby
+        if after.channel and after.channel.id == LOBBY_VC_ID:
+            new_vc = await self._create_temp_vc(member)
+            try:
+                await member.move_to(new_vc)
+            except discord.HTTPException:
+                pass
+            await self._update_channel_name(new_vc)
+            return
+
+        # 2) Suppression du salon temporaire quand il se vide
+        if before.channel and before.channel.id in TEMP_VC_IDS:
+            if len(before.channel.members) == 0:
+                try:
+                    await before.channel.delete(reason="Salon temporaire vide")
+                except discord.HTTPException:
+                    logging.exception(
+                        "Suppression du salon %s échouée", before.channel.id
+                    )
+                else:
+                    TEMP_VC_IDS.discard(before.channel.id)
+                    save_temp_vc_ids(TEMP_VC_IDS)
+
+        # 3) Renommage sur changement d'état vocal
+        if after.channel and after.channel.id in TEMP_VC_IDS:
+            await self._update_channel_name(after.channel)
+        if (
+            before.channel
+            and before.channel != after.channel
+            and before.channel.id in TEMP_VC_IDS
+        ):
+            await self._update_channel_name(before.channel)
+
+    @commands.Cog.listener()
+    async def on_presence_update(
+        self, before: discord.Member, after: discord.Member
+    ) -> None:
+        """Renomme le salon quand un membre commence/arrête un jeu."""
+        if after.voice and after.voice.channel and after.voice.channel.id in TEMP_VC_IDS:
+            await self._update_channel_name(after.voice.channel)
+
+    # ---------- tâche de nettoyage ----------
 
     @tasks.loop(minutes=10)
     async def cleanup(self) -> None:
@@ -35,3 +146,4 @@ class TempVCCog(commands.Cog):
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(TempVCCog(bot))
+

--- a/utils/temp_vc_cleanup.py
+++ b/utils/temp_vc_cleanup.py
@@ -5,7 +5,7 @@ from typing import Iterable
 import discord
 from discord.ext import commands
 
-TEMP_VC_NAME_RE = re.compile(r"^(PC|Crossplay|Consoles|Chat)(?:\b.*)?$", re.I)
+TEMP_VC_NAME_RE = re.compile(r"^(PC|Console|Mobile|Crossplay|Chat)(?:\b.*)?$", re.I)
 
 
 async def delete_untracked_temp_vcs(


### PR DESCRIPTION
## Summary
- create temporary voice channels based on member roles and rename depending on activity
- mark idle rooms with Chat and muted users with Endormie
- expand temp VC cleanup regex to support new role names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a1fa72219c8324947cf24b94fa04f1