### PR TITLE
Enable daily ranking and summary cogs with unique test commands

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -65,6 +65,8 @@ class RefugeBot(commands.Bot):
             "cogs.radio",
             "cogs.stats",
             "cogs.welcome",
+            "cogs.daily_ranking",
+            "cogs.daily_summary_poster",
         ]
         for ext in extensions:
             try:

--- a/cogs/daily_ranking.py
+++ b/cogs/daily_ranking.py
@@ -194,8 +194,12 @@ class DailyRankingAndRoles(commands.Cog):
     async def before_daily_task(self) -> None:
         await self.bot.wait_until_ready()
 
-    @app_commands.command(name="test_classements", description="Prévisualise le classement du jour")
-    async def test_classements(self, interaction: discord.Interaction) -> None:
+    @app_commands.command(
+        name="test_classement1", description="Prévisualise le classement du jour"
+    )
+    async def test_classement1(
+        self, interaction: discord.Interaction
+    ) -> None:
         if not any(r.id == XP_VIEWER_ROLE_ID for r in getattr(interaction.user, "roles", [])):
             await safe_respond(interaction, "Accès refusé.", ephemeral=True)
             return

--- a/cogs/daily_summary_poster.py
+++ b/cogs/daily_summary_poster.py
@@ -150,8 +150,12 @@ class DailySummaryPoster(commands.Cog):
         await self._maybe_post(data)
 
     # ── Slash command -------------------------------------------------
-    @app_commands.command(name="test_classements", description="Prévisualise le message du jour")
-    async def test_classements(self, interaction: discord.Interaction) -> None:
+    @app_commands.command(
+        name="test_classement2", description="Prévisualise le message du jour"
+    )
+    async def test_classement2(
+        self, interaction: discord.Interaction
+    ) -> None:
         if not any(r.id == XP_VIEWER_ROLE_ID for r in getattr(interaction.user, "roles", [])):
             await safe_respond(interaction, "Accès refusé.", ephemeral=True)
             return

--- a/tests/test_daily_ranking_roles_reapply.py
+++ b/tests/test_daily_ranking_roles_reapply.py
@@ -80,12 +80,12 @@ async def test_roles_reapplied_after_restart():
 
 
 @pytest.mark.asyncio
-async def test_test_classements_permission_and_ephemeral():
+async def test_test_classement1_permission_and_ephemeral():
     cog = DailyRankingAndRoles.__new__(DailyRankingAndRoles)
     cog.bot = SimpleNamespace()
 
     interaction = SimpleNamespace(user=SimpleNamespace(roles=[]))
-    command = DailyRankingAndRoles.test_classements
+    command = DailyRankingAndRoles.test_classement1
     with patch("cogs.daily_ranking.safe_respond", new_callable=AsyncMock) as respond:
         await command.callback(cog, interaction)
     respond.assert_awaited_once_with(interaction, "Accès refusé.", ephemeral=True)


### PR DESCRIPTION
## Summary
- load the daily ranking and daily summary poster cogs
- rename conflicting `/test_classements` slash commands to `/test_classement1` and `/test_classement2`
- update tests for renamed command

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3d90fa67c832498d43463a2390599