### PR TITLE
Add lint configs and cache Discord channel fetches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 __pycache__/
 *.pyc
+venv/
 
 # Local data and JSON files
 data/

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.11
+ignore_missing_imports = True
+exclude = venv

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -q
+asyncio_mode = auto

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,5 @@
+line-length = 150
+exclude = ["venv"]
+
+[lint]
+select = ["E", "F", "B"]

--- a/tests/test_channel_cache.py
+++ b/tests/test_channel_cache.py
@@ -1,0 +1,17 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from utils.discord_utils import _fetch_channel_cached, _CHANNEL_CACHE
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_cached():
+    dummy_channel = SimpleNamespace(id=123)
+    bot = SimpleNamespace(fetch_channel=AsyncMock(return_value=dummy_channel))
+    _CHANNEL_CACHE.clear()
+    chan1 = await _fetch_channel_cached(bot, 123)
+    chan2 = await _fetch_channel_cached(bot, 123)
+    assert chan1 is chan2
+    bot.fetch_channel.assert_awaited_once_with(123)

--- a/utils/api_meter.py
+++ b/utils/api_meter.py
@@ -1,6 +1,6 @@
-from __future__ import annotations
-
 """API call metering and JSONL logging."""
+
+from __future__ import annotations
 
 import asyncio
 import contextvars
@@ -21,8 +21,8 @@ import config
 from utils.persistence import ensure_dir
 
 # Context variable used to propagate command information
-api_context: contextvars.ContextVar[Dict[str, str]] = contextvars.ContextVar(
-    "api_context", default={}
+api_context: contextvars.ContextVar[Dict[str, str] | None] = contextvars.ContextVar(
+    "api_context", default=None
 )
 
 
@@ -68,7 +68,7 @@ class APIMeter:
         api_context.set({"cog": cog or "", "command": command or ""})
 
     def _apply_context(self, data: Dict[str, Any]) -> None:
-        ctx = api_context.get()
+        ctx = api_context.get() or {}
         data.setdefault("cog", ctx.get("cog") or None)
         data.setdefault("command", ctx.get("command") or None)
         if not data.get("caller"):

--- a/utils/discord_utils.py
+++ b/utils/discord_utils.py
@@ -1,10 +1,30 @@
 """Helper functions for Discord channels and rate-limited edits."""
 
 import logging
+import time
+from typing import Dict, Tuple
+
 import discord
 from discord.ext import commands
 
 from utils.channel_edit_manager import channel_edit_manager
+
+_CHANNEL_CACHE: Dict[int, Tuple[discord.abc.GuildChannel, float]] = {}
+_CACHE_TTL = 300.0  # seconds
+
+
+async def _fetch_channel_cached(bot: commands.Bot, channel_id: int) -> discord.abc.GuildChannel | None:
+    cached = _CHANNEL_CACHE.get(channel_id)
+    now = time.monotonic()
+    if cached and now - cached[1] < _CACHE_TTL:
+        return cached[0]
+    try:
+        channel = await bot.fetch_channel(channel_id)
+    except discord.HTTPException as exc:
+        logging.warning("Impossible de récupérer le salon %s: %s", channel_id, exc)
+        return None
+    _CHANNEL_CACHE[channel_id] = (channel, now)
+    return channel
 
 
 async def ensure_channel_has_message(
@@ -13,12 +33,8 @@ async def ensure_channel_has_message(
     """Ensure the text channel with ``channel_id`` has at least one message."""
     channel = bot.get_channel(channel_id)
     if channel is None:
-        try:
-            channel = await bot.fetch_channel(channel_id)
-        except discord.HTTPException as exc:
-            logging.warning(
-                "Impossible de récupérer le salon %s: %s", channel_id, exc
-            )
+        channel = await _fetch_channel_cached(bot, channel_id)
+        if channel is None:
             return
 
     try:


### PR DESCRIPTION
## Summary
- add ruff/mypy/pytest configuration
- cache `fetch_channel` calls with TTL to reduce Discord API load
- fix API meter ContextVar and top-level import order
- add test for channel caching

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `ruff check .`
- `mypy .` *(fails: many untyped union-attr issues)*
- `bandit -q -r bot.py cogs utils`
- `pip-audit -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a86d8c3bc883249bac579bdfce0988