### PR TITLE
Import ZoneInfo after datetime

### DIFF
--- a/utils/timewin.py
+++ b/utils/timewin.py
@@ -1,5 +1,5 @@
-from zoneinfo import ZoneInfo
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 
 def is_open_now(


### PR DESCRIPTION
## Summary
- Move ZoneInfo import to follow datetime in utils/timewin

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a7ca11b5488324ba48066ffd108955