### PR TITLE
Add organised game event command with RSVP and XP multipliers

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -73,6 +73,7 @@ class RefugeBot(commands.Bot):
             "cogs.daily_summary_poster",
             "cogs.daily_awards",
             "cogs.api_stats",
+            "cogs.game_events",
         ]
         async def _load(ext: str) -> None:
             try:

--- a/cogs/game_events.py
+++ b/cogs/game_events.py
@@ -1,0 +1,226 @@
+import asyncio
+import logging
+import uuid
+from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from utils.interactions import safe_respond
+from view import RSVPView
+from utils.game_events import (
+    GameEvent,
+    EVENTS,
+    load_events,
+    save_event,
+    set_voice_channel,
+)
+
+
+class GameEventModal(discord.ui.Modal):
+    """Modal de création d'un événement de jeu."""
+
+    def __init__(self, cog: "GameEventsCog") -> None:
+        super().__init__(title="Organiser un jeu")
+        self.cog = cog
+        self.game_type = discord.ui.TextInput(label="Type de jeu")
+        self.game_name = discord.ui.TextInput(label="Nom du jeu")
+        self.date_time = discord.ui.TextInput(
+            label="Date & heure (JJ/MM/AAAA HH:MM)",
+            placeholder="22/10/2025 20:30",
+        )
+        self.add_item(self.game_type)
+        self.add_item(self.game_name)
+        self.add_item(self.date_time)
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await self.cog._create_event(
+            interaction,
+            self.game_type.value,
+            self.game_name.value,
+            self.date_time.value,
+        )
+
+
+class GameEventsCog(commands.Cog):
+    """Gestion des événements de jeu organisés."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        load_events()
+        for evt in EVENTS.values():
+            if evt.state in {"scheduled", "waiting"}:
+                try:
+                    bot.add_view(RSVPView(evt.id), message_id=evt.message_id)
+                except Exception:
+                    logging.exception("[game] Impossible d'attacher la vue pour %s", evt.id)
+        self.scheduler.start()
+
+    def cog_unload(self) -> None:
+        self.scheduler.cancel()
+
+    @app_commands.command(name="jeu_organise", description="Organiser un événement de jeu")
+    async def jeu_organise(self, interaction: discord.Interaction) -> None:
+        if interaction.guild is None or interaction.channel is None:
+            await safe_respond(
+                interaction,
+                "Commande utilisable uniquement sur un serveur.",
+                ephemeral=True,
+            )
+            return
+        await interaction.response.send_modal(GameEventModal(self))
+
+    async def _create_event(
+        self,
+        interaction: discord.Interaction,
+        game_type: str,
+        game_name: str,
+        date_str: str,
+    ) -> None:
+        try:
+            dt = datetime.strptime(date_str, "%d/%m/%Y %H:%M")
+            dt = dt.replace(tzinfo=ZoneInfo("Europe/Paris")).astimezone(timezone.utc)
+        except Exception:
+            await safe_respond(
+                interaction,
+                "Format de date invalide (JJ/MM/AAAA HH:MM)",
+                ephemeral=True,
+            )
+            return
+        evt = GameEvent(
+            id=uuid.uuid4().hex,
+            guild_id=interaction.guild_id,
+            creator_id=interaction.user.id,
+            game_type=game_type,
+            game_name=game_name,
+            time=dt,
+            channel_id=interaction.channel_id,
+            message_id=0,
+        )
+        EVENTS[evt.id] = evt
+        await save_event(evt)
+        embed = discord.Embed(
+            title=f"🎮 {game_name}",
+            description=f"Type: {game_type}\nDébut: <t:{int(dt.timestamp())}:F>",
+            color=discord.Color.blue(),
+        )
+        view = RSVPView(evt.id)
+        channel = interaction.channel
+        assert isinstance(channel, discord.abc.Messageable)
+        msg = await channel.send(embed=embed, view=view)
+        evt.message_id = msg.id
+        await save_event(evt)
+        self.bot.add_view(view, message_id=msg.id)
+        await safe_respond(interaction, "Événement créé ✔️", ephemeral=True)
+        logging.info("[game] Création événement %s", evt.id)
+
+    # ---------- boucle de planification ----------
+
+    @tasks.loop(seconds=30)
+    async def scheduler(self) -> None:
+        now = datetime.now(timezone.utc)
+        for evt in list(EVENTS.values()):
+            try:
+                await self._process_event(evt, now)
+            except Exception as e:
+                logging.exception("[game] scheduler error for %s: %s", evt.id, e)
+
+    async def _process_event(self, evt: GameEvent, now: datetime) -> None:
+        guild = self.bot.get_guild(evt.guild_id)
+        if guild is None:
+            return
+        # T-10 minutes: création salon vocal et DMs
+        if evt.state == "scheduled" and now >= evt.time - timedelta(minutes=10):
+            if any(s in {"yes", "maybe"} for s in evt.rsvps.values()):
+                creator = guild.get_member(evt.creator_id)
+                name = f"👥 {creator.display_name if creator else 'Joueur'}・{evt.game_name}"
+                vc = await guild.create_voice_channel(name)
+                set_voice_channel(evt, vc.id)
+                await save_event(evt)
+                for uid, status in evt.rsvps.items():
+                    if status in {"yes", "maybe"}:
+                        member = guild.get_member(int(uid))
+                        if member:
+                            try:
+                                await member.send(
+                                    f"{evt.game_name} commence dans 10 minutes !"
+                                )
+                            except discord.HTTPException:
+                                logging.info("[game] DM refusé pour %s", uid)
+                evt.state = "waiting"
+                await save_event(evt)
+                logging.info("[game] Salon vocal créé pour %s", evt.id)
+        # À l'heure H: annonce ou annulation
+        if evt.state in {"scheduled", "waiting"} and now >= evt.time:
+            if any(s in {"yes", "maybe"} for s in evt.rsvps.values()):
+                channel = guild.get_channel(evt.channel_id)
+                vc = guild.get_channel(evt.voice_channel_id) if evt.voice_channel_id else None
+                if isinstance(channel, discord.TextChannel):
+                    yes_mentions = [f"<@{u}>" for u, s in evt.rsvps.items() if s == "yes"]
+                    maybe_mentions = [f"<@{u}>" for u, s in evt.rsvps.items() if s == "maybe"]
+                    desc = "\n".join(yes_mentions) or "Personne"
+                    desc += "\nPeut-être : " + (", ".join(maybe_mentions) or "aucun")
+                    msg = await channel.send(
+                        f"C'est parti pour **{evt.game_name}** !\n"
+                        f"Salon vocal: {vc.mention if vc else 'n/a'}\n"
+                        f"Joueurs: {desc}\n"
+                        "Multiplicateurs: ✅ x2, 🤔 x1.5, autres x1",
+                    )
+                    try:
+                        await msg.pin()
+                    except discord.HTTPException:
+                        pass
+                evt.started_at = now
+                evt.state = "running"
+                await save_event(evt)
+                logging.info("[game] Annonce publiée pour %s", evt.id)
+            else:
+                creator = guild.get_member(evt.creator_id)
+                if creator:
+                    try:
+                        await creator.send(
+                            f"Ton événement **{evt.game_name}** est annulé (aucun RSVP)."
+                        )
+                    except discord.HTTPException:
+                        pass
+                evt.state = "cancelled"
+                await save_event(evt)
+                logging.info("[game] Événement %s annulé", evt.id)
+        # Fin de session quand le vocal est vide
+        if evt.state == "running" and evt.voice_channel_id:
+            vc = guild.get_channel(evt.voice_channel_id)
+            if not isinstance(vc, discord.VoiceChannel) or not vc.members:
+                duration = int((now - (evt.started_at or now)).total_seconds() // 60)
+                counts = {"x2": 0, "x1.5": 0, "x1": 0}
+                for uid in evt.participants:
+                    status = evt.rsvps.get(str(uid))
+                    if status == "yes":
+                        counts["x2"] += 1
+                    elif status == "maybe":
+                        counts["x1.5"] += 1
+                    else:
+                        counts["x1"] += 1
+                channel = guild.get_channel(evt.channel_id)
+                if isinstance(channel, discord.TextChannel):
+                    await channel.send(
+                        f"Session terminée : {evt.game_name}\n"
+                        f"Durée : {duration} min\n"
+                        f"Participants : {len(evt.participants)}\n"
+                        f"Bonus appliqués : x2={counts['x2']}, x1.5={counts['x1.5']}, x1={counts['x1']}"
+                    )
+                if isinstance(vc, discord.VoiceChannel):
+                    try:
+                        await vc.delete(reason="Événement terminé")
+                    except discord.HTTPException:
+                        pass
+                set_voice_channel(evt, None)
+                evt.state = "finished"
+                evt.ended_at = now
+                await save_event(evt)
+                logging.info("[game] Événement %s terminé", evt.id)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(GameEventsCog(bot))

--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -30,6 +30,7 @@ from utils.persistence import (
 )
 from utils.metrics import measure
 from storage.xp_store import xp_store
+from utils.game_events import get_multiplier, record_participant
 
 # Fichiers de persistance
 VOICE_TIMES_FILE = os.path.join(DATA_DIR, "voice_times.json")
@@ -185,6 +186,11 @@ class XPCog(commands.Cog):
             if start is not None:
                 duration = now - start
                 xp_amount = int(duration.total_seconds() // 60)
+                if before.channel is not None:
+                    mult = get_multiplier(before.channel.id, member.id)
+                    if mult != 1.0:
+                        xp_amount = int(xp_amount * mult)
+                        record_participant(before.channel.id, member.id)
                 old_lvl, new_lvl, total_xp = await award_xp(member.id, xp_amount)
                 if new_lvl > old_lvl:
                     await self.bot.announce_level_up(

--- a/config.py
+++ b/config.py
@@ -107,6 +107,10 @@ ROULETTE_BOUNDARY_CHECK_INTERVAL_MINUTES: int = int(
 DATA_DIR: str = _resolve_data_dir()
 """Répertoire de stockage persistant."""
 
+# ── Jeux organisés ────────────────────────────────────────────
+GAMES_DATA_DIR: str = os.getenv("GAMES_DATA_DIR", "/app/data/games")
+"""Répertoire de persistance des événements de jeu."""
+
 CHANNEL_EDIT_MIN_INTERVAL_SECONDS: int = int(
     os.getenv("CHANNEL_EDIT_MIN_INTERVAL_SECONDS", "180")
 )

--- a/utils/game_events.py
+++ b/utils/game_events.py
@@ -1,0 +1,152 @@
+import asyncio
+import logging
+import os
+import uuid
+from dataclasses import dataclass, field, asdict
+from datetime import datetime, timezone
+from typing import Dict, Optional, Set
+
+from config import GAMES_DATA_DIR
+from utils.persistence import ensure_dir, read_json_safe, atomic_write_json_async
+
+__all__ = [
+    "GameEvent",
+    "EVENTS",
+    "load_events",
+    "save_event",
+    "get_multiplier",
+    "record_participant",
+    "set_voice_channel",
+]
+
+
+@dataclass
+class GameEvent:
+    id: str
+    guild_id: int
+    creator_id: int
+    game_type: str
+    game_name: str
+    time: datetime
+    channel_id: int
+    message_id: int
+    rsvps: Dict[str, str] = field(default_factory=dict)  # uid -> status
+    first_bonus: bool = False
+    voice_channel_id: Optional[int] = None
+    started_at: Optional[datetime] = None
+    ended_at: Optional[datetime] = None
+    participants: Set[int] = field(default_factory=set)
+    state: str = "scheduled"  # scheduled, waiting, running, finished, cancelled
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self) -> Dict:
+        d = asdict(self)
+        d["time"] = self.time.astimezone(timezone.utc).isoformat()
+        d["created_at"] = self.created_at.astimezone(timezone.utc).isoformat()
+        d["started_at"] = (
+            self.started_at.astimezone(timezone.utc).isoformat()
+            if self.started_at
+            else None
+        )
+        d["ended_at"] = (
+            self.ended_at.astimezone(timezone.utc).isoformat()
+            if self.ended_at
+            else None
+        )
+        d["participants"] = list(self.participants)
+        return d
+
+    @staticmethod
+    def from_dict(data: Dict) -> "GameEvent":
+        def parse_dt(val: Optional[str]) -> Optional[datetime]:
+            if not val:
+                return None
+            try:
+                return datetime.fromisoformat(val).astimezone(timezone.utc)
+            except ValueError:
+                return None
+
+        return GameEvent(
+            id=data.get("id", uuid.uuid4().hex),
+            guild_id=int(data.get("guild_id", 0)),
+            creator_id=int(data.get("creator_id", 0)),
+            game_type=data.get("game_type", ""),
+            game_name=data.get("game_name", ""),
+            time=parse_dt(data.get("time")) or datetime.now(timezone.utc),
+            channel_id=int(data.get("channel_id", 0)),
+            message_id=int(data.get("message_id", 0)),
+            rsvps={str(k): str(v) for k, v in data.get("rsvps", {}).items()},
+            first_bonus=bool(data.get("first_bonus", False)),
+            voice_channel_id=(
+                int(data["voice_channel_id"]) if data.get("voice_channel_id") else None
+            ),
+            started_at=parse_dt(data.get("started_at")),
+            ended_at=parse_dt(data.get("ended_at")),
+            participants=set(map(int, data.get("participants", []))),
+            state=data.get("state", "scheduled"),
+            created_at=parse_dt(data.get("created_at")) or datetime.now(timezone.utc),
+        )
+
+
+EVENTS: Dict[str, GameEvent] = {}
+VC_INDEX: Dict[int, str] = {}
+_events_lock = asyncio.Lock()
+
+
+def load_events() -> None:
+    ensure_dir(GAMES_DATA_DIR)
+    for fname in os.listdir(GAMES_DATA_DIR):
+        if not fname.endswith(".json"):
+            continue
+        data = read_json_safe(os.path.join(GAMES_DATA_DIR, fname))
+        try:
+            evt = GameEvent.from_dict(data)
+        except Exception:
+            logging.exception("[game] Échec chargement événement %s", fname)
+            continue
+        EVENTS[evt.id] = evt
+        if evt.voice_channel_id:
+            VC_INDEX[evt.voice_channel_id] = evt.id
+    logging.info("[game] %d événements chargés", len(EVENTS))
+
+
+def _path_for(event_id: str) -> str:
+    return os.path.join(GAMES_DATA_DIR, f"{event_id}.json")
+
+
+async def save_event(evt: GameEvent) -> None:
+    ensure_dir(GAMES_DATA_DIR)
+    await atomic_write_json_async(_path_for(evt.id), evt.to_dict())
+
+
+def set_voice_channel(evt: GameEvent, vc_id: Optional[int]) -> None:
+    if evt.voice_channel_id:
+        VC_INDEX.pop(evt.voice_channel_id, None)
+    evt.voice_channel_id = vc_id
+    if vc_id:
+        VC_INDEX[vc_id] = evt.id
+
+
+def get_multiplier(channel_id: int, user_id: int) -> float:
+    eid = VC_INDEX.get(channel_id)
+    if not eid:
+        return 1.0
+    evt = EVENTS.get(eid)
+    if not evt:
+        return 1.0
+    status = evt.rsvps.get(str(user_id))
+    if status == "yes":
+        return 2.0
+    if status == "maybe":
+        return 1.5
+    return 1.0
+
+
+def record_participant(channel_id: int, user_id: int) -> None:
+    eid = VC_INDEX.get(channel_id)
+    if not eid:
+        return
+    evt = EVENTS.get(eid)
+    if evt:
+        evt.participants.add(user_id)
+


### PR DESCRIPTION
## Summary
- add game event scheduler and `/jeu_organise` slash command
- track RSVP status with bonus XP and voice multipliers
- persist game events in `GAMES_DATA_DIR`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b4756160832487ac66196f3ddd00