### PR TITLE
Use atomic write for roulette store

### DIFF
--- a/storage/roulette_store.py
+++ b/storage/roulette_store.py
@@ -5,6 +5,8 @@ from pathlib import Path
 from typing import Optional
 from zoneinfo import ZoneInfo
 
+from utils.persist import atomic_write_json
+
 
 class RouletteStore:
     def __init__(self, data_dir: str):
@@ -22,8 +24,7 @@ class RouletteStore:
 
     def _save(self):
         try:
-            with self.data_file.open("w", encoding="utf-8") as f:
-                json.dump(self.data, f, indent=2, ensure_ascii=False)
+            atomic_write_json(self.data_file, self.data)
         except Exception as e:
             logging.error("[RouletteStore] Écriture échouée pour %s: %s", self.data_file, e)
 

--- a/utils/persist.py
+++ b/utils/persist.py
@@ -1,0 +1,15 @@
+from .persistence import (
+    ensure_dir,
+    read_json_safe,
+    atomic_write_json,
+    atomic_write_json_async,
+    schedule_checkpoint,
+)
+
+__all__ = [
+    "ensure_dir",
+    "read_json_safe",
+    "atomic_write_json",
+    "atomic_write_json_async",
+    "schedule_checkpoint",
+]


### PR DESCRIPTION
## Summary
- use atomic_write_json for roulette store persistence
- add `utils.persist` as alias for persistence helpers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3cc0da9c08324ba1847723db2fe93