### PR TITLE
feat: post daily ranking summary

### DIFF
--- a/cogs/daily_ranking.py
+++ b/cogs/daily_ranking.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta, time, timezone
 from typing import Dict, Any
 
 import discord
-from discord import app_commands
 from discord.ext import commands, tasks
 
 from config import (
@@ -12,10 +11,8 @@ from config import (
     MVP_ROLE_ID,
     TOP_MSG_ROLE_ID,
     TOP_VC_ROLE_ID,
-    XP_VIEWER_ROLE_ID,
 )
 from utils.persist import read_json_safe, atomic_write_json, ensure_dir
-from utils.interactions import safe_respond
 from .xp import DAILY_STATS, DAILY_LOCK, save_daily_stats_to_disk
 
 try:
@@ -147,30 +144,6 @@ class DailyRankingAndRoles(commands.Cog):
     @daily_task.before_loop
     async def before_daily_task(self) -> None:
         await self.bot.wait_until_ready()
-
-    # ── Slash command -------------------------------------------------
-
-    @app_commands.command(name="test_classements", description="Affiche le classement du jour")
-    async def test_classements(self, interaction: discord.Interaction) -> None:
-        if not any(r.id == XP_VIEWER_ROLE_ID for r in getattr(interaction.user, "roles", [])):
-            await safe_respond(interaction, "Accès refusé.", ephemeral=True)
-            return
-        data = self._read_persistence()
-        if not data:
-            await safe_respond(interaction, "Aucun classement disponible.", ephemeral=True)
-            return
-
-        lines = [f"Classement du {data.get('date', '?')}"]
-        lines.append("\n📜 Messages:")
-        for i, entry in enumerate(data.get("top3", {}).get("msg", []), 1):
-            lines.append(f"{i}. <@{entry['id']}> — {entry['count']} msg")
-        lines.append("\n🎤 Vocal:")
-        for i, entry in enumerate(data.get("top3", {}).get("vc", []), 1):
-            lines.append(f"{i}. <@{entry['id']}> — {entry['minutes']} min")
-        lines.append("\n👑 MVP:")
-        for i, entry in enumerate(data.get("top3", {}).get("mvp", []), 1):
-            lines.append(f"{i}. <@{entry['id']}> — {entry['score']}")
-        await safe_respond(interaction, "\n".join(lines), ephemeral=True)
 
 
 async def setup(bot: commands.Bot) -> None:  # pragma: no cover - integration

--- a/cogs/daily_summary_poster.py
+++ b/cogs/daily_summary_poster.py
@@ -1,0 +1,159 @@
+"""Publication quotidienne du classement.
+
+Cette cog lit les classements calculés par :mod:`cogs.daily_ranking`
+et les publie chaque jour à 00h02 dans le salon dédié. Un fichier de
+persistance est utilisé pour éviter la publication multiple du même
+classement. Une commande slash permet également de prévisualiser le
+message envoyé.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import time, timezone
+from typing import Dict, Any
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from config import ACTIVITY_SUMMARY_CH, DATA_DIR, XP_VIEWER_ROLE_ID
+from utils.interactions import safe_respond
+from utils.persist import read_json_safe, atomic_write_json, ensure_dir
+
+try:
+    from zoneinfo import ZoneInfo
+
+    PARIS_TZ = ZoneInfo("Europe/Paris")
+except Exception:  # pragma: no cover - fallback
+    PARIS_TZ = timezone.utc
+
+
+DAILY_RANK_FILE = os.path.join(DATA_DIR, "daily_ranking.json")
+DAILY_SUMMARY_FILE = os.path.join(DATA_DIR, "daily_summary.json")
+ensure_dir(DATA_DIR)
+
+
+def _format_hm(minutes: int) -> str:
+    """Format ``minutes`` as ``HhMM``."""
+
+    h, m = divmod(int(minutes), 60)
+    return f"{h}h{m:02d}"
+
+
+class DailySummaryPoster(commands.Cog):
+    """Publie le classement quotidien à 00h02."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.daily_task.start()
+        self.bot.loop.create_task(self._startup_check())
+
+    def cog_unload(self) -> None:  # pragma: no cover - cleanup
+        self.daily_task.cancel()
+
+    # ── Persistence helpers ──────────────────────────────────
+    def _read_summary(self) -> Dict[str, Any]:
+        return read_json_safe(DAILY_SUMMARY_FILE)
+
+    def _write_summary(self, data: Dict[str, Any]) -> None:
+        atomic_write_json(DAILY_SUMMARY_FILE, data)
+
+    # ── Message formatting ───────────────────────────────────
+    def _build_message(self, data: Dict[str, Any]) -> str:
+        top3 = data.get("top3", {})
+
+        medals = ["🥇", "🥈", "🥉"]
+
+        def fmt_msg(idx: int) -> str:
+            if idx < len(top3.get("msg", [])):
+                entry = top3["msg"][idx]
+                return f"{medals[idx]} <@{entry['id']}> — {entry['count']} msgs"
+            return f"{medals[idx]} —"
+
+        def fmt_vc(idx: int) -> str:
+            if idx < len(top3.get("vc", [])):
+                entry = top3["vc"][idx]
+                hm = _format_hm(entry["minutes"])
+                return f"{medals[idx]} <@{entry['id']}> — {hm}"
+            return f"{medals[idx]} —"
+
+        def fmt_mvp(idx: int) -> str:
+            if idx < len(top3.get("mvp", [])):
+                entry = top3["mvp"][idx]
+                return f"{medals[idx]} <@{entry['id']}> — score {entry['score']}"
+            return f"{medals[idx]} —"
+
+        lines = [
+            "📊 Classement journalier du Refuge 📊",
+            "",
+            "**Messages envoyés**",
+            fmt_msg(0),
+            fmt_msg(1),
+            fmt_msg(2),
+            "",
+            "**Temps vocal**",
+            fmt_vc(0),
+            fmt_vc(1),
+            fmt_vc(2),
+            "",
+            "**MVP (messages + vocal)**",
+            fmt_mvp(0),
+            fmt_mvp(1),
+            fmt_mvp(2),
+            "",
+            "🔄 Les rôles journaliers ont été remis à zéro, et nos champions gardent leur titre jusqu’à **23h59** !",
+            "👉 Continuez à être actifs pour grimper au classement de demain 💬🎤",
+        ]
+        return "\n".join(lines)
+
+    # ── Core logic ───────────────────────────────────────────
+    async def _maybe_post(self, data: Dict[str, Any]) -> None:
+        if not data:
+            return
+        summary = self._read_summary()
+        if summary.get("date") == data.get("date"):
+            return  # already posted
+        channel = self.bot.get_channel(ACTIVITY_SUMMARY_CH)
+        if not channel:
+            logging.warning("[daily_summary] Salon %s introuvable", ACTIVITY_SUMMARY_CH)
+            return
+        message = self._build_message(data)
+        msg = await channel.send(message)
+        self._write_summary({"date": data.get("date"), "message_id": msg.id})
+        logging.info("[daily_summary] Classement %s publié", data.get("date"))
+
+    # ── Tasks ────────────────────────────────────────────────
+    @tasks.loop(time=time(hour=0, minute=2, tzinfo=PARIS_TZ))
+    async def daily_task(self) -> None:
+        await self.bot.wait_until_ready()
+        data = read_json_safe(DAILY_RANK_FILE)
+        await self._maybe_post(data)
+
+    @daily_task.before_loop
+    async def before_daily_task(self) -> None:  # pragma: no cover - scheduler hook
+        await self.bot.wait_until_ready()
+
+    async def _startup_check(self) -> None:
+        await self.bot.wait_until_ready()
+        data = read_json_safe(DAILY_RANK_FILE)
+        await self._maybe_post(data)
+
+    # ── Slash command -------------------------------------------------
+    @app_commands.command(name="test_classements", description="Prévisualise le message du jour")
+    async def test_classements(self, interaction: discord.Interaction) -> None:
+        if not any(r.id == XP_VIEWER_ROLE_ID for r in getattr(interaction.user, "roles", [])):
+            await safe_respond(interaction, "Accès refusé.", ephemeral=True)
+            return
+        data = read_json_safe(DAILY_RANK_FILE)
+        if not data:
+            await safe_respond(interaction, "Aucun classement disponible.", ephemeral=True)
+            return
+        message = self._build_message(data)
+        await safe_respond(interaction, message, ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:  # pragma: no cover - integration
+    await bot.add_cog(DailySummaryPoster(bot))
+


### PR DESCRIPTION
## Summary
- add `DailySummaryPoster` cog to publish daily top stats at 00:02
- store last published summary to prevent duplicate messages
- expose `/test_classements` command for previewing the daily message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ae8d296c8324b106761132793a7d