### PR TITLE
feat: refresh stats channels every minute

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -42,8 +42,9 @@ class StatsCog(commands.Cog):
             if len(channels) > 2:
                 await safe_channel_edit(channels[2], name=f"🔊 Voc : {voice}")
 
-    @tasks.loop(minutes=10)
+    @tasks.loop(minutes=1)
     async def refresh_stats(self) -> None:
+        """Met à jour les statistiques du serveur chaque minute."""
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
             await self.update_stats(guild)


### PR DESCRIPTION
## Summary
- refresh stats channels every minute to display member counts, users online and voice participants

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a313cd100c8324af9a4aaba13c4d31