### PR TITLE
feat: add radio 24 command

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -117,6 +117,23 @@ class RadioCog(commands.Cog):
             await rename_manager.request(channel, "rap")
         await interaction.response.send_message("Radio changée pour rap")
 
+    @app_commands.command(
+        name="radio_24", description="Revenir sur l'ancienne radio 24/7"
+    )
+    @app_commands.checks.cooldown(1, 3600, key=lambda i: i.user.id)
+    async def radio_24(self, interaction: discord.Interaction) -> None:
+        channel = self.bot.get_channel(self.vc_id)
+        self.stream_url = RADIO_STREAM_URL
+        self._previous_stream = None
+        if self.voice and self.voice.is_playing():
+            self.voice.stop()
+        await self._connect_and_play()
+        if isinstance(channel, discord.VoiceChannel) and self._original_name:
+            await rename_manager.request(channel, self._original_name)
+        await interaction.response.send_message(
+            "Radio changée pour la station 24/7"
+        )
+
     @commands.Cog.listener()
     async def on_voice_state_update(
         self,

--- a/tests/test_radio_24_command.py
+++ b/tests/test_radio_24_command.py
@@ -1,0 +1,42 @@
+import asyncio
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import AsyncMock
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import cogs.radio as radio_mod
+from cogs.radio import RadioCog
+from config import RADIO_RAP_STREAM_URL, RADIO_STREAM_URL, RADIO_VC_ID
+
+
+@pytest.mark.asyncio
+async def test_radio_24_command_restores_default(monkeypatch):
+    class FakeVoiceChannel(SimpleNamespace):
+        pass
+
+    monkeypatch.setattr(radio_mod.discord, "VoiceChannel", FakeVoiceChannel)
+    channel = FakeVoiceChannel(id=RADIO_VC_ID, name="Radio")
+    bot = SimpleNamespace(loop=asyncio.get_event_loop(), get_channel=lambda cid: channel)
+    cog = RadioCog(bot)
+    cog._original_name = "Radio"
+    cog.stream_url = RADIO_RAP_STREAM_URL
+    cog.voice = SimpleNamespace(is_playing=lambda: True, stop=lambda: None)
+    monkeypatch.setattr(cog, "_connect_and_play", AsyncMock())
+    rename_mock = AsyncMock()
+    monkeypatch.setattr(radio_mod.rename_manager, "request", rename_mock)
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=123),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await RadioCog.radio_24.callback(cog, interaction)
+
+    assert cog.stream_url == RADIO_STREAM_URL
+    assert cog._previous_stream is None
+    rename_mock.assert_awaited_once_with(channel, "Radio")
+    cog._connect_and_play.assert_awaited_once()
+    interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
## Summary
- add `/radio_24` slash command to switch radio back to 24/7 stream
- test command behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a73a555de4832496cb20723be48d71