### PR TITLE
feat: add level up announcements

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -10,6 +10,7 @@ import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 
+import config
 from utils.rate_limit import GlobalRateLimiter
 from storage.xp_store import xp_store
 from utils.rename_manager import rename_manager
@@ -18,6 +19,27 @@ from view import PlayerTypeView
 
 load_dotenv(override=True)
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+
+async def announce_level_up(
+    guild: discord.Guild,
+    user: discord.abc.User,
+    old_lvl: int,
+    new_lvl: int,
+    total_xp: int,
+) -> None:
+    """Annonce la montée de niveau d'un utilisateur dans un salon dédié."""
+    channel = guild.get_channel(config.LEVEL_UP_CHANNEL)
+    if channel is None:
+        return
+    embed = discord.Embed(
+        title="🎉 Niveau atteint !",
+        description=(
+            f"{user.mention} passe du niveau {old_lvl} au niveau {new_lvl}!"
+        ),
+        color=discord.Color.green(),
+    )
+    embed.set_footer(text=f"XP total : {total_xp}")
+    await channel.send(embed=embed)
 
 intents = discord.Intents.default()
 intents.members = True
@@ -59,6 +81,7 @@ class RefugeBot(commands.Bot):
 
 
 bot = RefugeBot(command_prefix="!", intents=intents)
+bot.announce_level_up = announce_level_up
 
 limiter = GlobalRateLimiter()
 _orig_request = bot.http.request

--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -149,7 +149,11 @@ class XPCog(commands.Cog):
         if bucket.update_rate_limit():
             return
         amount = random.randint(5, 15)
-        await award_xp(message.author.id, amount)
+        old_lvl, new_lvl, total_xp = await award_xp(message.author.id, amount)
+        if new_lvl > old_lvl:
+            await self.bot.announce_level_up(
+                message.guild, message.author, old_lvl, new_lvl, total_xp
+            )
 
     @commands.Cog.listener()
     async def on_voice_state_update(
@@ -172,7 +176,11 @@ class XPCog(commands.Cog):
             if start is not None:
                 duration = now - start
                 xp_amount = int(duration.total_seconds() // 60)
-                await award_xp(member.id, xp_amount)
+                old_lvl, new_lvl, total_xp = await award_xp(member.id, xp_amount)
+                if new_lvl > old_lvl:
+                    await self.bot.announce_level_up(
+                        member.guild, member, old_lvl, new_lvl, total_xp
+                    )
                 # Statistiques quotidiennes (en secondes)
                 day = now.date().isoformat()
                 async with DAILY_LOCK:


### PR DESCRIPTION
## Summary
- Announce level-ups in a dedicated channel
- Trigger level-up announcements after XP awards

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3d20d19cc8324824b7c959d3f8d0b