### PR TITLE
Remove radio automute for specific role

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -7,7 +7,6 @@ from discord import app_commands
 from discord.ext import commands
 
 from config import (
-    RADIO_MUTED_ROLE_ID,
     RADIO_RAP_STREAM_URL,
     RADIO_STREAM_URL,
     RADIO_VC_ID,
@@ -189,45 +188,10 @@ class RadioCog(commands.Cog):
                 )
             return
 
-        if any(role.id == RADIO_MUTED_ROLE_ID for role in member.roles):
-            # Join radio channel -> mute
-            if after.channel and after.channel.id == self.vc_id:
-                try:
-                    await member.edit(mute=True)
-                except discord.Forbidden:
-                    logging.warning(
-                        "Permissions insuffisantes pour mute %s", member
-                    )
-                except discord.NotFound:
-                    logging.warning("Membre introuvable pour mute %s", member)
-                except discord.HTTPException as e:
-                    logging.error(
-                        "Erreur HTTP lors du mute de %s: %s", member, e
-                    )
-                except Exception as e:
-                    logging.exception(
-                        "Impossible de mute %s: %s", member, e
-                    )
-            # Leave radio channel -> unmute
-            elif before.channel and before.channel.id == self.vc_id:
-                try:
-                    await member.edit(mute=False)
-                except discord.Forbidden:
-                    logging.warning(
-                        "Permissions insuffisantes pour demute %s", member
-                    )
-                except discord.NotFound:
-                    logging.warning(
-                        "Membre introuvable pour demute %s", member
-                    )
-                except discord.HTTPException as e:
-                    logging.error(
-                        "Erreur HTTP lors du demute de %s: %s", member, e
-                    )
-                except Exception as e:
-                    logging.exception(
-                        "Impossible de demute %s: %s", member, e
-                    )
+        # Previously, members with a specific role were automatically muted when
+        # joining the radio channel and unmuted when leaving it. This behaviour
+        # has been removed to ensure that the bot no longer alters voice states
+        # based on a role.
 
     def cog_unload(self) -> None:
         if self._reconnect_task and not self._reconnect_task.done():

--- a/cogs/rock_radio.py
+++ b/cogs/rock_radio.py
@@ -5,7 +5,7 @@ from typing import Optional
 import discord
 from discord.ext import commands
 
-from config import RADIO_MUTED_ROLE_ID, ROCK_RADIO_STREAM_URL, ROCK_RADIO_VC_ID
+from config import ROCK_RADIO_STREAM_URL, ROCK_RADIO_VC_ID
 
 FFMPEG_BEFORE = "-fflags nobuffer -probesize 32k"
 FFMPEG_OPTIONS = "-filter:a loudnorm"
@@ -110,45 +110,10 @@ class RockRadioCog(commands.Cog):
                 )
             return
 
-        if any(role.id == RADIO_MUTED_ROLE_ID for role in member.roles):
-            # Join rock radio channel -> mute
-            if after.channel and after.channel.id == self.vc_id:
-                try:
-                    await member.edit(mute=True)
-                except discord.Forbidden:
-                    logging.warning(
-                        "Permissions insuffisantes pour mute %s", member
-                    )
-                except discord.NotFound:
-                    logging.warning("Membre introuvable pour mute %s", member)
-                except discord.HTTPException as e:
-                    logging.error(
-                        "Erreur HTTP lors du mute de %s: %s", member, e
-                    )
-                except Exception as e:
-                    logging.exception(
-                        "Impossible de mute %s: %s", member, e
-                    )
-            # Leave rock radio channel -> unmute
-            elif before.channel and before.channel.id == self.vc_id:
-                try:
-                    await member.edit(mute=False)
-                except discord.Forbidden:
-                    logging.warning(
-                        "Permissions insuffisantes pour demute %s", member
-                    )
-                except discord.NotFound:
-                    logging.warning(
-                        "Membre introuvable pour demute %s", member
-                    )
-                except discord.HTTPException as e:
-                    logging.error(
-                        "Erreur HTTP lors du demute de %s: %s", member, e
-                    )
-                except Exception as e:
-                    logging.exception(
-                        "Impossible de demute %s: %s", member, e
-                    )
+        # Previously, members with a specific role were automatically muted when
+        # joining the rock radio channel and unmuted when leaving it. This logic
+        # has been removed so the bot no longer alters member voice states based
+        # on their roles.
 
     def cog_unload(self) -> None:
         if self._reconnect_task and not self._reconnect_task.done():

