### PR TITLE
Sync commands at startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -83,6 +83,7 @@ class RefugeBot(commands.Bot):
         await channel_edit_manager.start()
         await api_meter.start(self)
         self.error_counter_task = self.loop.create_task(reset_http_error_counter())
+        await self.tree.sync()
 
     async def close(self) -> None:
         rename_manager.stop()

--- a/tests/test_setup_hook_syncs_tree.py
+++ b/tests/test_setup_hook_syncs_tree.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import discord
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+import bot
+
+
+@pytest.mark.asyncio
+async def test_setup_hook_syncs_tree(monkeypatch):
+    intents = discord.Intents.none()
+    test_bot = bot.RefugeBot(command_prefix="!", intents=intents)
+
+    monkeypatch.setattr(bot.xp_store, "start", AsyncMock())
+    monkeypatch.setattr(bot.rename_manager, "start", AsyncMock())
+    monkeypatch.setattr(bot.channel_edit_manager, "start", AsyncMock())
+    monkeypatch.setattr(bot.api_meter, "start", AsyncMock())
+    monkeypatch.setattr(bot.limiter, "start", MagicMock())
+    monkeypatch.setattr(bot, "reset_http_error_counter", AsyncMock())
+    monkeypatch.setattr(test_bot, "loop", asyncio.get_event_loop(), raising=False)
+
+    load_mock = AsyncMock()
+    monkeypatch.setattr(test_bot, "load_extension", load_mock)
+
+    sync_mock = AsyncMock()
+    monkeypatch.setattr(test_bot.tree, "sync", sync_mock)
+
+    await test_bot.setup_hook()
+
+    sync_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Sync application commands after loading extensions so slash commands like `/radio_rap` are registered
- Add test ensuring `setup_hook` calls `tree.sync`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72212efa48324848af56552de90b2