### PR TITLE
Ensure data directory exists and log write failures

### DIFF
--- a/cogs/role_reminder.py
+++ b/cogs/role_reminder.py
@@ -76,10 +76,13 @@ def _read_json(path: str) -> Dict[str, Any]:
 
 def _write_json(path: str, data: Dict[str, Any]):
     _ensure_data_dir()
-    Path(path).write_text(
-        json.dumps(data, indent=2, ensure_ascii=False),
-        encoding="utf-8",
-    )
+    try:
+        Path(path).write_text(
+            json.dumps(data, indent=2, ensure_ascii=False),
+            encoding="utf-8",
+        )
+    except Exception as e:
+        logging.error(f"[rolescan] Écriture JSON échouée pour {path}: {e}")
 
 
 def user_without_chosen_role(member: discord.Member) -> bool:

--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -38,8 +38,13 @@ def _safe_read_json(path: str) -> dict:
         return {}
 
 def save_json(path: str, data: dict) -> None:
-    Path(path).parent.mkdir(parents=True, exist_ok=True)
-    Path(path).write_text(json.dumps(data, indent=4, ensure_ascii=False), encoding="utf-8")
+    try:
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_text(
+            json.dumps(data, indent=4, ensure_ascii=False), encoding="utf-8"
+        )
+    except Exception as e:
+        logging.error("❌ Écriture JSON échouée pour %s: %s", path, e)
 
 def load_json(path: str) -> dict:
     return _safe_read_json(path)

--- a/storage/roulette_store.py
+++ b/storage/roulette_store.py
@@ -1,27 +1,31 @@
 import json
-import os
+import logging
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
 from zoneinfo import ZoneInfo
 
 
 class RouletteStore:
     def __init__(self, data_dir: str):
-        self.data_file = os.path.join(data_dir, "roulette.json")
-        os.makedirs(data_dir, exist_ok=True)
+        self.data_file = Path(data_dir) / "roulette.json"
+        Path(data_dir).mkdir(parents=True, exist_ok=True)
         self._load()
 
     def _load(self):
         try:
-            with open(self.data_file, "r", encoding="utf-8") as f:
+            with self.data_file.open("r", encoding="utf-8") as f:
                 self.data = json.load(f)
         except (FileNotFoundError, json.JSONDecodeError):
             self.data = {}
             self._save()
 
     def _save(self):
-        with open(self.data_file, "w", encoding="utf-8") as f:
-            json.dump(self.data, f, indent=2, ensure_ascii=False)
+        try:
+            with self.data_file.open("w", encoding="utf-8") as f:
+                json.dump(self.data, f, indent=2, ensure_ascii=False)
+        except Exception as e:
+            logging.error("[RouletteStore] Écriture échouée pour %s: %s", self.data_file, e)
 
     # ——— Poster principal ———
     def set_poster(self, channel_id: str, message_id: str):

--- a/storage/temp_vc_store.py
+++ b/storage/temp_vc_store.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 from pathlib import Path
 from typing import Iterable, Set
@@ -17,6 +18,9 @@ def load_temp_vc_ids() -> Set[int]:
 
 def save_temp_vc_ids(ids: Iterable[int]) -> None:
     """Persiste ``ids`` vers le fichier de stockage."""
-    DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with DATA_FILE.open("w", encoding="utf-8") as fp:
-        json.dump(sorted(set(ids)), fp, ensure_ascii=False, indent=2)
+    try:
+        DATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+        with DATA_FILE.open("w", encoding="utf-8") as fp:
+            json.dump(sorted(set(ids)), fp, ensure_ascii=False, indent=2)
+    except Exception as e:
+        logging.error("[temp_vc_store] Écriture échouée pour %s: %s", DATA_FILE, e)


### PR DESCRIPTION
## Summary
- create the directory pointed by `DATA_DIR` where needed
- log a clear error when persisting data fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a24e023c508324b729c7971b122aaa