### PR TITLE
fix: use direct rock stream

### DIFF
--- a/config.py
+++ b/config.py
@@ -52,7 +52,7 @@ RADIO_RAP_STREAM_URL = "https://stream.laut.fm/24-7-rap"
 ROCK_RADIO_VC_ID = 1408081503707074650
 ROCK_RADIO_STREAM_URL = os.getenv(
     "ROCK_RADIO_STREAM_URL",
-    "https://stream.laut.fm/rocks.m3u",
+    "http://stream.laut.fm/rocks",
 )
 
 # ── Divers ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- fix rock radio by using direct audio stream URL

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a754f8a6ac8324b55e3f4d28957a03