### PR TITLE
refactor: mutualise connexion vocale

### DIFF
--- a/tests/test_rock_radio_moves_channel.py
+++ b/tests/test_rock_radio_moves_channel.py
@@ -19,6 +19,7 @@ async def test_move_to_rock_channel_when_connected_elsewhere(monkeypatch):
         pass
 
     monkeypatch.setattr("cogs.rock_radio.discord.VoiceChannel", DummyVoiceChannel)
+    monkeypatch.setattr("utils.voice.discord.VoiceChannel", DummyVoiceChannel)
     channel = DummyVoiceChannel(id=ROCK_RADIO_VC_ID)
     bot = SimpleNamespace(
         loop=loop,


### PR DESCRIPTION
## Summary
- factorise la connexion aux salons vocaux dans `utils.voice`
- utilise l'utilitaire dans `RadioCog` et `RockRadioCog`
- ajuste le test de déplacement de la rock radio

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a81d4243ec8324b544f30eee16b068