### PR TITLE
Add dedicated rock radio channel

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -65,6 +65,7 @@ class RefugeBot(commands.Bot):
             "cogs.temp_vc",
             "cogs.misc",
             "cogs.radio",
+            "cogs.rock_radio",
             "cogs.stats",
             "cogs.welcome",
             "cogs.daily_ranking",

--- a/cogs/rock_radio.py
+++ b/cogs/rock_radio.py
@@ -1,0 +1,143 @@
+import asyncio
+import logging
+from typing import Optional
+
+import discord
+from discord.ext import commands
+
+from config import RADIO_MUTED_ROLE_ID, ROCK_RADIO_STREAM_URL, ROCK_RADIO_VC_ID
+
+FFMPEG_BEFORE = "-fflags nobuffer -probesize 32k"
+FFMPEG_OPTIONS = "-filter:a loudnorm"
+
+
+class RockRadioCog(commands.Cog):
+    """Lit un flux radio rock dans un salon vocal."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.vc_id = ROCK_RADIO_VC_ID
+        self.stream_url: Optional[str] = ROCK_RADIO_STREAM_URL
+        self.voice: Optional[discord.VoiceClient] = None
+        self._reconnect_task: Optional[asyncio.Task] = None
+
+    async def _connect_and_play(self) -> None:
+        if not self.stream_url:
+            logging.warning("ROCK_RADIO_STREAM_URL non défini")
+            return
+        channel = self.bot.get_channel(self.vc_id)
+        if not isinstance(channel, discord.VoiceChannel):
+            logging.warning("Salon rock radio %s introuvable", self.vc_id)
+            return
+        if self.voice is None or not self.voice.is_connected():
+            try:
+                self.voice = await channel.connect(reconnect=True)
+            except discord.Forbidden:
+                logging.warning(
+                    "Permissions insuffisantes pour se connecter au salon rock radio %s",
+                    self.vc_id,
+                )
+                return
+            except discord.NotFound:
+                logging.warning(
+                    "Salon rock radio %s introuvable lors de la connexion",
+                    self.vc_id,
+                )
+                return
+            except discord.HTTPException as e:
+                logging.error(
+                    "Erreur HTTP lors de la connexion au salon rock radio: %s",
+                    e,
+                )
+                return
+            except Exception as e:
+                logging.exception(
+                    "Connexion au salon rock radio échouée: %s",
+                    e,
+                )
+                return
+        if self.voice and not self.voice.is_playing():
+            source = discord.FFmpegPCMAudio(
+                self.stream_url,
+                before_options=FFMPEG_BEFORE,
+                options=FFMPEG_OPTIONS,
+            )
+            self.voice.play(source, after=self._after_play)
+
+    def _after_play(self, error: Optional[Exception]) -> None:
+        if error:
+            logging.warning("Erreur de lecture rock radio: %s", error)
+        if self._reconnect_task is None or self._reconnect_task.done():
+            self._reconnect_task = self.bot.loop.create_task(self._delayed_reconnect())
+
+    async def _delayed_reconnect(self) -> None:
+        await asyncio.sleep(5)
+        await self._connect_and_play()
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        await self._connect_and_play()
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(
+        self,
+        member: discord.Member,
+        before: discord.VoiceState,
+        after: discord.VoiceState,
+    ) -> None:
+        if member.id == self.bot.user.id and after.channel is None:
+            if self._reconnect_task is None or self._reconnect_task.done():
+                self._reconnect_task = self.bot.loop.create_task(
+                    self._delayed_reconnect()
+                )
+            return
+
+        if any(role.id == RADIO_MUTED_ROLE_ID for role in member.roles):
+            # Join rock radio channel -> mute
+            if after.channel and after.channel.id == self.vc_id:
+                try:
+                    await member.edit(mute=True)
+                except discord.Forbidden:
+                    logging.warning(
+                        "Permissions insuffisantes pour mute %s", member
+                    )
+                except discord.NotFound:
+                    logging.warning("Membre introuvable pour mute %s", member)
+                except discord.HTTPException as e:
+                    logging.error(
+                        "Erreur HTTP lors du mute de %s: %s", member, e
+                    )
+                except Exception as e:
+                    logging.exception(
+                        "Impossible de mute %s: %s", member, e
+                    )
+            # Leave rock radio channel -> unmute
+            elif before.channel and before.channel.id == self.vc_id:
+                try:
+                    await member.edit(mute=False)
+                except discord.Forbidden:
+                    logging.warning(
+                        "Permissions insuffisantes pour demute %s", member
+                    )
+                except discord.NotFound:
+                    logging.warning(
+                        "Membre introuvable pour demute %s", member
+                    )
+                except discord.HTTPException as e:
+                    logging.error(
+                        "Erreur HTTP lors du demute de %s: %s", member, e
+                    )
+                except Exception as e:
+                    logging.exception(
+                        "Impossible de demute %s: %s", member, e
+                    )
+
+    def cog_unload(self) -> None:
+        if self._reconnect_task and not self._reconnect_task.done():
+            self._reconnect_task.cancel()
+        if self.voice and self.voice.is_connected():
+            self.bot.loop.create_task(self.voice.disconnect())
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RockRadioCog(bot))

--- a/config.py
+++ b/config.py
@@ -48,6 +48,12 @@ RADIO_STREAM_URL = os.getenv(
     "RADIO_STREAM_URL", "http://stream.laut.fm/englishrap"
 )
 
+ROCK_RADIO_VC_ID = 1408081503707074650
+ROCK_RADIO_STREAM_URL = os.getenv(
+    "ROCK_RADIO_STREAM_URL",
+    "https://rocks.stream.laut.fm/rocks?t302=2025-08-21_13-31-36&uuid=dd799269-47bb-4a86-9b7d-372b826df4e2",
+)
+
 # ── Divers ───────────────────────────────────────────────────
 XP_VIEWER_ROLE_ID = 1403510368340410550
 TOP_MSG_ROLE_ID = 1406412171965104208

--- a/tests/test_rock_radio_muted_role.py
+++ b/tests/test_rock_radio_muted_role.py
@@ -1,0 +1,47 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from cogs.rock_radio import RockRadioCog
+from config import RADIO_MUTED_ROLE_ID, ROCK_RADIO_VC_ID
+
+
+@pytest.mark.asyncio
+async def test_member_with_muted_role_gets_muted_when_joining_rock_radio():
+    bot = SimpleNamespace(user=SimpleNamespace(id=1), loop=asyncio.get_event_loop())
+    member = SimpleNamespace(
+        id=2,
+        roles=[SimpleNamespace(id=RADIO_MUTED_ROLE_ID)],
+        edit=AsyncMock(),
+    )
+    before = SimpleNamespace(channel=None)
+    after = SimpleNamespace(channel=SimpleNamespace(id=ROCK_RADIO_VC_ID))
+
+    cog = RockRadioCog(bot)
+    await cog.on_voice_state_update(member, before, after)
+
+    member.edit.assert_awaited_once()
+    assert member.edit.await_args.kwargs["mute"] is True
+
+
+@pytest.mark.asyncio
+async def test_member_unmuted_when_leaving_rock_radio():
+    bot = SimpleNamespace(user=SimpleNamespace(id=1), loop=asyncio.get_event_loop())
+    member = SimpleNamespace(
+        id=2,
+        roles=[SimpleNamespace(id=RADIO_MUTED_ROLE_ID)],
+        edit=AsyncMock(),
+    )
+    before = SimpleNamespace(channel=SimpleNamespace(id=ROCK_RADIO_VC_ID))
+    after = SimpleNamespace(channel=None)
+
+    cog = RockRadioCog(bot)
+    await cog.on_voice_state_update(member, before, after)
+
+    member.edit.assert_awaited_once()
+    assert member.edit.await_args.kwargs["mute"] is False


### PR DESCRIPTION
## Summary
- Restore original radio config and add separate 24/7 rock radio channel and stream
- Load new RockRadioCog to auto-mute users and play rock station

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a720d3c8e48324b23e2cdeabb72789