### PR TITLE
Add French rap radio stream and update default link

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -7,6 +7,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from config import (
+    RADIO_RAP_FR_STREAM_URL,
     RADIO_RAP_STREAM_URL,
     RADIO_STREAM_URL,
     RADIO_VC_ID,
@@ -66,6 +67,8 @@ class RadioCog(commands.Cog):
             await rename_manager.request(channel, "🔘・Radio-Rap")
         elif stream_url == ROCK_RADIO_STREAM_URL:
             await rename_manager.request(channel, "☢️・Radio-Rock")
+        elif stream_url == RADIO_RAP_FR_STREAM_URL:
+            await rename_manager.request(channel, "🔴・Radio-RapFR")
         elif stream_url == RADIO_STREAM_URL:
             await rename_manager.request(channel, "📻・Radio-HipHop")
         else:
@@ -123,6 +126,34 @@ class RadioCog(commands.Cog):
         if isinstance(channel, discord.VoiceChannel):
             await self._rename_for_stream(channel, ROCK_RADIO_STREAM_URL)
         await interaction.response.send_message("Radio changée pour rock")
+
+    @app_commands.command(
+        name="radio_rapfr", description="Basculer la radio sur le flux rap français"
+    )
+    async def radio_rapfr(self, interaction: discord.Interaction) -> None:
+        channel = self.bot.get_channel(self.vc_id)
+
+        if self.stream_url == RADIO_RAP_FR_STREAM_URL and self._previous_stream:
+            self.stream_url = self._previous_stream
+            self._previous_stream = None
+            if self.voice and self.voice.is_playing():
+                self.voice.stop()
+            await self._connect_and_play()
+            if isinstance(channel, discord.VoiceChannel):
+                await self._rename_for_stream(channel, self.stream_url)
+            await interaction.response.send_message(
+                "Radio changée pour la station précédente"
+            )
+            return
+
+        self._previous_stream = self.stream_url
+        self.stream_url = RADIO_RAP_FR_STREAM_URL
+        if self.voice and self.voice.is_playing():
+            self.voice.stop()
+        await self._connect_and_play()
+        if isinstance(channel, discord.VoiceChannel):
+            await self._rename_for_stream(channel, RADIO_RAP_FR_STREAM_URL)
+        await interaction.response.send_message("Radio changée pour rap français")
 
     @app_commands.command(
         name="radio_24", description="Revenir sur l'ancienne radio 24/7"

--- a/config.py
+++ b/config.py
@@ -45,9 +45,11 @@ LOBBY_VC_ID = 1405630965803520221
 RADIO_VC_ID = 1405695147114758245
 RADIO_MUTED_ROLE_ID = 1403510368340410550
 RADIO_STREAM_URL = os.getenv(
-    "RADIO_STREAM_URL", "http://stream.laut.fm/englishrap"
+    "RADIO_STREAM_URL",
+    "https://n08.radiojar.com/2b5w4a2kb?rj-ttl=5&rj-tok=AAABmNHaVWAAm4GDT5xyXjsi5A",
 )
 RADIO_RAP_STREAM_URL = "https://stream.laut.fm/24-7-rap"
+RADIO_RAP_FR_STREAM_URL = "http://icecast.radiofrance.fr/mouvrapfr-midfi.mp3"
 
 ROCK_RADIO_VC_ID = 1408081503707074650
 ROCK_RADIO_STREAM_URL = os.getenv(

--- a/tests/test_radio_rapfr_command.py
+++ b/tests/test_radio_rapfr_command.py
@@ -1,0 +1,49 @@
+import asyncio
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import AsyncMock
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import cogs.radio as radio_mod
+from cogs.radio import RadioCog
+from config import RADIO_RAP_FR_STREAM_URL, RADIO_STREAM_URL, RADIO_VC_ID
+
+
+@pytest.mark.asyncio
+async def test_radio_rapfr_command_toggles_stream(monkeypatch):
+    class FakeVoiceChannel(SimpleNamespace):
+        pass
+
+    monkeypatch.setattr(radio_mod.discord, "VoiceChannel", FakeVoiceChannel)
+    channel = FakeVoiceChannel(id=RADIO_VC_ID, name="Radio")
+    bot = SimpleNamespace(loop=asyncio.get_event_loop(), get_channel=lambda cid: channel)
+    cog = RadioCog(bot)
+    cog._original_name = "Radio"
+    monkeypatch.setattr(cog, "_connect_and_play", AsyncMock())
+    rename_mock = AsyncMock()
+    monkeypatch.setattr(radio_mod.rename_manager, "request", rename_mock)
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=123),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await RadioCog.radio_rapfr.callback(cog, interaction)
+
+    assert cog.stream_url == RADIO_RAP_FR_STREAM_URL
+    assert cog._previous_stream == RADIO_STREAM_URL
+    rename_mock.assert_awaited_once_with(channel, "🔴・Radio-RapFR")
+    interaction.response.send_message.assert_awaited_once()
+
+    interaction.response.send_message.reset_mock()
+    rename_mock.reset_mock()
+
+    await RadioCog.radio_rapfr.callback(cog, interaction)
+
+    assert cog.stream_url == RADIO_STREAM_URL
+    assert cog._previous_stream is None
+    rename_mock.assert_awaited_once_with(channel, "📻・Radio-HipHop")
+    interaction.response.send_message.assert_awaited_once()


### PR DESCRIPTION
## Summary
- update default 24/7 radio stream URL
- add `/radio_rapfr` command for French rap stream with channel rename
- cover new command with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8679626088324b6f34db3291e1b1b