### PR TITLE
Retry fetch_channel when summary channel missing

### DIFF
--- a/cogs/daily_summary_poster.py
+++ b/cogs/daily_summary_poster.py
@@ -115,8 +115,16 @@ class DailySummaryPoster(commands.Cog):
         summary = self._read_summary()
         channel = self.bot.get_channel(ACTIVITY_SUMMARY_CH)
         if not channel:
-            logging.warning("[daily_summary] Salon %s introuvable", ACTIVITY_SUMMARY_CH)
-            return
+            try:
+                channel = await self.bot.fetch_channel(ACTIVITY_SUMMARY_CH)
+            except Exception:
+                logging.exception(
+                    "[daily_summary] Salon %s introuvable", ACTIVITY_SUMMARY_CH
+                )
+                self._write_summary(
+                    {"date": data.get("date"), "error": "channel_not_found"}
+                )
+                return
 
         message_id = summary.get("message_id")
         if summary.get("date") == data.get("date") and message_id:

--- a/tests/test_daily_summary_fetch_channel.py
+++ b/tests/test_daily_summary_fetch_channel.py
@@ -1,0 +1,34 @@
+import discord
+import pytest
+from discord.ext import commands
+from unittest import mock
+
+from cogs.daily_summary_poster import DailySummaryPoster
+from config import ACTIVITY_SUMMARY_CH
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_failure_writes_persistence():
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    bot.get_channel = lambda _cid: None
+    bot.fetch_channel = mock.AsyncMock(
+        side_effect=discord.NotFound(mock.Mock(status=404), "Not Found")
+    )
+
+    written = {}
+
+    cog = DailySummaryPoster.__new__(DailySummaryPoster)
+    cog.bot = bot
+    cog._read_summary = lambda: {}
+
+    def fake_write(data):
+        written.update(data)
+    cog._write_summary = fake_write
+    cog._build_message = lambda data: "message"
+
+    await cog._maybe_post({"date": "today"})
+
+    bot.fetch_channel.assert_awaited_once_with(ACTIVITY_SUMMARY_CH)
+    assert written == {"date": "today", "error": "channel_not_found"}
+
+    await bot.close()


### PR DESCRIPTION
## Summary
- Retry fetching the daily summary channel when not cached
- Persist a `channel_not_found` error when channel retrieval fails
- Test fetch_channel fallback and persistence on failure

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a4f8ce42a88324b1c18a5c24ce3282