--- a/tests/test_radio_muted_role.py
+++ b/tests/test_radio_muted_role.py
@@ -12,7 +12,7 @@ from config import RADIO_MUTED_ROLE_ID, RADIO_VC_ID
 
 
 @pytest.mark.asyncio
-async def test_member_with_muted_role_gets_muted_when_joining_radio():
+async def test_member_with_muted_role_not_muted_when_joining_radio():
     bot = SimpleNamespace(user=SimpleNamespace(id=1), loop=asyncio.get_event_loop())
     member = SimpleNamespace(
         id=2,
@@ -25,14 +25,13 @@ async def test_member_with_muted_role_gets_muted_when_joining_radio():
     cog = RadioCog(bot)
     await cog.on_voice_state_update(member, before, after)
 
-    member.edit.assert_awaited_once()
-    assert member.edit.await_args.kwargs["mute"] is True
+    member.edit.assert_not_awaited()
 
     # no cleanup needed
 
 
 @pytest.mark.asyncio
-async def test_member_unmuted_when_leaving_radio():
+async def test_member_with_muted_role_not_unmuted_when_leaving_radio():
     bot = SimpleNamespace(user=SimpleNamespace(id=1), loop=asyncio.get_event_loop())
     member = SimpleNamespace(
         id=2,
@@ -45,8 +44,7 @@ async def test_member_unmuted_when_leaving_radio():
     cog = RadioCog(bot)
     await cog.on_voice_state_update(member, before, after)
 
-    member.edit.assert_awaited_once()
-    assert member.edit.await_args.kwargs["mute"] is False
+    member.edit.assert_not_awaited()
 
     # no cleanup needed
 

--- a/tests/test_rock_radio_muted_role.py
+++ b/tests/test_rock_radio_muted_role.py
@@ -12,7 +12,7 @@ from config import RADIO_MUTED_ROLE_ID, ROCK_RADIO_VC_ID
 
 
 @pytest.mark.asyncio
-async def test_member_with_muted_role_gets_muted_when_joining_rock_radio():
+async def test_member_with_muted_role_not_muted_when_joining_rock_radio():
     bot = SimpleNamespace(user=SimpleNamespace(id=1), loop=asyncio.get_event_loop())
     member = SimpleNamespace(
         id=2,
@@ -25,12 +25,11 @@ async def test_member_with_muted_role_gets_muted_when_joining_rock_radio():
     cog = RockRadioCog(bot)
     await cog.on_voice_state_update(member, before, after)
 
-    member.edit.assert_awaited_once()
-    assert member.edit.await_args.kwargs["mute"] is True
+    member.edit.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_member_unmuted_when_leaving_rock_radio():
+async def test_member_with_muted_role_not_unmuted_when_leaving_rock_radio():
     bot = SimpleNamespace(user=SimpleNamespace(id=1), loop=asyncio.get_event_loop())
     member = SimpleNamespace(
         id=2,
@@ -43,5 +42,4 @@ async def test_member_unmuted_when_leaving_rock_radio():
     cog = RockRadioCog(bot)
     await cog.on_voice_state_update(member, before, after)
 
-    member.edit.assert_awaited_once()
-    assert member.edit.await_args.kwargs["mute"] is False
+    member.edit.assert_not_awaited()


### PR DESCRIPTION
## Summary
- stop auto-muting members with the designated muted role when joining or leaving radio channels
- adjust unit tests accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a77ddca9648324b31daf3c2ae3904d