### PR TITLE
Make temp VC rename delay configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ fichier doit être conservé entre les redéploiements (volume monté ou dossier
 `DATA_DIR` persistant), sans quoi les salons existants seront supprimés lors du
 démarrage.
 
+Le délai avant renommage de ces salons peut être ajusté via la constante
+`RENAME_DELAY` dans [`config.py`](./config.py).
+
 ### Sauvegarde des sessions vocales
 
 Les heures d'entrée des membres en vocal sont stockées dans

--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -12,6 +12,7 @@ from config import (
     ROLE_PC,
     TEMP_VC_CATEGORY,
     TEMP_VC_LIMITS,
+    RENAME_DELAY,
 )
 from storage.temp_vc_store import load_temp_vc_ids, save_temp_vc_ids
 from utils.temp_vc_cleanup import delete_untracked_temp_vcs, TEMP_VC_NAME_RE
@@ -99,7 +100,7 @@ class TempVCCog(commands.Cog):
     async def _rename_channel(self, channel: discord.VoiceChannel) -> None:
         """Tâche différée effectuant le renommage du salon."""
         try:
-            await asyncio.sleep(5)
+            await asyncio.sleep(RENAME_DELAY)
             task = asyncio.current_task()
             if self._rename_tasks.get(channel.id) is not task:
                 return

--- a/config.py
+++ b/config.py
@@ -22,6 +22,7 @@ LEVEL_ROLE_REWARDS = {
 # ── Salons temporaires & radio ───────────────────────────────
 TEMP_VC_CATEGORY = 1400559884117999687
 TEMP_VC_LIMITS = {TEMP_VC_CATEGORY: 5}
+RENAME_DELAY = 5  # délai en secondes avant renommage des salons temporaires
 
 LOBBY_VC_ID = 1405630965803520221
 RADIO_VC_ID = 1405695147114758245

--- a/tests/test_temp_vc_rename_delay.py
+++ b/tests/test_temp_vc_rename_delay.py
@@ -1,0 +1,34 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import cogs.temp_vc as temp_vc
+from config import RENAME_DELAY
+
+
+@pytest.mark.asyncio
+async def test_rename_channel_uses_config_delay(monkeypatch):
+    channel = SimpleNamespace(id=1, name="Old", members=[object()])
+    loop = asyncio.get_running_loop()
+    bot = SimpleNamespace(loop=loop)
+
+    delays = []
+
+    async def fake_sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr(temp_vc.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(temp_vc, "safe_channel_edit", AsyncMock())
+
+    with patch.object(temp_vc.tasks.Loop, "start", lambda self, *a, **k: None):
+        cog = temp_vc.TempVCCog(bot)
+
+    cog._compute_channel_name = lambda ch: "New"
+
+    task = loop.create_task(cog._rename_channel(channel))
+    cog._rename_tasks[channel.id] = task
+    await task
+
+    assert delays == [RENAME_DELAY]
+    temp_vc.safe_channel_edit.assert_awaited_once_with(channel, name="New")


### PR DESCRIPTION
## Summary
- add `RENAME_DELAY` constant to configure delay before renaming temp voice channels
- use `RENAME_DELAY` in temp VC rename logic
- document configurable delay and test that delay is respected

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a25b931c30832486d9d3cf0d8dda6d