### PR TITLE
Replace cron loops with internal scheduler

### DIFF
--- a/cogs/daily_summary_poster.py
+++ b/cogs/daily_summary_poster.py
@@ -9,14 +9,15 @@ message envoyé.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
-from datetime import time, timezone
+from datetime import datetime, timedelta, time, timezone
 from typing import Dict, Any
 
 import discord
 from discord import app_commands
-from discord.ext import commands, tasks
+from discord.ext import commands
 
 from config import ACTIVITY_SUMMARY_CH, DATA_DIR, XP_VIEWER_ROLE_ID
 from utils.interactions import safe_respond
@@ -47,11 +48,11 @@ class DailySummaryPoster(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self.daily_task.start()
+        self._task = self.bot.loop.create_task(self._scheduler())
         self.bot.loop.create_task(self._startup_check())
 
     def cog_unload(self) -> None:  # pragma: no cover - cleanup
-        self.daily_task.cancel()
+        self._task.cancel()
 
     # ── Persistence helpers ──────────────────────────────────
     def _read_summary(self) -> Dict[str, Any]:
@@ -142,15 +143,18 @@ class DailySummaryPoster(commands.Cog):
         logging.info("[daily_summary] Classement %s publié", data.get("date"))
 
     # ── Tasks ────────────────────────────────────────────────
-    @tasks.loop(time=time(hour=0, minute=2, tzinfo=PARIS_TZ))
-    async def daily_task(self) -> None:
+    async def _scheduler(self) -> None:
         await self.bot.wait_until_ready()
-        data = read_json_safe(DAILY_RANK_FILE)
-        await self._maybe_post(data)
-
-    @daily_task.before_loop
-    async def before_daily_task(self) -> None:  # pragma: no cover - scheduler hook
-        await self.bot.wait_until_ready()
+        while not self.bot.is_closed():
+            now = datetime.now(PARIS_TZ)
+            target = datetime.combine(
+                now.date(), time(hour=0, minute=2, tzinfo=PARIS_TZ)
+            )
+            if now >= target:
+                target += timedelta(days=1)
+            await asyncio.sleep((target - now).total_seconds())
+            data = read_json_safe(DAILY_RANK_FILE)
+            await self._maybe_post(data)
 
     async def _startup_check(self) -> None:
         await self.bot.wait_until_ready()


### PR DESCRIPTION
## Summary
- migrate daily ranking, summary, and awards cogs from cron-based `tasks.loop` to internal `asyncio` schedulers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a7a9e11e048324bc777333dd5104ac