### PR TITLE
Prevent early game session termination

### DIFF
--- a/cogs/game_events.py
+++ b/cogs/game_events.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 import uuid
 from datetime import datetime, timedelta, timezone
@@ -189,7 +188,12 @@ class GameEventsCog(commands.Cog):
                 await save_event(evt)
                 logging.info("[game] Événement %s annulé", evt.id)
         # Fin de session quand le vocal est vide
-        if evt.state == "running" and evt.voice_channel_id:
+        if (
+            evt.state == "running"
+            and evt.voice_channel_id
+            and evt.started_at
+            and now - evt.started_at > timedelta(minutes=5)
+        ):
             vc = guild.get_channel(evt.voice_channel_id)
             if not isinstance(vc, discord.VoiceChannel) or not vc.members:
                 duration = int((now - (evt.started_at or now)).total_seconds() // 60)


### PR DESCRIPTION
## Summary
- require game sessions to run at least 5 minutes before ending when voice channel is empty
- remove unused import

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8d68dc9048324935c241c224a5757