### PR TITLE
feat: add welcome greeting

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -35,6 +35,7 @@ class RefugeBot(commands.Bot):
             "cogs.misc",
             "cogs.radio",
             "cogs.stats",
+            "cogs.welcome",
         ]
         for ext in extensions:
             try:

--- a/cogs/welcome.py
+++ b/cogs/welcome.py
@@ -1,0 +1,34 @@
+import logging
+
+import discord
+from discord.ext import commands
+
+from config import CHANNEL_ROLES, CHANNEL_WELCOME
+
+
+class WelcomeCog(commands.Cog):
+    """Gère les messages de bienvenue pour les nouveaux membres."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member: discord.Member) -> None:
+        """Envoie un message de bienvenue dans le salon dédié."""
+        if getattr(member, "bot", False):
+            return
+        channel = member.guild.get_channel(CHANNEL_WELCOME) if member.guild else None
+        if channel:
+            try:
+                await channel.send(
+                    "🎉 Bienvenue au Refuge !\n"
+                    f"{member.mention}, installe-toi bien !\n"
+                    f"🕹️ Choisis ton rôle dans le salon <#{CHANNEL_ROLES}> pour accéder à toutes les sections.\n"
+                    "Ravi de t’avoir parmi nous ! 🎮"
+                )
+            except Exception:
+                logging.exception("[welcome] Échec d'envoi du message de bienvenue pour %s", member.id)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(WelcomeCog(bot))

--- a/tests/test_welcome.py
+++ b/tests/test_welcome.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import discord
+from discord.ext import commands
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from cogs.welcome import WelcomeCog
+from config import CHANNEL_ROLES, CHANNEL_WELCOME
+
+
+@pytest.mark.asyncio
+async def test_welcome_message_sent():
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    channel = SimpleNamespace(id=CHANNEL_WELCOME, send=AsyncMock())
+    guild = SimpleNamespace(get_channel=lambda cid: channel if cid == CHANNEL_WELCOME else None)
+    member = SimpleNamespace(guild=guild, mention="@member", bot=False)
+
+    cog = WelcomeCog(bot)
+    await cog.on_member_join(member)
+
+    expected = (
+        "🎉 Bienvenue au Refuge !\n"
+        "@member, installe-toi bien !\n"
+        f"🕹️ Choisis ton rôle dans le salon <#{CHANNEL_ROLES}> pour accéder à toutes les sections.\n"
+        "Ravi de t’avoir parmi nous ! 🎮"
+    )
+    channel.send.assert_awaited_once_with(expected)
+
+    await bot.close()


### PR DESCRIPTION
## Summary
- load a new welcome cog
- greet new members in the welcome channel with role selection info
- test welcome message dispatch

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a36ceae36c8324b3a0cc248aff7b3c