### PR TITLE
Add channel edit manager with rate limiting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -11,6 +11,7 @@ from dotenv import load_dotenv
 from utils.rate_limit import GlobalRateLimiter
 from storage.xp_store import xp_store
 from utils.rename_manager import rename_manager
+from utils.channel_edit_manager import channel_edit_manager
 from view import PlayerTypeView
 
 load_dotenv(override=True)
@@ -42,9 +43,11 @@ class RefugeBot(commands.Bot):
                 logging.exception("Failed to load extension %s", ext)
         limiter.start()
         await rename_manager.start()
+        await channel_edit_manager.start()
 
     async def close(self) -> None:
         rename_manager.stop()
+        channel_edit_manager.stop()
         await xp_store.aclose()
         await super().close()
 

--- a/tests/test_channel_edit_manager.py
+++ b/tests/test_channel_edit_manager.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, call
+
+import pytest
+import pytest_asyncio
+
+import utils.channel_edit_manager as cem
+import utils.discord_utils as du
+from utils.discord_utils import safe_channel_edit
+
+
+@pytest_asyncio.fixture
+async def edit_manager(monkeypatch):
+    mgr = cem._ChannelEditManager()
+    monkeypatch.setattr(cem, "channel_edit_manager", mgr)
+    monkeypatch.setattr(du, "channel_edit_manager", mgr)
+    await mgr.start()
+    try:
+        yield mgr
+    finally:
+        mgr.stop()
+
+
+@pytest.mark.asyncio
+async def test_channel_edit_manager_respects_per_channel_interval(monkeypatch, edit_manager):
+    channel = SimpleNamespace(id=1, topic="Old", edit=AsyncMock())
+    delays = []
+
+    async def fake_sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr(cem.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(cem, "CHANNEL_EDIT_DEBOUNCE_SECONDS", 0)
+    monkeypatch.setattr(cem, "CHANNEL_EDIT_MIN_INTERVAL_SECONDS", 2)
+    monkeypatch.setattr(cem, "CHANNEL_EDIT_GLOBAL_MIN_INTERVAL_SECONDS", 0)
+
+    await safe_channel_edit(channel, topic="First")
+    await edit_manager._queue.join()
+    await safe_channel_edit(channel, topic="Second")
+    await edit_manager._queue.join()
+
+    assert delays == [pytest.approx(2, abs=0.1)]
+    channel.edit.assert_has_awaits([call(topic="First"), call(topic="Second")])
+
+
+@pytest.mark.asyncio
+async def test_channel_edit_manager_respects_global_interval(monkeypatch, edit_manager):
+    ch1 = SimpleNamespace(id=1, name="A", edit=AsyncMock())
+    ch2 = SimpleNamespace(id=2, name="B", edit=AsyncMock())
+    delays = []
+
+    async def fake_sleep(delay):
+        delays.append(delay)
+
+    monkeypatch.setattr(cem.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(cem, "CHANNEL_EDIT_DEBOUNCE_SECONDS", 0)
+    monkeypatch.setattr(cem, "CHANNEL_EDIT_MIN_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(cem, "CHANNEL_EDIT_GLOBAL_MIN_INTERVAL_SECONDS", 3)
+
+    await safe_channel_edit(ch1, name="A1")
+    await safe_channel_edit(ch2, name="B1")
+    await edit_manager._queue.join()
+
+    assert delays == [pytest.approx(3, abs=0.1)]
+    ch1.edit.assert_awaited_once()
+    ch2.edit.assert_awaited_once()

--- a/utils/channel_edit_manager.py
+++ b/utils/channel_edit_manager.py
@@ -1,0 +1,83 @@
+import asyncio
+import logging
+import time
+from typing import Dict, Tuple
+
+import discord
+
+from config import (
+    CHANNEL_EDIT_MIN_INTERVAL_SECONDS,
+    CHANNEL_EDIT_DEBOUNCE_SECONDS,
+    CHANNEL_EDIT_GLOBAL_MIN_INTERVAL_SECONDS,
+)
+
+from utils.metrics import errors
+
+
+class _ChannelEditManager:
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[int] = asyncio.Queue()
+        self._pending: Dict[int, Tuple[discord.abc.GuildChannel, dict]] = {}
+        self._last_per_channel: Dict[int, float] = {}
+        self._last_global: float = 0.0
+        self._worker: asyncio.Task | None = None
+
+    async def start(self) -> None:
+        if self._worker is None:
+            self._worker = asyncio.create_task(self._run())
+
+    def stop(self) -> None:
+        if self._worker is not None:
+            self._worker.cancel()
+            self._worker = None
+
+    async def request(self, channel: discord.abc.GuildChannel, **kwargs) -> None:
+        if all(getattr(channel, k, None) == v for k, v in kwargs.items()):
+            logging.debug("[channel_edit_manager] no-op for %s", channel.id)
+            return
+        if channel.id in self._pending:
+            self._pending[channel.id] = (channel, kwargs)
+        else:
+            self._pending[channel.id] = (channel, kwargs)
+            await self._queue.put(channel.id)
+
+    async def _run(self) -> None:
+        while True:
+            cid = await self._queue.get()
+            channel, params = self._pending.pop(cid, (None, None))
+            if channel is None:
+                self._queue.task_done()
+                continue
+
+            if CHANNEL_EDIT_DEBOUNCE_SECONDS > 0:
+                await asyncio.sleep(CHANNEL_EDIT_DEBOUNCE_SECONDS)
+
+            now = time.monotonic()
+            last = self._last_per_channel.get(cid, 0.0)
+            wait = CHANNEL_EDIT_MIN_INTERVAL_SECONDS - (now - last)
+            if wait > 0:
+                await asyncio.sleep(wait)
+
+            now = time.monotonic()
+            gwait = CHANNEL_EDIT_GLOBAL_MIN_INTERVAL_SECONDS - (
+                now - self._last_global
+            )
+            if gwait > 0:
+                await asyncio.sleep(gwait)
+
+            try:
+                await channel.edit(**params)
+            except discord.NotFound:
+                logging.warning("[channel_edit_manager] channel %s not found", cid)
+            except discord.HTTPException as exc:
+                logging.warning("[channel_edit_manager] edit failed for %s: %s", cid, exc)
+                errors["channel_edit_failed"] += 1
+            else:
+                now = time.monotonic()
+                self._last_per_channel[cid] = now
+                self._last_global = now
+
+            self._queue.task_done()
+
+
+channel_edit_manager = _ChannelEditManager()

--- a/utils/discord_utils.py
+++ b/utils/discord_utils.py
@@ -2,6 +2,8 @@ import logging
 import discord
 from discord.ext import commands
 
+from utils.channel_edit_manager import channel_edit_manager
+
 
 async def ensure_channel_has_message(
     bot: commands.Bot, channel_id: int, content: str
@@ -28,15 +30,6 @@ async def ensure_channel_has_message(
 
 
 async def safe_channel_edit(channel: discord.abc.GuildChannel, **kwargs) -> None:
-    """Edit a channel while gracefully handling Discord errors."""
-    if all(getattr(channel, k, None) == v for k, v in kwargs.items()):
-        logging.debug("[safe_channel_edit] no-op for %s", channel.id)
-        return
-
-    try:
-        await channel.edit(**kwargs)
-    except discord.NotFound:
-        logging.warning("[safe_channel_edit] channel %s not found", channel.id)
-    except discord.HTTPException as exc:
-        logging.warning("[safe_channel_edit] edit failed for %s: %s", channel.id, exc)
+    """Schedule a channel edit respecting configured rate limits."""
+    await channel_edit_manager.request(channel, **kwargs)
 


### PR DESCRIPTION
## Summary
- add ChannelEditManager enforcing CHANNEL_EDIT_* intervals
- integrate manager with safe_channel_edit and bot startup/shutdown
- test per-channel and global edit throttling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a34ab3c90083249a59f81cd959b129