### PR TITLE
Ensure rename manager shuts down with bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -44,6 +44,7 @@ class RefugeBot(commands.Bot):
         await rename_manager.start()
 
     async def close(self) -> None:
+        rename_manager.stop()
         await xp_store.aclose()
         await super().close()
 

--- a/tests/test_bot_close_stops_rename_manager.py
+++ b/tests/test_bot_close_stops_rename_manager.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import discord
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+import bot
+
+
+@pytest.mark.asyncio
+async def test_bot_close_stops_rename_manager(monkeypatch):
+    intents = discord.Intents.none()
+    test_bot = bot.RefugeBot(command_prefix="!", intents=intents)
+
+    stop_mock = MagicMock()
+    monkeypatch.setattr(bot.rename_manager, "stop", stop_mock)
+
+    aclose_mock = AsyncMock()
+    monkeypatch.setattr(bot.xp_store, "aclose", aclose_mock)
+
+    super_close_mock = AsyncMock()
+    from discord.ext import commands as d_commands
+
+    monkeypatch.setattr(d_commands.Bot, "close", super_close_mock)
+
+    await test_bot.close()
+
+    stop_mock.assert_called_once()
+    aclose_mock.assert_awaited_once()
+    super_close_mock.assert_awaited_once()

--- a/utils/rename_manager.py
+++ b/utils/rename_manager.py
@@ -28,6 +28,11 @@ class _RenameManager:
         if self._worker is None:
             self._worker = asyncio.create_task(self._run())
 
+    def stop(self) -> None:
+        if self._worker is not None:
+            self._worker.cancel()
+            self._worker = None
+
     async def request(
         self, channel: discord.abc.GuildChannel, new_name: str
     ) -> None:


### PR DESCRIPTION
## Summary
- add `stop` method to rename manager to cancel its worker task
- stop rename manager when the bot shuts down
- test bot shutdown calls rename manager stop

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3451765348324bd612cf05c730283