### PR TITLE
Add pytest-asyncio dependency for tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv>=1.0
 Pillow>=10.0
 yt-dlp>=2024.7.1
 imageio-ffmpeg>=0.4
+pytest-asyncio>=0.23


### PR DESCRIPTION
## Summary
- add pytest-asyncio to requirements to support running async tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2d80161d88324ae28ec804fa22abd