### PR TITLE
refactor: centralize ffmpeg options

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -13,9 +13,7 @@ from config import (
     ROCK_RADIO_STREAM_URL,
 )
 from utils.rename_manager import rename_manager
-
-FFMPEG_BEFORE = "-fflags nobuffer -probesize 32k"
-FFMPEG_OPTIONS = "-filter:a loudnorm"
+from utils.audio import FFMPEG_BEFORE, FFMPEG_OPTIONS
 
 
 class RadioCog(commands.Cog):

--- a/cogs/rock_radio.py
+++ b/cogs/rock_radio.py
@@ -6,9 +6,7 @@ import discord
 from discord.ext import commands
 
 from config import ROCK_RADIO_STREAM_URL, ROCK_RADIO_VC_ID
-
-FFMPEG_BEFORE = "-fflags nobuffer -probesize 32k"
-FFMPEG_OPTIONS = "-filter:a loudnorm"
+from utils.audio import FFMPEG_BEFORE, FFMPEG_OPTIONS
 
 
 class RockRadioCog(commands.Cog):

--- a/utils/audio.py
+++ b/utils/audio.py
@@ -1,0 +1,5 @@
+"""Audio-related constants and utilities."""
+
+# Common FFmpeg options for audio streaming
+FFMPEG_BEFORE = "-fflags nobuffer -probesize 32k"
+FFMPEG_OPTIONS = "-filter:a loudnorm"


### PR DESCRIPTION
## Summary
- add shared audio constants module
- use shared FFmpeg options in radio cogs

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7ca9a6f708324b5cac00ac67235cb