### PR TITLE
Reduce first message XP reward

### DIFF
--- a/cogs/first_message.py
+++ b/cogs/first_message.py
@@ -126,13 +126,13 @@ class FirstMessageCog(commands.Cog):
             self.first_message_claimed = True
             self.winner_id = message.author.id
             self.claimed_at = datetime.now()
-        old_lvl, new_lvl, total_xp = await xp_store.add_xp(message.author.id, 1000)
+        old_lvl, new_lvl, total_xp = await xp_store.add_xp(message.author.id, 400)
         if new_lvl > old_lvl:
             await self.bot.announce_level_up(
                 message.guild, message.author, old_lvl, new_lvl, total_xp
             )
         await message.channel.send(
-            f"🎉 Félicitations {message.author.mention}, tu es le premier de la journée et tu gagnes 1000 XP !",
+            f"🎉 Félicitations {message.author.mention}, tu es le premier de la journée et tu gagnes 400 XP !",
         )
         await self._save_state()
         logging.info(


### PR DESCRIPTION
## Summary
- Adjust daily first-message bonus from 1000 to 400 XP
- Update congratulatory message to reflect reduced reward

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8eb4b2968832486f598ec4ef80687