### PR TITLE
Fix rock radio stream and ensure rename worker runs

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -28,6 +28,13 @@ class RadioCog(commands.Cog):
         self._original_name: Optional[str] = None
         self._previous_stream: Optional[str] = None
 
+        if rename_manager._worker is None:
+            async def _ensure_rename_worker() -> None:
+                await rename_manager.start()
+                logging.info("[radio] rename_manager worker démarré")
+
+            asyncio.create_task(_ensure_rename_worker())
+
     async def _connect_and_play(self) -> None:
         if not self.stream_url:
             logging.warning("RADIO_STREAM_URL non défini")

--- a/config.py
+++ b/config.py
@@ -52,7 +52,7 @@ RADIO_RAP_STREAM_URL = "https://stream.laut.fm/24-7-rap"
 ROCK_RADIO_VC_ID = 1408081503707074650
 ROCK_RADIO_STREAM_URL = os.getenv(
     "ROCK_RADIO_STREAM_URL",
-    "http://stream.laut.fm/rocks",
+    "http://stream.radioparadise.com/rock-192",
 )
 
 # ── Divers ───────────────────────────────────────────────────

--- a/tests/test_radio_cog_starts_rename_manager.py
+++ b/tests/test_radio_cog_starts_rename_manager.py
@@ -1,0 +1,24 @@
+import asyncio
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from cogs.radio import RadioCog
+from utils.rename_manager import rename_manager
+
+
+@pytest.mark.asyncio
+async def test_radio_cog_starts_rename_manager(monkeypatch):
+    bot = SimpleNamespace(loop=asyncio.get_event_loop())
+    rename_manager._worker = None
+    start_mock = AsyncMock()
+    monkeypatch.setattr("cogs.radio.rename_manager.start", start_mock)
+
+    RadioCog(bot)
+    await asyncio.sleep(0)
+
+    start_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- update rock radio stream URL to `http://stream.radioparadise.com/rock-192`
- ensure RadioCog starts rename_manager worker so channel renames succeed
- add regression test for rename worker startup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a84251db08832480cc3c2c492dcfeb