### PR TITLE
Ensure rock radio cog connects on load

### DIFF
--- a/cogs/rock_radio.py
+++ b/cogs/rock_radio.py
@@ -21,6 +21,10 @@ class RockRadioCog(commands.Cog):
         self.voice: Optional[discord.VoiceClient] = None
         self._reconnect_task: Optional[asyncio.Task] = None
 
+    async def cog_load(self) -> None:
+        if self.bot.is_ready():
+            await self._connect_and_play()
+
     async def _connect_and_play(self) -> None:
         if not self.stream_url:
             logging.warning("ROCK_RADIO_STREAM_URL non défini")

--- a/tests/test_rock_radio_cog_load.py
+++ b/tests/test_rock_radio_cog_load.py
@@ -1,0 +1,25 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cogs.rock_radio import RockRadioCog
+
+
+@pytest.mark.asyncio
+async def test_cog_load_connects_when_bot_ready():
+    bot = SimpleNamespace(loop=asyncio.get_event_loop(), is_ready=lambda: True)
+    cog = RockRadioCog(bot)
+    cog._connect_and_play = AsyncMock()
+    await cog.cog_load()
+    cog._connect_and_play.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cog_load_skips_when_bot_not_ready():
+    bot = SimpleNamespace(loop=asyncio.get_event_loop(), is_ready=lambda: False)
+    cog = RockRadioCog(bot)
+    cog._connect_and_play = AsyncMock()
+    await cog.cog_load()
+    cog._connect_and_play.assert_not_called()


### PR DESCRIPTION
## Summary
- Connect to rock radio voice channel when the cog loads and the bot is ready
- Add tests covering cog load connection behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7359e99b48324b6f7055739c4e265