### PR TITLE
Log queued renames and warn when worker inactive

### DIFF
--- a/utils/rename_manager.py
+++ b/utils/rename_manager.py
@@ -44,6 +44,15 @@ class _RenameManager:
         else:
             self._pending[channel.id] = (channel, new_name)
             await self._queue.put(channel.id)
+            logging.debug(
+                "[rename_manager] queued rename %s -> %r", channel.id, new_name
+            )
+        if self._worker is None or self._worker.done():
+            logging.warning(
+                "[rename_manager] worker inactive; rename for %s -> %r may not run",
+                channel.id,
+                new_name,
+            )
 
     async def _run(self) -> None:
         while True:


### PR DESCRIPTION
## Summary
- log channel id and new name whenever a rename request is queued
- warn when rename worker is inactive

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a376afaeb8832498cc15f6952f1245