### PR TITLE
refactor role reminder loops

### DIFF
--- a/tests/test_role_reminder_unload.py
+++ b/tests/test_role_reminder_unload.py
@@ -1,5 +1,4 @@
 import asyncio
-from unittest.mock import patch
 from pathlib import Path
 import sys
 
@@ -11,32 +10,18 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 from cogs.role_reminder import RoleReminderCog
 
 
-class DummyTask:
-    def __init__(self):
-        self.cancelled = False
-
-    def cancel(self):
-        self.cancelled = True
-
-
 @pytest.mark.asyncio
 async def test_cog_unload_cancels_tasks():
-    created_tasks = []
-
-    def fake_create_task(coro, *args, **kwargs):
-        coro.close()
-        t = DummyTask()
-        created_tasks.append(t)
-        return t
-
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
 
-    with patch("asyncio.create_task", fake_create_task):
-        cog = RoleReminderCog(bot)
+    cog = RoleReminderCog(bot)
 
     await bot.add_cog(cog)
     await bot.remove_cog(cog.__cog_name__)
 
-    assert all(t.cancelled for t in created_tasks)
+    await asyncio.sleep(0)
+
+    assert not cog._scan_loop.is_running()
+    assert not cog._cleanup_loop.is_running()
 
     await bot.close()


### PR DESCRIPTION
## Summary
- refactor role reminder scan and cleanup loops using `@tasks.loop`
- start/stop loops in cog lifecycle and wait for bot readiness
- adjust unload test for new loop approach

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2858794388324b4117968e3b77a22