### PR TITLE
Start rename manager worker in TempVCCog

### DIFF
--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -52,6 +52,13 @@ class TempVCCog(commands.Cog):
 
         self.cleanup.start()
 
+        if rename_manager._worker is None:
+            async def _ensure_rename_worker() -> None:
+                await rename_manager.start()
+                logging.info("[temp_vc] rename_manager worker démarré")
+
+            asyncio.create_task(_ensure_rename_worker())
+
     def cog_unload(self) -> None:
         self.cleanup.cancel()
         for task in self._rename_tasks.values():


### PR DESCRIPTION
## Summary
- Ensure TempVCCog initializes rename_manager if its worker isn't running
- Log that the rename_manager worker was started

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a374b329b483248800424be370b6fb