### PR TITLE
Support activity-based temp voice channel renaming

### DIFF
--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -86,7 +86,10 @@ class TempVCCog(commands.Cog):
                 status = "Endormie"
                 break
             for act in m.activities:
-                if isinstance(act, discord.Game):
+                if isinstance(act, discord.Game) or (
+                    isinstance(act, discord.Activity)
+                    and act.type is discord.ActivityType.playing
+                ):
                     status = act.name
                     break
             if status not in {"Chat", "Endormie"}:


### PR DESCRIPTION
## Summary
- Handle `discord.Activity` with `ActivityType.playing` when computing temp voice channel names

## Testing
- `python -m pytest -q`
- `python bot.py` *(fails: DISCORD_TOKEN manquant)*

------
https://chatgpt.com/codex/tasks/task_e_68a24a312fa88324b71dbcd6cc6dbc14