### PR TITLE
docs: add module docstrings to cogs

### DIFF
--- a/cogs/daily_ranking.py
+++ b/cogs/daily_ranking.py
@@ -1,3 +1,11 @@
+"""Gestion du classement quotidien et attribution des rôles associés.
+
+Ce module calcule les gagnants quotidiens à partir des statistiques
+d'activité et persiste les résultats dans ``daily_ranking.json`` via
+``utils.persist``. Il lit et écrit également les statistiques
+journalières partagées avec la cog XP.
+"""
+
 import logging
 import os
 from datetime import datetime, timedelta, time, timezone

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -1,3 +1,10 @@
+"""Commandes diverses ne nécessitant pas de persistance.
+
+Cette cog regroupe plusieurs commandes utilitaires (sondages, liens,
+purge, choix du type de joueur) qui n'enregistrent aucune donnée de
+manière permanente.
+"""
+
 import logging
 
 import discord

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -1,3 +1,11 @@
+"""Mise à jour des salons de statistiques du serveur.
+
+La cog renomme périodiquement les canaux affichant le nombre de
+membres, les utilisateurs en ligne et l'activité vocale. Elle ne recourt
+à aucune persistance, s'appuyant seulement sur ``rename_manager`` pour
+effectuer les changements.
+"""
+
 import discord
 from discord.ext import commands, tasks
 from discord import app_commands

--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -1,3 +1,11 @@
+"""Système d'XP du serveur : messages, voix et statistiques quotidiennes.
+
+La cog enregistre l'activité des membres, calcule l'XP et gère les
+statistiques journalières. La persistance repose sur ``xp_store`` pour
+les données d'XP et sur des fichiers JSON pour les temps vocaux et les
+statistiques quotidiennes.
+"""
+
 import asyncio
 import io
 import logging


### PR DESCRIPTION
## Summary
- document daily ranking roles and persistence
- describe XP system and its storage strategy
- explain stats channel management and lack of persistence
- outline miscellaneous commands without persistence

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3b69fffb483248bad1a14f1edb5c5