### PR TITLE
Stabilize radio playback and add permanent message helper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r requirements.txt
+      - run: pip install ruff
+      - run: ruff .
+      - run: pytest
+

--- a/README.md
+++ b/README.md
@@ -14,15 +14,16 @@ The `nixpacks.toml` build configuration already lists `libopus0` to ensure the l
 
 ## FFmpeg options
 
-Audio playback relies on FFmpeg. Some useful parameters can be tuned in
-`bot.py`:
+Audio playback relies on FFmpeg with resilient parameters:
 
-- `-fflags nobuffer` : désactive le tampon d'entrée pour réduire la latence.
-- `-probesize 32k` : diminue les données analysées afin d'accélérer le démarrage du flux.
-- `-filter:a loudnorm` : applique une normalisation du volume.
+- `-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5`
+- `-reconnect_on_http_error 429,502,503,504`
+- `-user_agent 'Mozilla/5.0'`
+- `-fflags nobuffer -rw_timeout 30000000 -headers 'Icy-MetaData:1'`
+- `-vn -loglevel error`
 
-Ces valeurs peuvent être ajustées dans la fonction `_before_opts()` et dans
-la variable `audio_opts` selon vos besoins.
+Set the environment variable `ENABLE_LOUDNORM=1` to append
+`-filter:a loudnorm` and normalize volume.
 
 ## Configuration du serveur
 
@@ -58,6 +59,7 @@ export DATA_DIR=/chemin/vers/mes/données
 Assurez-vous que ce dossier existe et est accessible en lecture/écriture par
 le bot. Pour migrer un ancien déploiement utilisant `/data`, copiez vos fichiers
 vers `/app/data` ou définissez `DATA_DIR=/data`.
+Au démarrage, un log "[boot] DATA_DIR résolu" indique le chemin utilisé.
 
 Les salons vocaux temporaires sont listés dans `data/temp_vc_ids.json`. Ce
 fichier doit être conservé entre les redéploiements (volume monté ou dossier

--- a/bot.py
+++ b/bot.py
@@ -11,9 +11,13 @@ from dotenv import load_dotenv
 from utils.rate_limit import GlobalRateLimiter
 from storage.xp_store import xp_store
 from utils.rename_manager import rename_manager
+from utils.permanent_message import ensure_permanent_message
+from view import PlayerTypeView
+from config import CHANNEL_ROLES, DATA_DIR
 
 load_dotenv(override=True)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logging.info("[boot] DATA_DIR résolu: %s", DATA_DIR)
 
 intents = discord.Intents.default()
 intents.members = True
@@ -40,6 +44,10 @@ class RefugeBot(commands.Bot):
                 logging.exception("Failed to load extension %s", ext)
         limiter.start()
         await rename_manager.start()
+        self.add_view(PlayerTypeView())
+        await ensure_permanent_message(
+            self, CHANNEL_ROLES, "Quel type de joueur es-tu ?", lambda: (PlayerTypeView(), None)
+        )
 
     async def close(self) -> None:
         await xp_store.aclose()

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -8,6 +8,7 @@ from utils.interactions import safe_respond
 from utils.metrics import measure
 from view import PlayerTypeView
 from config import CHANNEL_ROLES, OWNER_ID
+from utils.permanent_message import ensure_permanent_message
 
 
 class MiscCog(commands.Cog):
@@ -23,9 +24,12 @@ class MiscCog(commands.Cog):
                 f"Les boutons ont été postés dans <#{CHANNEL_ROLES}> 😉",
                 ephemeral=True,
             )
-            channel = interaction.guild.get_channel(CHANNEL_ROLES)
-        if channel:
-            await channel.send("Quel type de joueur es-tu ?", view=PlayerTypeView())
+            await ensure_permanent_message(
+                self.bot,
+                CHANNEL_ROLES,
+                "Quel type de joueur es-tu ?",
+                lambda: (PlayerTypeView(), None),
+            )
 
     @app_commands.command(name="sondage", description="Créer un sondage Oui/Non")
     @app_commands.describe(question="La question à poser")

