### PR TITLE
Specify safe_respond return type

### DIFF
--- a/utils/interactions.py
+++ b/utils/interactions.py
@@ -2,7 +2,7 @@ import logging
 
 import discord
 
-async def safe_respond(inter: discord.Interaction, content=None, **kwargs):
+async def safe_respond(inter: discord.Interaction, content=None, **kwargs) -> None:
     """Safely respond to an interaction.
 
     If the initial response has already been sent, uses followup instead.
@@ -21,3 +21,4 @@ async def safe_respond(inter: discord.Interaction, content=None, **kwargs):
         pass
     except Exception as e:
         logging.error(f"Réponse interaction échouée: {e}")
+


### PR DESCRIPTION
## Summary
- annotate `utils.interactions.safe_respond` with an explicit `None` return type
- ensure file ends with a trailing newline for POSIX compliance

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a780a219f08324aa279718cbe0688f