### PR TITLE
chore: clean apt cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && \
     ffmpeg \
     libjpeg-dev \
     zlib1g-dev \
-    && apt-get clean
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Répertoire de travail dans le conteneur
 WORKDIR /app


### PR DESCRIPTION
## Summary
- clean up apt cache in Dockerfile to reduce image size

## Testing
- `pytest`
- `podman build -t discord-bot-refuge:baseline .` *(fails: Forbidden)*
- `podman build -t discord-bot-refuge:new .` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a346901bdc8324b667bae7344ee170