--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -5,10 +5,16 @@ from typing import Optional
 import discord
 from discord.ext import commands
 
-from config import RADIO_VC_ID, RADIO_STREAM_URL
+from config import ENABLE_LOUDNORM, RADIO_VC_ID, RADIO_STREAM_URL
 
-FFMPEG_BEFORE = "-fflags nobuffer -probesize 32k"
-FFMPEG_OPTIONS = "-filter:a loudnorm"
+FFMPEG_BEFORE = (
+    "-reconnect 1 -reconnect_streamed 1 -reconnect_delay_max 5 "
+    "-reconnect_on_http_error 429,502,503,504 -user_agent 'Mozilla/5.0' "
+    "-fflags nobuffer -rw_timeout 30000000 -headers 'Icy-MetaData:1'"
+)
+FFMPEG_OPTIONS = "-vn -loglevel error"
+if ENABLE_LOUDNORM:
+    FFMPEG_OPTIONS += " -filter:a loudnorm"
 
 
 class RadioCog(commands.Cog):

--- a/cogs/role_reminder.py
+++ b/cogs/role_reminder.py
@@ -3,7 +3,6 @@ import asyncio
 import json
 import logging
 import random
-import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict

--- a/config.py
+++ b/config.py
@@ -47,6 +47,7 @@ RADIO_MUTED_ROLE_ID = 1403510368340410550
 RADIO_STREAM_URL = os.getenv(
     "RADIO_STREAM_URL", "http://stream.laut.fm/englishrap"
 )
+ENABLE_LOUDNORM = os.getenv("ENABLE_LOUDNORM", "0") == "1"
 
 # ── Divers ───────────────────────────────────────────────────
 XP_VIEWER_ROLE_ID = 1403510368340410550

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Pillow>=10.0
 yt-dlp>=2024.7.1
 imageio-ffmpeg>=0.4
 pytest-asyncio>=0.23
+ruff>=0.1.7

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,3 @@
+line-length = 100
+target-version = "py311"
+

--- a/tests/test_persist_utils.py
+++ b/tests/test_persist_utils.py
@@ -1,0 +1,23 @@
+import json
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils import persist
+
+
+def test_atomic_write(tmp_path):
+    p = tmp_path / "data.json"
+    persist.atomic_write_json(p, {"a": 1})
+    assert json.loads(p.read_text()) == {"a": 1}
+
+
+def test_read_json_fallback(tmp_path):
+    p = tmp_path / "data.json"
+    persist.atomic_write_json(p, {"a": 1})
+    persist.atomic_write_json(p, {"a": 2})
+    p.write_text("{")
+    data = persist.read_json_safe(p)
+    assert data == {"a": 1}
+

