### PR TITLE
Reduce rename delay and document total latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ démarrage.
 Le délai avant renommage de ces salons peut être ajusté via la constante
 `RENAME_DELAY` dans [`config.py`](./config.py).
 
+Le renommage effectif intervient après un délai total d'environ
+`RENAME_DELAY` + `CHANNEL_RENAME_DEBOUNCE_SECONDS`. Avec les valeurs par
+défaut (3 s et 2 s), le bot attend environ 5 s avant d'émettre la
+requête de renommage, tout en respectant les limites de l'API Discord
+(5 s entre deux renommages d'un même salon et 2 s globalement).
+Réduire ces valeurs diminue la latence mais augmente la consommation de
+ces limites.
+
 La fréquence de vérification des noms de ces salons est définie par la constante
 `TEMP_VC_CHECK_INTERVAL_SECONDS` (30 secondes par défaut).
 

--- a/config.py
+++ b/config.py
@@ -38,7 +38,7 @@ LEVEL_ROLE_REWARDS = {
 # ── Salons temporaires & radio ───────────────────────────────
 TEMP_VC_CATEGORY = 1400559884117999687
 TEMP_VC_LIMITS = {TEMP_VC_CATEGORY: 5}
-RENAME_DELAY = 5  # délai en secondes avant renommage des salons temporaires
+RENAME_DELAY = 3  # délai en secondes avant renommage des salons temporaires
 TEMP_VC_CHECK_INTERVAL_SECONDS = 30  # fréquence de vérification des noms
 
 LOBBY_VC_ID = 1405630965803520221
@@ -116,7 +116,7 @@ CHANNEL_RENAME_MIN_INTERVAL_GLOBAL: int = int(
 """Intervalle minimal global entre les renommages de salons."""
 
 CHANNEL_RENAME_DEBOUNCE_SECONDS: int = int(
-    os.getenv("CHANNEL_RENAME_DEBOUNCE_SECONDS", "3")
+    os.getenv("CHANNEL_RENAME_DEBOUNCE_SECONDS", "2")
 )
 """Délai appliqué avant le renommage d'un salon."""
 


### PR DESCRIPTION
## Summary
- Reduce temporary voice channel rename delay to 3s
- Shorten global channel rename debounce to 2s
- Document combined latency and rate-limit considerations in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3758186308324948e5ee31e3c4812