### PR TITLE
fix(temp-vc): preserve channels across redeploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ export DATA_DIR=/chemin/vers/mes/données
 Assurez-vous que ce dossier existe et est accessible en lecture/écriture par
 le bot.
 
+Les salons vocaux temporaires sont listés dans `data/temp_vc_ids.json`. Ce
+fichier doit être conservé entre les redéploiements (volume monté ou dossier
+`DATA_DIR` persistant), sans quoi les salons existants seront supprimés lors du
+démarrage.
+
 ### Sauvegarde des sessions vocales
 
 Les heures d'entrée des membres en vocal sont stockées dans

--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -14,7 +14,7 @@ from config import (
     TEMP_VC_LIMITS,
 )
 from storage.temp_vc_store import load_temp_vc_ids, save_temp_vc_ids
-from utils.temp_vc_cleanup import delete_untracked_temp_vcs
+from utils.temp_vc_cleanup import delete_untracked_temp_vcs, TEMP_VC_NAME_RE
 from utils.discord_utils import safe_channel_edit
 
 # IDs des salons vocaux temporaires connus
@@ -33,6 +33,17 @@ class TempVCCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
+
+        if not TEMP_VC_IDS:
+            category = bot.get_channel(TEMP_VC_CATEGORY)
+            if isinstance(category, discord.CategoryChannel):
+                for ch in category.voice_channels:
+                    base = ch.name.split("•", 1)[0].strip()
+                    if TEMP_VC_NAME_RE.match(base):
+                        TEMP_VC_IDS.add(ch.id)
+                if TEMP_VC_IDS:
+                    save_temp_vc_ids(TEMP_VC_IDS)
+
         self.cleanup.start()
         self._rename_tasks: Dict[int, asyncio.Task] = {}
 

--- a/tests/test_temp_vc_cleanup.py
+++ b/tests/test_temp_vc_cleanup.py
@@ -1,0 +1,53 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from utils.temp_vc_cleanup import delete_untracked_temp_vcs
+import cogs.temp_vc as temp_vc
+
+
+class DummyCategory:
+    def __init__(self, voice_channels):
+        self.voice_channels = voice_channels
+
+
+@pytest.mark.asyncio
+async def test_delete_untracked_skips_populated_channels():
+    tracked = {1}
+    ch1 = SimpleNamespace(id=1, name="PC", members=[], delete=AsyncMock())
+    ch2 = SimpleNamespace(id=2, name="Console", members=[object()], delete=AsyncMock())
+    ch3 = SimpleNamespace(id=3, name="Autre", members=[], delete=AsyncMock())
+    ch4 = SimpleNamespace(id=4, name="Mobile", members=[], delete=AsyncMock())
+    category = DummyCategory([ch1, ch2, ch3, ch4])
+    bot = SimpleNamespace(get_channel=lambda cid: category)
+
+    with patch("utils.temp_vc_cleanup.discord.CategoryChannel", DummyCategory):
+        await delete_untracked_temp_vcs(bot, 123, tracked)
+
+    ch1.delete.assert_not_awaited()
+    ch2.delete.assert_not_awaited()
+    ch3.delete.assert_not_awaited()
+    ch4.delete.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_repopulate_ids_when_missing(monkeypatch):
+    temp_vc.TEMP_VC_IDS.clear()
+
+    ch1 = SimpleNamespace(id=10, name="PC", members=[])
+    ch2 = SimpleNamespace(id=20, name="General", members=[])
+    category = DummyCategory([ch1, ch2])
+    bot = SimpleNamespace(get_channel=lambda cid: category)
+
+    saved = []
+    def fake_save(ids):
+        saved.append(set(ids))
+
+    with patch.object(temp_vc.tasks.Loop, "start", lambda self, *a, **k: None):
+        with patch("cogs.temp_vc.save_temp_vc_ids", fake_save):
+            with patch("cogs.temp_vc.discord.CategoryChannel", DummyCategory):
+                temp_vc.TempVCCog(bot)
+
+    assert ch1.id in temp_vc.TEMP_VC_IDS
+    assert ch2.id not in temp_vc.TEMP_VC_IDS
+    assert saved and ch1.id in saved[0]

--- a/utils/temp_vc_cleanup.py
+++ b/utils/temp_vc_cleanup.py
@@ -26,6 +26,8 @@ async def delete_untracked_temp_vcs(
     for ch in list(category.voice_channels):
         base = ch.name.split("•", 1)[0].strip()
         if TEMP_VC_NAME_RE.match(base) and ch.id not in tracked:
+            if ch.members:
+                continue
             try:
                 await ch.delete(reason="Salon temporaire orphelin")
             except discord.HTTPException as exc:


### PR DESCRIPTION
## Summary
- avoid deleting temporary voice channels that still have members
- repopulate tracked temporary voice channels on startup when persistence is missing
- document need to persist `temp_vc_ids.json` across redeploys

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a239953ee08324b6b4b41a758fcb90