### PR TITLE
Rename default radio channel

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -98,6 +98,8 @@ class RadioCog(commands.Cog):
             await rename_manager.request(channel, "rap")
         elif stream_url == ROCK_RADIO_STREAM_URL:
             await rename_manager.request(channel, "☢️ .Radio-Rock")
+        elif stream_url == RADIO_STREAM_URL:
+            await rename_manager.request(channel, "📻.Radio-HipHop")
         else:
             if self._original_name:
                 await rename_manager.request(channel, self._original_name)

--- a/tests/test_radio_24_command.py
+++ b/tests/test_radio_24_command.py
@@ -37,6 +37,6 @@ async def test_radio_24_command_restores_default(monkeypatch):
 
     assert cog.stream_url == RADIO_STREAM_URL
     assert cog._previous_stream is None
-    rename_mock.assert_awaited_once_with(channel, "Radio")
+    rename_mock.assert_awaited_once_with(channel, "📻.Radio-HipHop")
     cog._connect_and_play.assert_awaited_once()
     interaction.response.send_message.assert_awaited_once()

--- a/tests/test_radio_rap_command.py
+++ b/tests/test_radio_rap_command.py
@@ -45,6 +45,6 @@ async def test_radio_rap_command_toggles_stream(monkeypatch):
 
     assert cog.stream_url == RADIO_STREAM_URL
     assert cog._previous_stream is None
-    rename_mock.assert_awaited_once_with(channel, "Radio")
+    rename_mock.assert_awaited_once_with(channel, "📻.Radio-HipHop")
     interaction.response.send_message.assert_awaited_once()
 

--- a/tests/test_radio_rock_command.py
+++ b/tests/test_radio_rock_command.py
@@ -45,5 +45,5 @@ async def test_radio_rock_command_toggles_stream(monkeypatch):
 
     assert cog.stream_url == RADIO_STREAM_URL
     assert cog._previous_stream is None
-    rename_mock.assert_awaited_once_with(channel, "Radio")
+    rename_mock.assert_awaited_once_with(channel, "📻.Radio-HipHop")
     interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
## Summary
- rename radio channel to `📻.Radio-HipHop` when switching back to the 24/7 stream
- adjust tests for new channel name

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a77580afec83249a118c1c28b85d67