### PR TITLE
Harden channel context checks

### DIFF
--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -25,6 +25,13 @@ class MiscCog(commands.Cog):
     @app_commands.checks.has_permissions(manage_guild=True)
     async def type_joueur(self, interaction: discord.Interaction) -> None:
         with measure("slash:type_joueur"):
+            if interaction.guild is None:
+                await safe_respond(
+                    interaction,
+                    "Commande utilisable uniquement sur un serveur.",
+                    ephemeral=True,
+                )
+                return
             await safe_respond(
                 interaction,
                 f"Les boutons ont été postés dans <#{CHANNEL_ROLES}> 😉",
@@ -38,7 +45,13 @@ class MiscCog(commands.Cog):
     @app_commands.describe(question="La question à poser")
     async def sondage(self, interaction: discord.Interaction, question: str) -> None:
         with measure("slash:sondage"):
-            msg = await interaction.channel.send(
+            ch = interaction.channel
+            if ch is None:
+                await safe_respond(
+                    interaction, "Salon introuvable.", ephemeral=True
+                )
+                return
+            msg = await ch.send(
                 f"📊 **{question}**\n> ✅ = Oui   ❌ = Non\n_Posé par {interaction.user.mention}_"
             )
             await msg.add_reaction("✅")

--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -33,6 +33,11 @@ class RadioCog(commands.Cog):
             logging.warning("RADIO_STREAM_URL non défini")
             return
         channel = self.bot.get_channel(self.vc_id)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(self.vc_id)
+            except discord.HTTPException:
+                channel = None
         if not isinstance(channel, discord.VoiceChannel):
             logging.warning("Salon radio %s introuvable", self.vc_id)
             return

--- a/utils/api_meter.py
+++ b/utils/api_meter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import discord
 import inspect
 import json
 import logging
@@ -227,11 +228,16 @@ class APIMeter:
         self.logger.log(level, message)
         if notify and self.bot and config.BOT_ALERTS_CHANNEL_ID:
             channel = self.bot.get_channel(config.BOT_ALERTS_CHANNEL_ID)
-            if channel is not None:
+            if isinstance(channel, (discord.TextChannel, discord.Thread)):
                 try:
                     await channel.send(f"⚠️ {message}")
                 except Exception:
                     self.logger.exception("failed to send alert message")
+            else:
+                self.logger.warning(
+                    "Alerts channel %s missing or not messageable",
+                    config.BOT_ALERTS_CHANNEL_ID,
+                )
 
     # ------------------------------------------------------------------
     async def start(self, bot: Any) -> None:


### PR DESCRIPTION
## Summary
- Guard `type_joueur` and `sondage` commands against missing guild or channel context
- Ensure radio cog fetches voice channel when not cached
- Validate alert channel is messageable before sending API meter notifications

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a7cbabed648324a8aaaaca1afa8367