### PR TITLE
Fix role cleanup iteration to avoid dict resize error

### DIFF
--- a/cogs/roulette.py
+++ b/cogs/roulette.py
@@ -425,7 +425,8 @@ class RouletteCog(commands.Cog):
         try:
             assignments = self.store.get_all_role_assignments()
             now = datetime.now(self.tz)
-            for uid, data in assignments.items():
+            # Iterate over a copy to avoid RuntimeError: dictionary changed size during iteration
+            for uid, data in list(assignments.items()):
                 try:
                     exp = datetime.fromisoformat(data.get("expires_at", "")).astimezone(self.tz)
                 except Exception:


### PR DESCRIPTION
## Summary
- Iterate over a copy of role assignments during cleanup to avoid runtime errors

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a39196efc083249f89c7351cfebfa2