### PR TITLE
feat: add global Discord API rate limiter

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,13 @@
+import asyncio
 import logging
 import os
+import types
 
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
+
+from utils.rate_limit import GlobalRateLimiter
 
 load_dotenv(override=True)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
@@ -16,6 +20,50 @@ intents.presences = True
 
 bot = commands.Bot(command_prefix="!", intents=intents)
 
+limiter = GlobalRateLimiter()
+_orig_request = bot.http.request
+
+
+async def _limited_request(self, route, **kwargs):
+    buckets = ["global"]
+    path = route.path
+    method = route.method
+
+    if method == "POST" and path.startswith("/channels") and path.endswith("/messages"):
+        channel_id = path.split("/")[2]
+        buckets.append(f"channel:{channel_id}")
+    if "reactions" in path:
+        buckets.append("reactions")
+    if "/members/" in path and "/roles/" in path:
+        parts = path.split("/")
+        if len(parts) > 5:
+            user_id = parts[4]
+            buckets.append(f"roles:{user_id}")
+
+    for bucket in buckets:
+        await limiter.acquire(bucket=bucket)
+
+    while True:
+        try:
+            return await _orig_request(route, **kwargs)
+        except discord.HTTPException as e:
+            if e.status == 429:
+                retry_after = 0.0
+                if e.response is not None:
+                    retry_after = float(e.response.headers.get("Retry-After", 0))
+                    if retry_after == 0:
+                        try:
+                            data = await e.response.json()
+                            retry_after = data.get("retry_after", 0)
+                        except Exception:
+                            pass
+                await asyncio.sleep(retry_after + 0.1)
+                continue
+            raise
+
+
+bot.http.request = types.MethodType(_limited_request, bot.http)
+
 
 @bot.event
 async def setup_hook() -> None:
@@ -26,6 +74,7 @@ async def setup_hook() -> None:
     await bot.load_extension("cogs.misc")
     await bot.load_extension("cogs.radio")
     await bot.load_extension("cogs.stats")
+    limiter.start()
 
 
 TOKEN = os.getenv("DISCORD_TOKEN") or os.getenv("TOKEN") or os.getenv("BOT_TOKEN")

--- a/utils/rate_limit.py
+++ b/utils/rate_limit.py
@@ -1,0 +1,93 @@
+import asyncio
+import logging
+import os
+import time
+from typing import Dict
+
+
+class TokenBucket:
+    def __init__(self, capacity: int, refill_rate: float) -> None:
+        self.capacity = float(capacity)
+        self.refill_rate = float(refill_rate)
+        self.tokens = float(capacity)
+        self.updated = time.monotonic()
+        self.lock = asyncio.Lock()
+
+    def _refill(self) -> None:
+        now = time.monotonic()
+        delta = now - self.updated
+        self.updated = now
+        if delta > 0:
+            self.tokens = min(self.capacity, self.tokens + delta * self.refill_rate)
+
+    async def acquire(self, n: int = 1) -> None:
+        n = float(n)
+        async with self.lock:
+            while True:
+                self._refill()
+                if self.tokens >= n:
+                    self.tokens -= n
+                    return
+                needed = n - self.tokens
+                wait = needed / self.refill_rate if self.refill_rate > 0 else 0.0
+                await asyncio.sleep(wait)
+
+
+class GlobalRateLimiter:
+    """Simple token bucket based global rate limiter."""
+
+    def __init__(self) -> None:
+        self.strict = os.getenv("RATE_LIMIT_STRICT", "true").lower() == "true"
+        self.global_rps = int(os.getenv("GLOBAL_RPS", "50"))
+        self.buckets: Dict[str, TokenBucket] = {}
+        self.logger = logging.getLogger("rate_limit")
+        self._task: asyncio.Task | None = None
+        self._requests = 0
+        self._total_wait = 0.0
+
+    def _get_bucket(self, name: str) -> TokenBucket:
+        bucket = self.buckets.get(name)
+        if bucket is None:
+            if name == "global":
+                bucket = TokenBucket(self.global_rps, self.global_rps)
+            elif name.startswith("channel:"):
+                bucket = TokenBucket(5, 1)  # 5 messages / 5s per channel
+            elif name == "reactions":
+                bucket = TokenBucket(4, 4)  # 4 reactions per second globally
+            elif name.startswith("roles:"):
+                bucket = TokenBucket(10, 1)  # 10 roles / 10s per member
+            else:
+                bucket = TokenBucket(self.global_rps, self.global_rps)
+            self.buckets[name] = bucket
+        return bucket
+
+    async def acquire(self, n: int = 1, bucket: str = "global") -> None:
+        if not self.strict:
+            self._requests += n
+            return
+        bucket_obj = self._get_bucket(bucket)
+        start = time.monotonic()
+        await bucket_obj.acquire(n)
+        elapsed = time.monotonic() - start
+        self._requests += n
+        self._total_wait += elapsed
+        if elapsed > 0.1:
+            self.logger.debug("Rate limiter waited %.3fs for bucket %s", elapsed, bucket)
+
+    def start(self) -> None:
+        if self.strict and self._task is None:
+            loop = asyncio.get_running_loop()
+            self._task = loop.create_task(self._log_loop())
+
+    async def _log_loop(self) -> None:
+        while True:
+            await asyncio.sleep(60)
+            if self._requests:
+                avg = self._total_wait / self._requests
+            else:
+                avg = 0.0
+            self.logger.info(
+                "Limiter processed %d requests, avg wait %.3fs", self._requests, avg
+            )
+            self._requests = 0
+            self._total_wait = 0.0


### PR DESCRIPTION
## Summary
- implement token bucket based global rate limiter with per-channel, reaction, and member role buckets
- wrap Discord HTTP requests to enforce limits and retry on 429 responses
- start periodic logging and expose config via env vars

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a26528af44832499f2be625d9a77ee