--- a/tests/test_rename_manager_utils.py
+++ b/tests/test_rename_manager_utils.py
@@ -1,0 +1,57 @@
+import time
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils import rename_manager as rm
+from utils.rename_manager import _RenameManager
+
+
+class DummyChannel:
+    def __init__(self, cid):
+        self.id = cid
+        self.name = ""
+        self.calls: list[float] = []
+
+    async def edit(self, name):
+        self.name = name
+        self.calls.append(time.monotonic())
+
+
+@pytest.mark.asyncio
+async def test_coalescing(monkeypatch):
+    rm.CHANNEL_RENAME_DEBOUNCE_SECONDS = 0
+    rm.CHANNEL_RENAME_MIN_INTERVAL_PER_CHANNEL = 0
+    rm.CHANNEL_RENAME_MIN_INTERVAL_GLOBAL = 0
+    mgr = _RenameManager()
+
+    ch = DummyChannel(1)
+    await mgr.start()
+    await mgr.request(ch, "a")
+    await mgr.request(ch, "b")
+    await mgr.request(ch, "c")
+    await mgr._queue.join()
+
+    assert ch.name == "c"
+    assert len(ch.calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_cooldowns(monkeypatch):
+    rm.CHANNEL_RENAME_DEBOUNCE_SECONDS = 0
+    rm.CHANNEL_RENAME_MIN_INTERVAL_PER_CHANNEL = 0.05
+    rm.CHANNEL_RENAME_MIN_INTERVAL_GLOBAL = 0.05
+    mgr = _RenameManager()
+
+    a = DummyChannel(1)
+    b = DummyChannel(2)
+    await mgr.start()
+    await mgr.request(a, "a")
+    await mgr.request(b, "b")
+    await mgr._queue.join()
+
+    assert b.calls[0] - a.calls[0] >= 0.05
+

--- a/tests/test_timewin_utils.py
+++ b/tests/test_timewin_utils.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+from zoneinfo import ZoneInfo
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import utils.timewin as tw
+
+
+def test_is_open_now_true(monkeypatch):
+    class MockDT(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2023, 1, 1, 12, tzinfo=tz)
+
+    monkeypatch.setattr(tw, "datetime", MockDT)
+    assert tw.is_open_now("UTC", 10, 22)
+
+
+def test_is_open_now_false(monkeypatch):
+    class MockDT(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2023, 1, 1, 23, tzinfo=tz)
+
+    monkeypatch.setattr(tw, "datetime", MockDT)
+    assert not tw.is_open_now("UTC", 10, 22)
+
+
+def test_next_boundary_dt():
+    tz = ZoneInfo("UTC")
+    now = datetime(2023, 1, 1, 9, tzinfo=tz)
+    assert tw.next_boundary_dt(now, tz="UTC", start_h=10, end_h=22) == datetime(
+        2023, 1, 1, 10, tzinfo=tz
+    )
+
+    late = datetime(2023, 1, 1, 23, tzinfo=tz)
+    assert tw.next_boundary_dt(late, tz="UTC", start_h=10, end_h=22) == datetime(
+        2023, 1, 2, 10, tzinfo=tz
+    )
+

--- a/utils/permanent_message.py
+++ b/utils/permanent_message.py
@@ -1,0 +1,57 @@
+import logging
+from pathlib import Path
+from typing import Callable, Tuple
+
+import discord
+
+from config import DATA_DIR
+from utils.persist import atomic_write_json, read_json_safe
+
+
+async def ensure_permanent_message(
+    bot: discord.Client,
+    channel_id: int,
+    signature: str,
+    build_view_and_embed: Callable[[], Tuple[discord.ui.View | None, discord.Embed | None]],
+) -> discord.Message | None:
+    """Ensure a message with ``signature`` exists in ``channel_id``.
+
+    The helper tries three strategies in order:
+
+    1. Fetch an existing message using a stored ID.
+    2. Scan the channel history for a message containing ``signature``.
+    3. Publish a new message and persist its ID.
+    """
+
+    path = Path(DATA_DIR) / "permanent_messages.json"
+    data = read_json_safe(path)
+    msg_id = data.get(signature)
+
+    channel = bot.get_channel(channel_id)
+    if not isinstance(channel, (discord.TextChannel, discord.Thread)):
+        logging.warning("[perm_msg] channel %s introuvable", channel_id)
+        return None
+
+    message: discord.Message | None = None
+    if msg_id:
+        try:
+            message = await channel.fetch_message(msg_id)  # type: ignore[arg-type]
+        except discord.NotFound:
+            message = None
+
+    if message is None:
+        async for m in channel.history(limit=50):
+            if m.author.id == bot.user.id and signature in (m.content or ""):
+                message = m
+                break
+
+    if message is None:
+        view, embed = build_view_and_embed()
+        message = await channel.send(signature, view=view, embed=embed)
+
+    if data.get(signature) != message.id:
+        data[signature] = message.id
+        atomic_write_json(path, data)
+
+    return message
+


### PR DESCRIPTION
## Summary
- harden FFmpeg radio stream with automatic reconnection and optional loudnorm filter
- add helper to ensure idempotent permanent messages saved under DATA_DIR
- log resolved DATA_DIR and set up lint/test workflow

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a33b3799f88324a04a79c18a07d1bd