### PR TITLE
Throttle voice voice_times checkpoint to 5 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,12 @@ démarrage.
 ### Sauvegarde des sessions vocales
 
 Les heures d'entrée des membres en vocal sont stockées dans
-`data/voice_times.json`. Chaque événement vocal programme un *checkpoint*
-debouncé (2 s par défaut) qui écrit ce fichier de manière atomique dans un
+`data/voice_times.json`. Chaque événement vocal planifie une sauvegarde
+différée (5 min par défaut) qui écrit ce fichier de manière atomique dans un
 thread séparé afin de ne pas bloquer l'event loop. Une sauvegarde
 périodique toutes les 10 minutes est conservée en secours.
 
-Le délai de debounce peut être ajusté via la variable d'environnement
+Le délai peut être ajusté via la variable d'environnement
 `VOICE_CP_DEBOUNCE_SECONDS`.
 
 ## Limitation des éditions de salon


### PR DESCRIPTION
## Summary
- reduce `voice_times` checkpoint frequency to 5 minutes and throttle repeated scheduling
- document new checkpoint interval and env variable in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a25246a7908324b3558f10da5a6cf4