### PR TITLE
Add module docstrings

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,3 +1,5 @@
+"""Discord bot entry point configuring extensions, rate limits, and tasks."""
+
 import asyncio
 import logging
 import os

--- a/storage/xp_store.py
+++ b/storage/xp_store.py
@@ -1,3 +1,5 @@
+"""Persistent XP storage with debounced and periodic disk flushes."""
+
 import asyncio
 import logging
 import math

--- a/utils/channel_edit_manager.py
+++ b/utils/channel_edit_manager.py
@@ -1,3 +1,5 @@
+"""Queues and throttles channel edits to respect Discord rate limits."""
+
 import asyncio
 import logging
 import time

--- a/utils/discord_utils.py
+++ b/utils/discord_utils.py
@@ -1,3 +1,5 @@
+"""Helper functions for Discord channels and rate-limited edits."""
+
 import logging
 import discord
 from discord.ext import commands

--- a/utils/rename_manager.py
+++ b/utils/rename_manager.py
@@ -1,3 +1,5 @@
+"""Handles queued channel rename operations with rate limiting and retries."""
+
 import asyncio
 import logging
 import time


### PR DESCRIPTION
## Summary
- document bot entry point and core utilities with module docstrings
- clarify responsibilities for channel editing, renaming, and XP storage modules

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3c534685c832499d5a79967e048dd