### PR TITLE
Handle missing channels during temp VC rename

### DIFF
--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -104,10 +104,17 @@ class TempVCCog(commands.Cog):
             task = asyncio.current_task()
             if self._rename_tasks.get(channel.id) is not task:
                 return
+            # Le salon peut avoir été supprimé pendant l'attente
+            if getattr(channel, "guild", None) and channel.guild.get_channel(channel.id) is None:
+                return
+
             new = self._compute_channel_name(channel)
             if new and channel.name != new:
                 try:
                     await safe_channel_edit(channel, name=new)
+                except discord.NotFound:
+                    # Le salon n'existe plus, rien à faire
+                    return
                 except discord.HTTPException:
                     logging.exception("Renommage du salon %s échoué", channel.id)
         except asyncio.CancelledError:


### PR DESCRIPTION
## Summary
- Avoid attempting to rename a voice channel that no longer exists
- Silently ignore missing channels during rename instead of logging errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2601fb09c83249e645763e38c621e