### PR TITLE
Remove radio command cooldown

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -66,7 +66,6 @@ class RadioCog(commands.Cog):
                 await rename_manager.request(channel, self._original_name)
 
     @app_commands.command(name="radio_rap", description="Basculer la radio sur le flux rap")
-    @app_commands.checks.cooldown(1, 3600, key=lambda i: i.user.id)
     async def radio_rap(self, interaction: discord.Interaction) -> None:
         channel = self.bot.get_channel(self.vc_id)
 
@@ -93,7 +92,6 @@ class RadioCog(commands.Cog):
         await interaction.response.send_message("Radio changée pour rap")
 
     @app_commands.command(name="radio_rock", description="Basculer la radio sur le flux rock")
-    @app_commands.checks.cooldown(1, 3600, key=lambda i: i.user.id)
     async def radio_rock(self, interaction: discord.Interaction) -> None:
         channel = self.bot.get_channel(self.vc_id)
 
@@ -122,7 +120,6 @@ class RadioCog(commands.Cog):
     @app_commands.command(
         name="radio_24", description="Revenir sur l'ancienne radio 24/7"
     )
-    @app_commands.checks.cooldown(1, 3600, key=lambda i: i.user.id)
     async def radio_24(self, interaction: discord.Interaction) -> None:
         channel = self.bot.get_channel(self.vc_id)
         self.stream_url = RADIO_STREAM_URL


### PR DESCRIPTION
## Summary
- allow switching radio streams without 1 hour cooldown

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a82afa8ab8832495b3a82383f24dc1