### PR TITLE
chore: use module logger for temp VC cleanup

### DIFF
--- a/utils/temp_vc_cleanup.py
+++ b/utils/temp_vc_cleanup.py
@@ -5,6 +5,8 @@ from typing import Iterable
 import discord
 from discord.ext import commands
 
+logger = logging.getLogger(__name__)
+
 TEMP_VC_NAME_RE = re.compile(r"^(PC|Console|Mobile|Crossplay|Chat)(?:\b.*)?$", re.I)
 
 
@@ -31,4 +33,4 @@ async def delete_untracked_temp_vcs(
             try:
                 await ch.delete(reason="Salon temporaire orphelin")
             except discord.HTTPException as exc:
-                logging.warning("Suppression salon %s échouée: %s", ch.id, exc)
+                logger.warning("Suppression salon %s échouée: %s", ch.id, exc)


### PR DESCRIPTION
## Summary
- use a module-level logger in temporary voice channel cleanup

## Testing
- `pytest`
- manual call to `delete_untracked_temp_vcs` to observe warning log


------
https://chatgpt.com/codex/tasks/task_e_68a38c4039c8832492c1e569fc471539