### PR TITLE
Sync commands at startup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -83,6 +83,7 @@ class RefugeBot(commands.Bot):
         await channel_edit_manager.start()
         await api_meter.start(self)
         self.error_counter_task = self.loop.create_task(reset_http_error_counter())
+        await self.tree.sync()
 
     async def close(self) -> None:
         rename_manager.stop()

--- a/tests/test_radio_rap_command.py
+++ b/tests/test_radio_rap_command.py
@@ -9,11 +9,11 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import cogs.radio as radio_mod
 from cogs.radio import RadioCog
-from config import RADIO_RAP_STREAM_URL, RADIO_VC_ID
+from config import RADIO_RAP_STREAM_URL, RADIO_STREAM_URL, RADIO_VC_ID
 
 
 @pytest.mark.asyncio
-async def test_radio_rap_command_switches_stream(monkeypatch):
+async def test_radio_rap_command_toggles_stream(monkeypatch):
     class FakeVoiceChannel(SimpleNamespace):
         pass
 
@@ -21,8 +21,10 @@ async def test_radio_rap_command_switches_stream(monkeypatch):
     channel = FakeVoiceChannel(id=RADIO_VC_ID, name="Radio")
     bot = SimpleNamespace(loop=asyncio.get_event_loop(), get_channel=lambda cid: channel)
     cog = RadioCog(bot)
+    cog._original_name = "Radio"
     monkeypatch.setattr(cog, "_connect_and_play", AsyncMock())
-    monkeypatch.setattr(radio_mod.rename_manager, "request", AsyncMock())
+    rename_mock = AsyncMock()
+    monkeypatch.setattr(radio_mod.rename_manager, "request", rename_mock)
 
     interaction = SimpleNamespace(
         user=SimpleNamespace(id=123),
@@ -32,6 +34,17 @@ async def test_radio_rap_command_switches_stream(monkeypatch):
     await RadioCog.radio_rap.callback(cog, interaction)
 
     assert cog.stream_url == RADIO_RAP_STREAM_URL
-    radio_mod.rename_manager.request.assert_awaited_once_with(channel, "rap")
+    assert cog._previous_stream == RADIO_STREAM_URL
+    rename_mock.assert_awaited_once_with(channel, "rap")
+    interaction.response.send_message.assert_awaited_once()
+
+    interaction.response.send_message.reset_mock()
+    rename_mock.reset_mock()
+
+    await RadioCog.radio_rap.callback(cog, interaction)
+
+    assert cog.stream_url == RADIO_STREAM_URL
+    assert cog._previous_stream is None
+    rename_mock.assert_awaited_once_with(channel, "Radio")
     interaction.response.send_message.assert_awaited_once()
 

--- a/tests/test_setup_hook_syncs_tree.py
+++ b/tests/test_setup_hook_syncs_tree.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import discord
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+import bot
+
+
+@pytest.mark.asyncio
+async def test_setup_hook_syncs_tree(monkeypatch):
+    intents = discord.Intents.none()
+    test_bot = bot.RefugeBot(command_prefix="!", intents=intents)
+
+    monkeypatch.setattr(bot.xp_store, "start", AsyncMock())
+    monkeypatch.setattr(bot.rename_manager, "start", AsyncMock())
+    monkeypatch.setattr(bot.channel_edit_manager, "start", AsyncMock())
+    monkeypatch.setattr(bot.api_meter, "start", AsyncMock())
+    monkeypatch.setattr(bot.limiter, "start", MagicMock())
+    monkeypatch.setattr(bot, "reset_http_error_counter", AsyncMock())
+    monkeypatch.setattr(test_bot, "loop", asyncio.get_event_loop(), raising=False)
+
+    load_mock = AsyncMock()
+    monkeypatch.setattr(test_bot, "load_extension", load_mock)
+
+    sync_mock = AsyncMock()
+    monkeypatch.setattr(test_bot.tree, "sync", sync_mock)
+
+    await test_bot.setup_hook()
+
+    sync_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Sync application commands after loading extensions so slash commands like `/radio_rap` are registered
- Add test ensuring `setup_hook` calls `tree.sync`
- Toggle radio back to previous station when `/radio_rap` is issued a second time
- Cover radio toggling with a dedicated unit test

## Testing
- `pytest tests/test_radio_*.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72212efa48324848af56552de90b2