### PR TITLE
feat: update radio channel names

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -95,11 +95,11 @@ class RadioCog(commands.Cog):
         self, channel: discord.VoiceChannel, stream_url: str
     ) -> None:
         if stream_url == RADIO_RAP_STREAM_URL:
-            await rename_manager.request(channel, "rap")
+            await rename_manager.request(channel, "🔘・Radio-Rap")
         elif stream_url == ROCK_RADIO_STREAM_URL:
-            await rename_manager.request(channel, "☢️ .Radio-Rock")
+            await rename_manager.request(channel, "☢️・Radio-Rock")
         elif stream_url == RADIO_STREAM_URL:
-            await rename_manager.request(channel, "📻.Radio-HipHop")
+            await rename_manager.request(channel, "📻・Radio-HipHop")
         else:
             if self._original_name:
                 await rename_manager.request(channel, self._original_name)

--- a/tests/test_radio_24_command.py
+++ b/tests/test_radio_24_command.py
@@ -37,6 +37,6 @@ async def test_radio_24_command_restores_default(monkeypatch):
 
     assert cog.stream_url == RADIO_STREAM_URL
     assert cog._previous_stream is None
-    rename_mock.assert_awaited_once_with(channel, "📻.Radio-HipHop")
+    rename_mock.assert_awaited_once_with(channel, "📻・Radio-HipHop")
     cog._connect_and_play.assert_awaited_once()
     interaction.response.send_message.assert_awaited_once()

--- a/tests/test_radio_rap_command.py
+++ b/tests/test_radio_rap_command.py
@@ -35,7 +35,7 @@ async def test_radio_rap_command_toggles_stream(monkeypatch):
 
     assert cog.stream_url == RADIO_RAP_STREAM_URL
     assert cog._previous_stream == RADIO_STREAM_URL
-    rename_mock.assert_awaited_once_with(channel, "rap")
+    rename_mock.assert_awaited_once_with(channel, "🔘・Radio-Rap")
     interaction.response.send_message.assert_awaited_once()
 
     interaction.response.send_message.reset_mock()
@@ -45,6 +45,6 @@ async def test_radio_rap_command_toggles_stream(monkeypatch):
 
     assert cog.stream_url == RADIO_STREAM_URL
     assert cog._previous_stream is None
-    rename_mock.assert_awaited_once_with(channel, "📻.Radio-HipHop")
+    rename_mock.assert_awaited_once_with(channel, "📻・Radio-HipHop")
     interaction.response.send_message.assert_awaited_once()
 

--- a/tests/test_radio_rock_command.py
+++ b/tests/test_radio_rock_command.py
@@ -35,7 +35,7 @@ async def test_radio_rock_command_toggles_stream(monkeypatch):
 
     assert cog.stream_url == ROCK_RADIO_STREAM_URL
     assert cog._previous_stream == RADIO_STREAM_URL
-    rename_mock.assert_awaited_once_with(channel, "☢️ .Radio-Rock")
+    rename_mock.assert_awaited_once_with(channel, "☢️・Radio-Rock")
     interaction.response.send_message.assert_awaited_once()
 
     interaction.response.send_message.reset_mock()
@@ -45,5 +45,5 @@ async def test_radio_rock_command_toggles_stream(monkeypatch):
 
     assert cog.stream_url == RADIO_STREAM_URL
     assert cog._previous_stream is None
-    rename_mock.assert_awaited_once_with(channel, "📻.Radio-HipHop")
+    rename_mock.assert_awaited_once_with(channel, "📻・Radio-HipHop")
     interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
## Summary
- rename radio voice channels to ☢️・Radio-Rock, 📻・Radio-HipHop, 🔘・Radio-Rap
- update tests for new radio names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7795b1d3c8324b7321078ba32c441