### PR TITLE
Await channel rename/edit manager shutdown

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -90,8 +90,8 @@ class RefugeBot(commands.Bot):
         await self.tree.sync()
 
     async def close(self) -> None:
-        rename_manager.stop()
-        channel_edit_manager.stop()
+        await rename_manager.aclose()
+        await channel_edit_manager.aclose()
         await xp_store.aclose()
         if hasattr(self, "error_counter_task"):
             self.error_counter_task.cancel()

--- a/tests/test_bot_close_stops_rename_manager.py
+++ b/tests/test_bot_close_stops_rename_manager.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 import discord
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 os.environ.setdefault("DISCORD_TOKEN", "dummy")
@@ -17,11 +17,14 @@ async def test_bot_close_stops_rename_manager(monkeypatch):
     intents = discord.Intents.none()
     test_bot = bot.RefugeBot(command_prefix="!", intents=intents)
 
-    stop_mock = MagicMock()
-    monkeypatch.setattr(bot.rename_manager, "stop", stop_mock)
+    rm_aclose_mock = AsyncMock()
+    monkeypatch.setattr(bot.rename_manager, "aclose", rm_aclose_mock)
 
-    aclose_mock = AsyncMock()
-    monkeypatch.setattr(bot.xp_store, "aclose", aclose_mock)
+    cem_aclose_mock = AsyncMock()
+    monkeypatch.setattr(bot.channel_edit_manager, "aclose", cem_aclose_mock)
+
+    store_aclose_mock = AsyncMock()
+    monkeypatch.setattr(bot.xp_store, "aclose", store_aclose_mock)
 
     super_close_mock = AsyncMock()
     from discord.ext import commands as d_commands
@@ -30,6 +33,7 @@ async def test_bot_close_stops_rename_manager(monkeypatch):
 
     await test_bot.close()
 
-    stop_mock.assert_called_once()
-    aclose_mock.assert_awaited_once()
+    rm_aclose_mock.assert_awaited_once()
+    cem_aclose_mock.assert_awaited_once()
+    store_aclose_mock.assert_awaited_once()
     super_close_mock.assert_awaited_once()

--- a/tests/test_channel_edit_manager.py
+++ b/tests/test_channel_edit_manager.py
@@ -18,7 +18,7 @@ async def edit_manager(monkeypatch):
     try:
         yield mgr
     finally:
-        mgr.stop()
+        await mgr.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/test_rename_manager_deleted_channel.py
+++ b/tests/test_rename_manager_deleted_channel.py
@@ -34,7 +34,7 @@ async def test_skip_when_channel_deleted(monkeypatch, caplog):
 
     await rm.request(channel, "new")
     await rm._queue.join()
-    rm.stop()
+    await rm.aclose()
 
     assert called is False
     assert any(

--- a/utils/channel_edit_manager.py
+++ b/utils/channel_edit_manager.py
@@ -28,9 +28,13 @@ class _ChannelEditManager:
         if self._worker is None:
             self._worker = asyncio.create_task(self._run())
 
-    def stop(self) -> None:
+    async def aclose(self) -> None:
         if self._worker is not None:
             self._worker.cancel()
+            try:
+                await self._worker
+            except asyncio.CancelledError:
+                pass
             self._worker = None
 
     async def request(self, channel: discord.abc.GuildChannel, **kwargs) -> None:

--- a/utils/rename_manager.py
+++ b/utils/rename_manager.py
@@ -30,9 +30,13 @@ class _RenameManager:
         if self._worker is None:
             self._worker = asyncio.create_task(self._run())
 
-    def stop(self) -> None:
+    async def aclose(self) -> None:
         if self._worker is not None:
             self._worker.cancel()
+            try:
+                await self._worker
+            except asyncio.CancelledError:
+                pass
             self._worker = None
 
     async def request(


### PR DESCRIPTION
## Summary
- make rename manager `aclose` await cancelled worker
- make channel edit manager `aclose` await cancelled worker
- close bot by awaiting manager shutdowns

## Testing
- `ruff check utils/rename_manager.py utils/channel_edit_manager.py bot.py tests/test_bot_close_stops_rename_manager.py tests/test_channel_edit_manager.py tests/test_rename_manager_deleted_channel.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8e7bedcf48324baafb4ff5b671952