### PR TITLE
Add test for safe_channel_edit no-op behavior

### DIFF
--- a/tests/test_safe_channel_edit_noop.py
+++ b/tests/test_safe_channel_edit_noop.py
@@ -1,0 +1,12 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from utils.discord_utils import safe_channel_edit
+
+
+@pytest.mark.asyncio
+async def test_safe_channel_edit_noop():
+    channel = SimpleNamespace(id=1, name="Foo", edit=AsyncMock())
+    await safe_channel_edit(channel, name="Foo")
+    channel.edit.assert_not_awaited()


### PR DESCRIPTION
## Summary
- add test ensuring `safe_channel_edit` doesn't call `edit` when no changes are needed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a27fbb1ad8832495e9e49d12ef29bd