### PR TITLE
Await API meter tasks on close

### DIFF
--- a/tests/test_api_meter_aclose.py
+++ b/tests/test_api_meter_aclose.py
@@ -1,0 +1,28 @@
+import os
+import sys
+import asyncio
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+from utils.api_meter import APIMeter
+
+
+@pytest.mark.asyncio
+async def test_aclose_cancels_and_resets_tasks():
+    meter = APIMeter()
+    writer = asyncio.create_task(asyncio.sleep(10))
+    summary = asyncio.create_task(asyncio.sleep(10))
+    meter.writer_task = writer
+    meter.summary_task = summary
+
+    await asyncio.sleep(0)
+    await meter.aclose()
+
+    assert writer.done()
+    assert summary.done()
+    assert meter.writer_task is None
+    assert meter.summary_task is None

--- a/utils/api_meter.py
+++ b/utils/api_meter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import contextvars
 import discord
 import inspect
@@ -250,8 +251,14 @@ class APIMeter:
     async def aclose(self) -> None:
         if self.writer_task:
             self.writer_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.writer_task
+            self.writer_task = None
         if self.summary_task:
             self.summary_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self.summary_task
+            self.summary_task = None
 
 
 # Global instance


### PR DESCRIPTION
## Summary
- ensure `APIMeter.aclose` awaits writer and summary tasks and clears references
- add regression test for `APIMeter.aclose`

## Testing
- `ruff check utils/api_meter.py tests/test_api_meter_aclose.py`
- `mypy utils/api_meter.py tests/test_api_meter_aclose.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e6d264388324bb1438b388f7d087