### PR TITLE
Fix syntax error in XP report generation

### DIFF
--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -365,7 +365,7 @@ class XPCog(commands.Cog):
             if not lines:
                 await safe_respond(interaction, "Aucun membre trouvé.", ephemeral=True)
                 return
-            report = "\n".join(lines)
+            report = '\n'.join(lines)
             if len(report) < 1900:
                 await safe_respond(interaction, f"```\n{report}\n```", ephemeral=True)
             else:


### PR DESCRIPTION
## Summary
- fix unterminated string in XP report by joining lines with newline

## Testing
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d6629e948324bacd7d7ad1feba71