### PR TITLE
Add server statistics cog

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -25,6 +25,7 @@ async def setup_hook() -> None:
     await bot.load_extension("cogs.temp_vc")
     await bot.load_extension("cogs.misc")
     await bot.load_extension("cogs.radio")
+    await bot.load_extension("cogs.stats")
 
 
 TOKEN = os.getenv("DISCORD_TOKEN") or os.getenv("TOKEN") or os.getenv("BOT_TOKEN")

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -1,0 +1,46 @@
+import discord
+from discord.ext import commands, tasks
+from discord import app_commands
+
+import config
+from utils.discord_utils import safe_channel_edit
+from utils.interactions import safe_respond
+
+
+class StatsCog(commands.Cog):
+    """Gestion des salons de statistiques (membres, activité, etc.)."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.refresh_stats.start()
+
+    def cog_unload(self) -> None:
+        self.refresh_stats.cancel()
+
+    async def update_stats(self, guild: discord.Guild) -> None:
+        """Met à jour les salons de statistiques pour ``guild``."""
+        category = guild.get_channel(config.STATS_CATEGORY_ID)
+        if category is None:
+            return
+        members = guild.member_count
+        online = sum(1 for m in guild.members if m.status != discord.Status.offline)
+        channels = getattr(category, "channels", [])
+        if len(channels) > 0:
+            await safe_channel_edit(channels[0], name=f"Members: {members}")
+        if len(channels) > 1:
+            await safe_channel_edit(channels[1], name=f"Online: {online}")
+
+    @tasks.loop(minutes=10)
+    async def refresh_stats(self) -> None:
+        await self.bot.wait_until_ready()
+        for guild in self.bot.guilds:
+            await self.update_stats(guild)
+
+    @app_commands.command(name="stats_refresh", description="Met à jour les salons de statistiques.")
+    async def slash_stats_refresh(self, interaction: discord.Interaction) -> None:
+        await self.update_stats(interaction.guild)
+        await safe_respond(interaction, "Statistiques mises à jour", ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(StatsCog(bot))

--- a/tests/test_stats_update.py
+++ b/tests/test_stats_update.py
@@ -1,0 +1,64 @@
+import discord
+import pytest
+from discord.ext import commands
+
+import config
+from cogs.stats import StatsCog
+
+
+class DummyChannel:
+    def __init__(self):
+        self.name: str | None = None
+
+
+class DummyCategory:
+    def __init__(self, channels):
+        self.channels = channels
+
+
+class DummyMember:
+    def __init__(self, status):
+        self.status = status
+
+
+class DummyGuild:
+    def __init__(self, members, category):
+        self.members = members
+        self._category = category
+
+    @property
+    def member_count(self):
+        return len(self.members)
+
+    def get_channel(self, cid):
+        if cid == config.STATS_CATEGORY_ID:
+            return self._category
+        return None
+
+
+@pytest.mark.asyncio
+async def test_update_stats_changes_channel_names(monkeypatch):
+    ch1 = DummyChannel()
+    ch2 = DummyChannel()
+    category = DummyCategory([ch1, ch2])
+    guild = DummyGuild(
+        [DummyMember(discord.Status.online), DummyMember(discord.Status.offline)],
+        category,
+    )
+
+    async def fake_safe_channel_edit(channel, **kwargs):
+        channel.name = kwargs.get("name")
+
+    monkeypatch.setattr("cogs.stats.safe_channel_edit", fake_safe_channel_edit)
+
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = StatsCog(bot)
+    cog.refresh_stats.cancel()
+
+    await cog.update_stats(guild)
+
+    assert ch1.name == f"Members: {guild.member_count}"
+    online = sum(1 for m in guild.members if m.status != discord.Status.offline)
+    assert ch2.name == f"Online: {online}"
+
+    await bot.close()


### PR DESCRIPTION
## Summary
- add `StatsCog` to update member and online counts in a stats category
- expose `/stats_refresh` slash command and periodic update loop
- load new cog at bot startup and cover with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2365bfc988324839e2404fbabe186