### PR TITLE
Improve Discord exception handling in cogs

### DIFF
--- a/cogs/daily_ranking.py
+++ b/cogs/daily_ranking.py
@@ -84,9 +84,28 @@ class DailyRankingAndRoles(commands.Cog):
             to_remove = [r for r in roles.values() if r and r in member.roles]
             if to_remove:
                 try:
-                    await member.remove_roles(*to_remove, reason="Réinitialisation des rôles journaliers")
+                    await member.remove_roles(
+                        *to_remove,
+                        reason="Réinitialisation des rôles journaliers",
+                    )
+                except discord.Forbidden:
+                    logging.warning(
+                        "[daily_ranking] Permissions insuffisantes pour retirer un rôle"
+                    )
+                except discord.NotFound:
+                    logging.warning(
+                        "[daily_ranking] Rôle ou membre introuvable lors du retrait"
+                    )
+                except discord.HTTPException as e:
+                    logging.error(
+                        "[daily_ranking] Erreur HTTP lors du retrait d'un rôle: %s",
+                        e,
+                    )
                 except Exception as e:  # pragma: no cover - just log
-                    logging.error("[daily_ranking] Retrait rôle échoué: %s", e)
+                    logging.exception(
+                        "[daily_ranking] Erreur inattendue lors du retrait d'un rôle: %s",
+                        e,
+                    )
         for key, uid in winners.items():
             role = roles.get(key)
             if not role or not uid:
@@ -95,10 +114,28 @@ class DailyRankingAndRoles(commands.Cog):
             if not member:
                 continue
             try:
-                await member.add_roles(role, reason="Attribution classement quotidien")
+                await member.add_roles(
+                    role, reason="Attribution classement quotidien"
+                )
                 logging.info("[daily_ranking] Rôle %s attribué à %s", role.id, uid)
+            except discord.Forbidden:
+                logging.warning(
+                    "[daily_ranking] Permissions insuffisantes pour attribuer un rôle"
+                )
+            except discord.NotFound:
+                logging.warning(
+                    "[daily_ranking] Rôle ou membre introuvable lors de l'attribution"
+                )
+            except discord.HTTPException as e:
+                logging.error(
+                    "[daily_ranking] Erreur HTTP lors de l'attribution du rôle: %s",
+                    e,
+                )
             except Exception as e:  # pragma: no cover
-                logging.error("[daily_ranking] Attribution rôle échouée: %s", e)
+                logging.exception(
+                    "[daily_ranking] Erreur inattendue lors de l'attribution du rôle: %s",
+                    e,
+                )
 
     # ── Computation ──────────────────────────────────────────
 

--- a/cogs/welcome.py
+++ b/cogs/welcome.py
@@ -26,8 +26,23 @@ class WelcomeCog(commands.Cog):
                     f"🕹️ Choisis ton rôle dans le salon <#{CHANNEL_ROLES}> pour accéder à toutes les sections.\n"
                     "Ravi de t’avoir parmi nous ! 🎮"
                 )
+            except discord.Forbidden:
+                logging.warning(
+                    "[welcome] Permissions insuffisantes pour envoyer le message de bienvenue"
+                )
+            except discord.NotFound:
+                logging.warning(
+                    "[welcome] Salon de bienvenue introuvable pour l'envoi du message"
+                )
+            except discord.HTTPException as e:
+                logging.error(
+                    "[welcome] Erreur HTTP lors de l'envoi du message de bienvenue: %s",
+                    e,
+                )
             except Exception:
-                logging.exception("[welcome] Échec d'envoi du message de bienvenue pour %s", member.id)
+                logging.exception(
+                    "[welcome] Échec d'envoi du message de bienvenue pour %s", member.id
+                )
 
 
 async def setup(bot: commands.Bot) -> None:


### PR DESCRIPTION
## Summary
- handle Discord-specific exceptions instead of generic `except Exception`
- add contextual logging for permission, missing resource and HTTP errors

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3bbea3c648324976b326d780c7877