### PR TITLE
feat: toggle rap radio back to default

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -92,14 +92,26 @@ class RadioCog(commands.Cog):
     @app_commands.command(name="radio_rap", description="Basculer la radio sur le flux rap")
     @app_commands.checks.cooldown(1, 3600, key=lambda i: i.user.id)
     async def radio_rap(self, interaction: discord.Interaction) -> None:
-        self.stream_url = RADIO_RAP_STREAM_URL
-        if self.voice and self.voice.is_playing():
-            self.voice.stop()
-        await self._connect_and_play()
-        channel = self.bot.get_channel(self.vc_id)
-        if isinstance(channel, discord.VoiceChannel):
-            await rename_manager.request(channel, "rap")
-        await interaction.response.send_message("Radio changée pour rap")
+        if self.stream_url == RADIO_RAP_STREAM_URL:
+            self.stream_url = RADIO_STREAM_URL
+            if self.voice and self.voice.is_playing():
+                self.voice.stop()
+            await self._connect_and_play()
+            channel = self.bot.get_channel(self.vc_id)
+            if isinstance(channel, discord.VoiceChannel) and self._original_name:
+                await rename_manager.request(channel, self._original_name)
+            await interaction.response.send_message(
+                "Radio remise sur la station d'origine"
+            )
+        else:
+            self.stream_url = RADIO_RAP_STREAM_URL
+            if self.voice and self.voice.is_playing():
+                self.voice.stop()
+            await self._connect_and_play()
+            channel = self.bot.get_channel(self.vc_id)
+            if isinstance(channel, discord.VoiceChannel):
+                await rename_manager.request(channel, "rap")
+            await interaction.response.send_message("Radio changée pour rap")
 
     @commands.Cog.listener()
     async def on_voice_state_update(

--- a/tests/test_radio_rap_command.py
+++ b/tests/test_radio_rap_command.py
@@ -9,7 +9,7 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import cogs.radio as radio_mod
 from cogs.radio import RadioCog
-from config import RADIO_RAP_STREAM_URL, RADIO_VC_ID
+from config import RADIO_RAP_STREAM_URL, RADIO_STREAM_URL, RADIO_VC_ID
 
 
 @pytest.mark.asyncio
@@ -21,6 +21,7 @@ async def test_radio_rap_command_switches_stream(monkeypatch):
     channel = FakeVoiceChannel(id=RADIO_VC_ID, name="Radio")
     bot = SimpleNamespace(loop=asyncio.get_event_loop(), get_channel=lambda cid: channel)
     cog = RadioCog(bot)
+    cog._original_name = channel.name
     monkeypatch.setattr(cog, "_connect_and_play", AsyncMock())
     monkeypatch.setattr(radio_mod.rename_manager, "request", AsyncMock())
 
@@ -34,4 +35,36 @@ async def test_radio_rap_command_switches_stream(monkeypatch):
     assert cog.stream_url == RADIO_RAP_STREAM_URL
     radio_mod.rename_manager.request.assert_awaited_once_with(channel, "rap")
     interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_radio_rap_command_toggles_back(monkeypatch):
+    class FakeVoiceChannel(SimpleNamespace):
+        pass
+
+    monkeypatch.setattr(radio_mod.discord, "VoiceChannel", FakeVoiceChannel)
+    channel = FakeVoiceChannel(id=RADIO_VC_ID, name="Radio")
+    bot = SimpleNamespace(loop=asyncio.get_event_loop(), get_channel=lambda cid: channel)
+    cog = RadioCog(bot)
+    cog._original_name = channel.name
+    monkeypatch.setattr(cog, "_connect_and_play", AsyncMock())
+    rename_mock = AsyncMock()
+    monkeypatch.setattr(radio_mod.rename_manager, "request", rename_mock)
+
+    interaction1 = SimpleNamespace(
+        user=SimpleNamespace(id=123),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    await RadioCog.radio_rap.callback(cog, interaction1)
+
+    rename_mock.reset_mock()
+    interaction2 = SimpleNamespace(
+        user=SimpleNamespace(id=123),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    await RadioCog.radio_rap.callback(cog, interaction2)
+
+    assert cog.stream_url == RADIO_STREAM_URL
+    rename_mock.assert_awaited_once_with(channel, "Radio")
+    interaction2.response.send_message.assert_awaited_once()
 


### PR DESCRIPTION
## Summary
- allow `/radio_rap` to switch back to the original stream and name when invoked again
- extend radio command tests for toggling behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72def14c083248af6b8e107cb9d22