### PR TITLE
Ensure rename manager skips deleted channels

### DIFF
--- a/tests/test_rename_manager_deleted_channel.py
+++ b/tests/test_rename_manager_deleted_channel.py
@@ -1,0 +1,43 @@
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from utils.rename_manager import _RenameManager
+
+
+@pytest.mark.asyncio
+async def test_skip_when_channel_deleted(monkeypatch, caplog):
+    monkeypatch.setattr(
+        "utils.rename_manager.CHANNEL_RENAME_DEBOUNCE_SECONDS", 0
+    )
+    monkeypatch.setattr(
+        "utils.rename_manager.CHANNEL_RENAME_MIN_INTERVAL_PER_CHANNEL", 0
+    )
+    monkeypatch.setattr(
+        "utils.rename_manager.CHANNEL_RENAME_MIN_INTERVAL_GLOBAL", 0
+    )
+
+    rm = _RenameManager()
+    await rm.start()
+
+    called = False
+
+    async def edit(name):
+        nonlocal called
+        called = True
+
+    guild = SimpleNamespace(get_channel=lambda cid: None)
+    channel = SimpleNamespace(id=123, name="old", guild=guild, edit=edit)
+
+    caplog.set_level(logging.DEBUG)
+
+    await rm.request(channel, "new")
+    await rm._queue.join()
+    rm.stop()
+
+    assert called is False
+    assert any(
+        "deleted before rename" in record.getMessage() for record in caplog.records
+    )
+    assert not any(record.levelno >= logging.WARNING for record in caplog.records)

--- a/utils/rename_manager.py
+++ b/utils/rename_manager.py
@@ -76,6 +76,13 @@ class _RenameManager:
             if gwait > 0:
                 await asyncio.sleep(gwait)
 
+            if channel.guild.get_channel(cid) is None:
+                logging.debug(
+                    "[rename_manager] channel %s deleted before rename; skipping", cid
+                )
+                self._queue.task_done()
+                continue
+
             attempt = 0
             while True:
                 start = time.monotonic()


### PR DESCRIPTION
## Summary
- Skip rename if target channel no longer exists and log debug message
- Add unit test for deleted channels

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a38334f118832497c501387b1461fd