### PR TITLE
Handle missing daily summary posts

### DIFF
--- a/cogs/daily_summary_poster.py
+++ b/cogs/daily_summary_poster.py
@@ -113,12 +113,21 @@ class DailySummaryPoster(commands.Cog):
         if not data:
             return
         summary = self._read_summary()
-        if summary.get("date") == data.get("date"):
-            return  # already posted
         channel = self.bot.get_channel(ACTIVITY_SUMMARY_CH)
         if not channel:
             logging.warning("[daily_summary] Salon %s introuvable", ACTIVITY_SUMMARY_CH)
             return
+
+        message_id = summary.get("message_id")
+        if summary.get("date") == data.get("date") and message_id:
+            try:
+                await channel.fetch_message(message_id)
+                return  # already posted and message exists
+            except discord.NotFound:
+                logging.warning(
+                    "[daily_summary] Message %s introuvable, re-publication", message_id
+                )
+
         message = self._build_message(data)
         msg = await channel.send(message)
         self._write_summary({"date": data.get("date"), "message_id": msg.id})

--- a/tests/test_daily_summary_republish_missing.py
+++ b/tests/test_daily_summary_republish_missing.py
@@ -1,0 +1,40 @@
+import discord
+import pytest
+from discord.ext import commands
+from unittest import mock
+
+from cogs.daily_summary_poster import DailySummaryPoster
+
+
+class DummyChannel:
+    def __init__(self):
+        self.sent_contents = []
+
+    async def send(self, content):
+        self.sent_contents.append(content)
+        return mock.Mock(id=456)
+
+    async def fetch_message(self, mid):
+        raise discord.NotFound(mock.Mock(status=404), "Not Found")
+
+
+@pytest.mark.asyncio
+async def test_republish_when_message_missing():
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    channel = DummyChannel()
+    bot.get_channel = lambda _cid: channel
+
+    summary = {"date": "today", "message_id": 123}
+
+    cog = DailySummaryPoster.__new__(DailySummaryPoster)
+    cog.bot = bot
+    cog._read_summary = lambda: summary
+    cog._write_summary = lambda data: summary.update(data)
+    cog._build_message = lambda data: "message"
+
+    await cog._maybe_post({"date": "today"})
+
+    assert summary == {"date": "today", "message_id": 456}
+    assert channel.sent_contents == ["message"]
+
+    await bot.close()


### PR DESCRIPTION
## Summary
- Verify stored daily summary message exists by fetching it
- Repost and update tracking file when the message is missing
- Test republishing logic for missing daily summary

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3b4477e4c8324989b8af3cc2386c5