### PR TITLE
feat: compute daily rankings and apply winner roles

### DIFF
--- a/cogs/daily_ranking.py
+++ b/cogs/daily_ranking.py
@@ -1,0 +1,178 @@
+import logging
+import os
+from datetime import datetime, timedelta, time, timezone
+from typing import Dict, Any
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from config import (
+    DATA_DIR,
+    MVP_ROLE_ID,
+    TOP_MSG_ROLE_ID,
+    TOP_VC_ROLE_ID,
+    XP_VIEWER_ROLE_ID,
+)
+from utils.persist import read_json_safe, atomic_write_json, ensure_dir
+from utils.interactions import safe_respond
+from .xp import DAILY_STATS, DAILY_LOCK, save_daily_stats_to_disk
+
+try:
+    from zoneinfo import ZoneInfo
+
+    PARIS_TZ = ZoneInfo("Europe/Paris")
+except Exception:  # pragma: no cover - fallback
+    PARIS_TZ = timezone.utc
+
+
+DAILY_RANK_FILE = os.path.join(DATA_DIR, "daily_ranking.json")
+ensure_dir(DATA_DIR)
+
+
+class DailyRankingAndRoles(commands.Cog):
+    """Calcul et attribution des classements quotidiens."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.daily_task.start()
+        self.bot.loop.create_task(self._startup_apply())
+
+    def cog_unload(self) -> None:
+        self.daily_task.cancel()
+
+    async def _startup_apply(self) -> None:
+        await self.bot.wait_until_ready()
+        await self._apply_roles_from_file()
+
+    # ── Persistence helpers ──────────────────────────────────
+
+    def _read_persistence(self) -> Dict[str, Any]:
+        return read_json_safe(DAILY_RANK_FILE)
+
+    def _write_persistence(self, data: Dict[str, Any]) -> None:
+        atomic_write_json(DAILY_RANK_FILE, data)
+
+    # ── Roles management ─────────────────────────────────────
+
+    async def _apply_roles_from_file(self) -> None:
+        data = self._read_persistence()
+        winners = data.get("winners") if data else {}
+        if winners:
+            logging.info("[daily_ranking] Réapplication des rôles pour %s", data.get("date"))
+            await self._reset_and_assign(winners)
+
+    async def _reset_and_assign(self, winners: Dict[str, int | None]) -> None:
+        guild = self.bot.guilds[0] if self.bot.guilds else None
+        if not guild:
+            return
+        roles = {
+            "mvp": guild.get_role(MVP_ROLE_ID),
+            "msg": guild.get_role(TOP_MSG_ROLE_ID),
+            "vc": guild.get_role(TOP_VC_ROLE_ID),
+        }
+        for member in guild.members:
+            to_remove = [r for r in roles.values() if r and r in member.roles]
+            if to_remove:
+                try:
+                    await member.remove_roles(*to_remove, reason="Réinitialisation des rôles journaliers")
+                except Exception as e:  # pragma: no cover - just log
+                    logging.error("[daily_ranking] Retrait rôle échoué: %s", e)
+        for key, uid in winners.items():
+            role = roles.get(key)
+            if not role or not uid:
+                continue
+            member = guild.get_member(int(uid))
+            if not member:
+                continue
+            try:
+                await member.add_roles(role, reason="Attribution classement quotidien")
+                logging.info("[daily_ranking] Rôle %s attribué à %s", role.id, uid)
+            except Exception as e:  # pragma: no cover
+                logging.error("[daily_ranking] Attribution rôle échouée: %s", e)
+
+    # ── Computation ──────────────────────────────────────────
+
+    def _compute_ranking(self, stats: Dict[str, Dict[str, int]]) -> Dict[str, Any]:
+        msg_sorted = sorted(stats.items(), key=lambda x: x[1].get("messages", 0), reverse=True)
+        vc_sorted = sorted(stats.items(), key=lambda x: x[1].get("voice", 0), reverse=True)
+
+        def score(item: tuple[str, Dict[str, int]]) -> float:
+            s = item[1]
+            return s.get("messages", 0) + s.get("voice", 0) / 60.0
+
+        mvp_sorted = sorted(stats.items(), key=score, reverse=True)
+
+        top_msg = [
+            {"id": int(uid), "count": int(data.get("messages", 0))}
+            for uid, data in msg_sorted[:3]
+        ]
+        top_vc = [
+            {"id": int(uid), "minutes": int(data.get("voice", 0) // 60)}
+            for uid, data in vc_sorted[:3]
+        ]
+        top_mvp = [
+            {"id": int(uid), "score": round(score((uid, data)), 2)}
+            for uid, data in mvp_sorted[:3]
+        ]
+
+        winners = {
+            "msg": top_msg[0]["id"] if top_msg else None,
+            "vc": top_vc[0]["id"] if top_vc else None,
+            "mvp": top_mvp[0]["id"] if top_mvp else None,
+        }
+        return {"top3": {"msg": top_msg, "vc": top_vc, "mvp": top_mvp}, "winners": winners}
+
+    # ── Main task ───────────────────────────────────────────
+
+    @tasks.loop(time=time(hour=0, tzinfo=PARIS_TZ))
+    async def daily_task(self) -> None:
+        await self.bot.wait_until_ready()
+        now = datetime.now(PARIS_TZ)
+        day = (now - timedelta(days=1)).date().isoformat()
+        logging.info("[daily_ranking] Calcul du classement pour %s", day)
+        async with DAILY_LOCK:
+            stats = DAILY_STATS.pop(day, {})
+        if not stats:
+            logging.info("[daily_ranking] Aucune statistique pour %s", day)
+            await save_daily_stats_to_disk()
+            return
+        ranking = self._compute_ranking(stats)
+        ranking["date"] = day
+        self._write_persistence(ranking)
+        await save_daily_stats_to_disk()
+        await self._reset_and_assign(ranking["winners"])
+        logging.info("[daily_ranking] Classement %s sauvegardé et rôles attribués", day)
+
+    @daily_task.before_loop
+    async def before_daily_task(self) -> None:
+        await self.bot.wait_until_ready()
+
+    # ── Slash command -------------------------------------------------
+
+    @app_commands.command(name="test_classements", description="Affiche le classement du jour")
+    async def test_classements(self, interaction: discord.Interaction) -> None:
+        if not any(r.id == XP_VIEWER_ROLE_ID for r in getattr(interaction.user, "roles", [])):
+            await safe_respond(interaction, "Accès refusé.", ephemeral=True)
+            return
+        data = self._read_persistence()
+        if not data:
+            await safe_respond(interaction, "Aucun classement disponible.", ephemeral=True)
+            return
+
+        lines = [f"Classement du {data.get('date', '?')}"]
+        lines.append("\n📜 Messages:")
+        for i, entry in enumerate(data.get("top3", {}).get("msg", []), 1):
+            lines.append(f"{i}. <@{entry['id']}> — {entry['count']} msg")
+        lines.append("\n🎤 Vocal:")
+        for i, entry in enumerate(data.get("top3", {}).get("vc", []), 1):
+            lines.append(f"{i}. <@{entry['id']}> — {entry['minutes']} min")
+        lines.append("\n👑 MVP:")
+        for i, entry in enumerate(data.get("top3", {}).get("mvp", []), 1):
+            lines.append(f"{i}. <@{entry['id']}> — {entry['score']}")
+        await safe_respond(interaction, "\n".join(lines), ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:  # pragma: no cover - integration
+    await bot.add_cog(DailyRankingAndRoles(bot))
+

--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -3,7 +3,7 @@ import io
 import logging
 import os
 import random
-from datetime import datetime, timezone, time, timedelta
+from datetime import datetime, timezone, time
 
 import discord
 from discord import app_commands
@@ -11,10 +11,6 @@ from discord.ext import commands, tasks
 
 from config import (
     DATA_DIR,
-    ACTIVITY_SUMMARY_CH,
-    MVP_ROLE_ID,
-    TOP_MSG_ROLE_ID,
-    TOP_VC_ROLE_ID,
 )
 from utils.interactions import safe_respond
 from utils.persist import atomic_write_json, read_json_safe, ensure_dir
@@ -108,14 +104,12 @@ class XPCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         self.auto_backup_xp.start()
-        self.daily_awards.start()
         self._message_cooldown = commands.CooldownMapping.from_cooldown(
             1, 60.0, commands.BucketType.user
         )
 
     def cog_unload(self) -> None:
         self.auto_backup_xp.cancel()
-        self.daily_awards.cancel()
 
     @tasks.loop(minutes=10)
     async def auto_backup_xp(self) -> None:
@@ -126,69 +120,6 @@ class XPCog(commands.Cog):
             logging.exception("[xp] auto_backup_xp: exception: %s", e)
         await save_daily_stats_to_disk()
         logging.info("🛟 Sauvegarde périodique effectuée.")
-
-    @tasks.loop(time=time(hour=0, tzinfo=timezone.utc))
-    async def daily_awards(self) -> None:
-        yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()
-        async with DAILY_LOCK:
-            stats = DAILY_STATS.get(yesterday, {})
-        if not stats:
-            return
-
-        def top_user(key: str) -> str | None:
-            if not stats:
-                return None
-            return max(stats.items(), key=lambda x: x[1].get(key, 0))[0]
-
-        top_msg = top_user("messages")
-        top_vc = top_user("voice")
-        top_mvp = max(
-            stats.items(),
-            key=lambda x: x[1].get("messages", 0) + x[1].get("voice", 0) // 60,
-        )[0]
-
-        guild = self.bot.guilds[0] if self.bot.guilds else None
-        if guild:
-            roles = {
-                "mvp": guild.get_role(MVP_ROLE_ID),
-                "msg": guild.get_role(TOP_MSG_ROLE_ID),
-                "vc": guild.get_role(TOP_VC_ROLE_ID),
-            }
-            for member in guild.members:
-                to_remove = [r for r in roles.values() if r and r in member.roles]
-                if to_remove:
-                    try:
-                        await member.remove_roles(*to_remove, reason="Remise à zéro du classement quotidien")
-                    except Exception:
-                        pass
-            winners = {
-                "mvp": guild.get_member(int(top_mvp)) if top_mvp else None,
-                "msg": guild.get_member(int(top_msg)) if top_msg else None,
-                "vc": guild.get_member(int(top_vc)) if top_vc else None,
-            }
-            if winners["mvp"] and roles["mvp"]:
-                await winners["mvp"].add_roles(roles["mvp"], reason="👑 MVP du Refuge")
-            if winners["msg"] and roles["msg"]:
-                await winners["msg"].add_roles(roles["msg"], reason="📜 Écrivain du Refuge")
-            if winners["vc"] and roles["vc"]:
-                await winners["vc"].add_roles(roles["vc"], reason="🎤 Voix du Refuge")
-            channel = guild.get_channel(ACTIVITY_SUMMARY_CH)
-            if channel:
-                await channel.send(
-                    (
-                        "🎉 Félicitations aux champions du Refuge ! 🎉\n\n"
-                        "Chaque jour, nous mettons à l’honneur nos membres les plus actifs.\n"
-                        "Les Top 1 de chaque catégorie reçoivent un rôle spécial, valable du moment du message (00h00) jusqu’à 23h59 :\n\n"
-                        f"👑 MVP du Refuge **{winners['mvp'].mention if winners['mvp'] else 'Personne'}**\n"
-                        f"📜 Écrivain du Refuge **{winners['msg'].mention if winners['msg'] else 'Personne'}**\n"
-                        f"🎤 Voix du Refuge **{winners['vc'].mention if winners['vc'] else 'Personne'}**\n\n"
-                        "👏 Bravo aux gagnants du jour, continuez à faire vivre le Refuge !"
-                    )
-                )
-
-        async with DAILY_LOCK:
-            DAILY_STATS.pop(yesterday, None)
-        await save_daily_stats_to_disk()
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message) -> None:
@@ -248,9 +179,6 @@ class XPCog(commands.Cog):
     async def before_auto_backup_xp(self) -> None:
         await self.bot.wait_until_ready()
 
-    @daily_awards.before_loop
-    async def before_daily_awards(self) -> None:
-        await self.bot.wait_until_ready()
 
     @app_commands.command(name="rang", description="Affiche ton niveau avec une carte graphique")
     async def rang(self, interaction: discord.Interaction) -> None:


### PR DESCRIPTION
## Summary
- compute daily rankings from message and voice activity
- reset and assign daily winner roles with persistent storage
- provide `/test_classements` command for authorized users

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3ac01ed848324add5fb57e0e34294