### PR TITLE
Avoid double initialization of XP store

### DIFF
--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -79,7 +79,6 @@ async def save_daily_stats_to_disk() -> None:
 
 async def xp_bootstrap_cache() -> None:
     global XP_CACHE, voice_times, DAILY_STATS, XP_LOCK
-    await xp_store.start()
     XP_CACHE = xp_store.data
     XP_LOCK = xp_store.lock
     voice_times = load_voice_times()

--- a/storage/xp_store.py
+++ b/storage/xp_store.py
@@ -27,6 +27,8 @@ class XPStore:
         self._periodic_task: asyncio.Task | None = None
 
     async def start(self) -> None:
+        if self._periodic_task and not self._periodic_task.done():
+            return
         ensure_dir(DATA_DIR)
         self.data = read_json_safe(self.path)
         logging.info("DATA_DIR=%s", DATA_DIR)


### PR DESCRIPTION
## Summary
- prevent XPStore.start from scheduling duplicate periodic tasks
- initialize XP cache without extra start call

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a3d8abe2e08324b2a16ea0ade0b1c1