### PR TITLE
refactor: remove unused time import

### DIFF
--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -11,7 +11,7 @@ import io
 import logging
 import os
 import random
-from datetime import datetime, timezone, time
+from datetime import datetime, timezone
 
 import discord
 from discord import app_commands


### PR DESCRIPTION
## Summary
- remove unused `time` import from XP cog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7cb15943483249c425b899e71580c