### PR TITLE
Store XP in legacy data.json file

### DIFF
--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -71,6 +71,7 @@ async def save_daily_stats_to_disk() -> None:
 
 async def xp_bootstrap_cache() -> None:
     global XP_CACHE, voice_times, DAILY_STATS, XP_LOCK
+    await xp_store.start()
     XP_CACHE = xp_store.data
     XP_LOCK = xp_store.lock
     voice_times = load_voice_times()

--- a/storage/xp_store.py
+++ b/storage/xp_store.py
@@ -8,7 +8,10 @@ from typing import Dict
 from config import DATA_DIR
 from utils.persist import ensure_dir, read_json_safe, atomic_write_json
 
-XP_PATH = os.path.join(DATA_DIR, "xp.json")
+# Legacy bots stored XP in ``data.json``. To maintain compatibility with
+# existing deployments that expect this filename, we default to writing XP
+# data into ``data.json`` instead of ``xp.json``.
+XP_PATH = os.path.join(DATA_DIR, "data.json")
 
 
 class XPStore:


### PR DESCRIPTION
## Summary
- Restore XP persistence compatibility by writing to `data/data.json`
- Bootstrap XP cache by starting the XP store on load

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a34eb1aaa48324a491442b6346a9d6