### PR TITLE
Prioritize game names for temp voice channel names

### DIFF
--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -81,20 +81,27 @@ class TempVCCog(commands.Cog):
         if not channel.members:
             return None
         base = self._base_name_from_members(channel.members)
-        status = "Chat"
+
+        # Priorité : nom du jeu > "Endormie" > "Chat"
+        game_name = None
         for m in channel.members:
-            if m.voice and m.voice.self_mute:
-                status = "Endormie"
-                break
             for act in m.activities:
                 if isinstance(act, discord.Game) or (
                     isinstance(act, discord.Activity)
                     and act.type is discord.ActivityType.playing
                 ):
-                    status = act.name
+                    game_name = act.name
                     break
-            if status not in {"Chat", "Endormie"}:
+            if game_name:
                 break
+
+        if game_name:
+            status = game_name
+        elif any(m.voice and m.voice.self_mute for m in channel.members):
+            status = "Endormie"
+        else:
+            status = "Chat"
+
         return f"{base} • {status}"
 
     async def _rename_channel(self, channel: discord.VoiceChannel) -> None:

--- a/tests/test_temp_vc_game_priority.py
+++ b/tests/test_temp_vc_game_priority.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import discord
+
+import cogs.temp_vc as temp_vc
+
+
+def test_game_name_has_priority_over_sleep_and_chat():
+    channel = SimpleNamespace(members=[])
+    bot = SimpleNamespace(get_channel=lambda _id: None)
+
+    # Empêche le démarrage de la boucle de nettoyage lors de l'instanciation
+    with patch.object(temp_vc.tasks.Loop, "start", lambda self, *a, **k: None):
+        cog = temp_vc.TempVCCog(bot)
+
+    cog._base_name_from_members = lambda members: "Base"
+
+    player = SimpleNamespace(
+        activities=[discord.Game("Minecraft")],
+        voice=SimpleNamespace(self_mute=False),
+    )
+    sleeper = SimpleNamespace(
+        activities=[],
+        voice=SimpleNamespace(self_mute=True),
+    )
+
+    channel.members = [sleeper, player]
+
+    assert cog._compute_channel_name(channel) == "Base • Minecraft"
+


### PR DESCRIPTION
## Summary
- Prioritize detected game activity when renaming temporary voice channels
- Add regression test ensuring game names override "Endormie" and "Chat"

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a262c2d18483248bc076d03514d1f8