### PR TITLE
Use debug logs for safe channel edit

### DIFF
--- a/utils/discord_utils.py
+++ b/utils/discord_utils.py
@@ -48,7 +48,7 @@ async def safe_channel_edit(channel: discord.abc.GuildChannel, **kwargs) -> None
     lock = _CHANNEL_LOCKS.setdefault(channel.id, asyncio.Lock())
     async with lock:
         if all(getattr(channel, k, None) == v for k, v in kwargs.items()):
-            logging.info("[safe_channel_edit] no-op for %s", channel.id)
+            logging.debug("[safe_channel_edit] no-op for %s", channel.id)
             return
 
         if _DEBOUNCE > 0:
@@ -64,7 +64,7 @@ async def safe_channel_edit(channel: discord.abc.GuildChannel, **kwargs) -> None
             await asyncio.sleep(wait)
 
         try:
-            logging.info(
+            logging.debug(
                 "[safe_channel_edit] editing channel %s with %s", channel.id, kwargs
             )
             await channel.edit(**kwargs)


### PR DESCRIPTION
## Summary
- lower log level for safe_channel_edit no-op and edit messages

## Testing
- `PYTHONPATH=. pytest tests/test_safe_channel_edit_noop.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2828987cc83249e654ac138afa915