### PR TITLE
docs: clarify asyncio import

### DIFF
--- a/utils/rate_limit.py
+++ b/utils/rate_limit.py
@@ -1,4 +1,4 @@
-import asyncio
+import asyncio  # required for asynchronous rate limiting
 import logging
 import os
 import time


### PR DESCRIPTION
## Summary
- clarify that the rate limiter requires asyncio

## Testing
- `pytest -q`
- `python bot.py` *(fails: Cannot connect to host discord.com:443 ssl:default [Network is unreachable])*

------
https://chatgpt.com/codex/tasks/task_e_68a38debb3008324a9deff2cdc00dc37