### PR TITLE
Avoid reposting roulette status on bot restart

### DIFF
--- a/cogs/roulette.py
+++ b/cogs/roulette.py
@@ -285,7 +285,6 @@ class RouletteCog(commands.Cog):
         self._last_announced_state = self.current_view_enabled
         try:
             await self._ensure_poster_message()
-            await self._ensure_state_message(self.current_view_enabled)
         except Exception as err:
             logging.warning("[Roulette] Init failed: %s", err)
         self.boundary_watch_loop.start()


### PR DESCRIPTION
## Summary
- Prevent roulette status message from posting when the bot starts

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a259d5c8cc8324a36799b9a85bc0d3