### PR TITLE
Add /radio_rap command for rap station

### DIFF
--- a/config.py
+++ b/config.py
@@ -47,6 +47,7 @@ RADIO_MUTED_ROLE_ID = 1403510368340410550
 RADIO_STREAM_URL = os.getenv(
     "RADIO_STREAM_URL", "http://stream.laut.fm/englishrap"
 )
+RADIO_RAP_STREAM_URL = "https://stream.laut.fm/24-7-rap"
 
 # ── Divers ───────────────────────────────────────────────────
 XP_VIEWER_ROLE_ID = 1403510368340410550

--- a/tests/test_radio_rap_command.py
+++ b/tests/test_radio_rap_command.py
@@ -1,0 +1,37 @@
+import asyncio
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import AsyncMock
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import cogs.radio as radio_mod
+from cogs.radio import RadioCog
+from config import RADIO_RAP_STREAM_URL, RADIO_VC_ID
+
+
+@pytest.mark.asyncio
+async def test_radio_rap_command_switches_stream(monkeypatch):
+    class FakeVoiceChannel(SimpleNamespace):
+        pass
+
+    monkeypatch.setattr(radio_mod.discord, "VoiceChannel", FakeVoiceChannel)
+    channel = FakeVoiceChannel(id=RADIO_VC_ID, name="Radio")
+    bot = SimpleNamespace(loop=asyncio.get_event_loop(), get_channel=lambda cid: channel)
+    cog = RadioCog(bot)
+    monkeypatch.setattr(cog, "_connect_and_play", AsyncMock())
+    monkeypatch.setattr(radio_mod.rename_manager, "request", AsyncMock())
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=123),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await RadioCog.radio_rap.callback(cog, interaction)
+
+    assert cog.stream_url == RADIO_RAP_STREAM_URL
+    radio_mod.rename_manager.request.assert_awaited_once_with(channel, "rap")
+    interaction.response.send_message.assert_awaited_once()
+


### PR DESCRIPTION
## Summary
- use dedicated `/radio_rap` slash command with hourly cooldown
- ensure command switches stream to rap and renames channel
- test rap command behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a71db5a4048324b262d3119299e785