### PR TITLE
Handle missing cache for rock radio channel

### DIFF
--- a/cogs/rock_radio.py
+++ b/cogs/rock_radio.py
@@ -26,6 +26,11 @@ class RockRadioCog(commands.Cog):
             logging.warning("ROCK_RADIO_STREAM_URL non défini")
             return
         channel = self.bot.get_channel(self.vc_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(self.vc_id)
+            except discord.HTTPException:
+                channel = None
         if not isinstance(channel, discord.VoiceChannel):
             logging.warning("Salon rock radio %s introuvable", self.vc_id)
             return


### PR DESCRIPTION
## Summary
- fetch rock radio channel if not cached before connecting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72c7e704c8324be9791d50e48e7a2