### PR TITLE
feat: make roulette boundary check interval configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ ces limites.
 La fréquence de vérification des noms de ces salons est définie par la constante
 `TEMP_VC_CHECK_INTERVAL_SECONDS` (30 secondes par défaut).
 
+La vérification de l'état de la roulette est contrôlée par la constante
+`ROULETTE_BOUNDARY_CHECK_INTERVAL_MINUTES` (5 minutes par défaut).
+
 ### Sauvegarde des sessions vocales
 
 Les heures d'entrée des membres en vocal sont stockées dans

--- a/cogs/roulette.py
+++ b/cogs/roulette.py
@@ -19,6 +19,7 @@ from config import (
     ROULETTE_ROLE_ID as ROLE_ID,
     ROULETTE_CHANNEL_ID as CHANNEL_ID,
     DATA_DIR,
+    ROULETTE_BOUNDARY_CHECK_INTERVAL_MINUTES,
 )
 
 PARIS_TZ = "Europe/Paris"
@@ -387,7 +388,7 @@ class RouletteCog(commands.Cog):
             logging.debug("Error ensuring state message: %s", e)
         await self._post_state_message(opened)
 
-    @tasks.loop(seconds=60.0)
+    @tasks.loop(minutes=ROULETTE_BOUNDARY_CHECK_INTERVAL_MINUTES)
     async def boundary_watch_loop(self):
         try:
             enabled_now = is_open_now(PARIS_TZ, 10, 22)

--- a/config.py
+++ b/config.py
@@ -85,6 +85,11 @@ ROULETTE_ROLE_ID: int = 1405170057792979025
 ANNOUNCE_CHANNEL_ID: int = 1400552164979507263
 """Salon utilisé pour les annonces de la roulette."""
 
+ROULETTE_BOUNDARY_CHECK_INTERVAL_MINUTES: int = int(
+    os.getenv("ROULETTE_BOUNDARY_CHECK_INTERVAL_MINUTES", "5")
+)
+"""Intervalle en minutes entre deux vérifications de l'état de la roulette."""
+
 # ── Persistance et I/O ───────────────────────────────────────
 DATA_DIR: str = _resolve_data_dir()
 """Répertoire de stockage persistant."""


### PR DESCRIPTION
## Summary
- allow adjusting roulette state polling frequency via `ROULETTE_BOUNDARY_CHECK_INTERVAL_MINUTES`
- document new interval in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a46efbce98832488ddd4d8f4e95f95