### PR TITLE
Exclude bots from member stats

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -22,8 +22,12 @@ class StatsCog(commands.Cog):
         category = guild.get_channel(config.STATS_CATEGORY_ID)
         if category is None:
             return
-        members = guild.member_count
-        online = sum(1 for m in guild.members if m.status != discord.Status.offline)
+        members = sum(1 for m in guild.members if not getattr(m, "bot", False))
+        online = sum(
+            1
+            for m in guild.members
+            if not getattr(m, "bot", False) and m.status != discord.Status.offline
+        )
         voice = sum(
             len([m for m in vc.members if not getattr(m, "bot", False)])
             for vc in getattr(guild, "voice_channels", [])

--- a/tests/test_stats_update.py
+++ b/tests/test_stats_update.py
@@ -53,7 +53,11 @@ async def test_update_stats_changes_channel_names(monkeypatch):
         [DummyMember(discord.Status.online), DummyMember(discord.Status.online, bot=True)]
     )
     guild = DummyGuild(
-        [DummyMember(discord.Status.online), DummyMember(discord.Status.offline)],
+        [
+            DummyMember(discord.Status.online),
+            DummyMember(discord.Status.offline),
+            DummyMember(discord.Status.online, bot=True),
+        ],
         category,
         [voice_channel],
     )
@@ -69,8 +73,9 @@ async def test_update_stats_changes_channel_names(monkeypatch):
 
     await cog.update_stats(guild)
 
-    assert ch1.name == f"👥 Membres : {guild.member_count}"
-    online = sum(1 for m in guild.members if m.status != discord.Status.offline)
+    members = sum(1 for m in guild.members if not m.bot)
+    assert ch1.name == f"👥 Membres : {members}"
+    online = sum(1 for m in guild.members if not m.bot and m.status != discord.Status.offline)
     assert ch2.name == f"🟢 En ligne : {online}"
     voice = sum(len([m for m in vc.members if not m.bot]) for vc in guild.voice_channels)
     assert ch3.name == f"🔊 Voc : {voice}"


### PR DESCRIPTION
## Summary
- Ignore bot accounts when counting total and online members in stats cog
- Expand stats tests to cover bot exclusion and update expectations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a258f994cc83249e743825d7a3f3fc