### PR TITLE
feat: add randomized double voice xp sessions

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -62,6 +62,7 @@ class RefugeBot(commands.Bot):
             "cogs.role_reminder",
             "cogs.roulette",
             "cogs.xp",
+            "cogs.voice_double_xp",
             "cogs.first_message",
             "cogs.temp_vc",
             "cogs.misc",

--- a/cogs/voice_double_xp.py
+++ b/cogs/voice_double_xp.py
@@ -1,0 +1,146 @@
+"""Gestion des sessions Double XP vocal.
+
+Tire quotidiennement jusqu'à deux créneaux horaires aléatoires et active
+un multiplicateur ×2 sur l'XP vocal pendant une heure avec annonces de début
+et de fin dans un salon dédié.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import random
+from datetime import date, datetime, time, timedelta
+from typing import List
+
+import discord
+from discord.ext import commands, tasks
+
+from config import (
+    DATA_DIR,
+    XP_DOUBLE_VOICE_SESSIONS_PER_DAY,
+    XP_DOUBLE_VOICE_DURATION_MINUTES,
+    XP_DOUBLE_VOICE_START_HOUR,
+    XP_DOUBLE_VOICE_END_HOUR,
+    XP_DOUBLE_VOICE_ANNOUNCE_CHANNEL_ID,
+)
+from utils.persistence import read_json_safe, atomic_write_json_async, ensure_dir
+from utils.voice_bonus import set_voice_bonus
+
+try:
+    from zoneinfo import ZoneInfo
+
+    PARIS_TZ = ZoneInfo("Europe/Paris")
+except Exception:  # pragma: no cover - fallback when zoneinfo is missing
+    from datetime import timezone
+
+    PARIS_TZ = timezone.utc
+
+STATE_FILE = os.path.join(DATA_DIR, "double_voice_xp.json")
+ensure_dir(DATA_DIR)
+
+
+def _read_state() -> dict:
+    return read_json_safe(STATE_FILE)
+
+
+async def _write_state(data: dict) -> None:
+    await atomic_write_json_async(STATE_FILE, data)
+
+
+def _random_sessions() -> List[str]:
+    """Return a list of random HH:MM sessions for today."""
+    count = random.randint(0, XP_DOUBLE_VOICE_SESSIONS_PER_DAY)
+    if count == 0:
+        return []
+    start_min = XP_DOUBLE_VOICE_START_HOUR * 60
+    end_min = XP_DOUBLE_VOICE_END_HOUR * 60 - XP_DOUBLE_VOICE_DURATION_MINUTES
+    if end_min < start_min:
+        end_min = start_min
+    minutes = random.sample(range(start_min, end_min + 1), count)
+    minutes.sort()
+    return [f"{m // 60:02d}:{m % 60:02d}" for m in minutes]
+
+
+def _hm_to_dt(hm: str, day: date) -> datetime:
+    h, m = map(int, hm.split(":"))
+    return datetime.combine(day, time(hour=h, minute=m, tzinfo=PARIS_TZ))
+
+
+class DoubleVoiceXP(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._tasks: List[asyncio.Task] = []
+        self.daily_planner.start()
+        self.bot.loop.create_task(self._startup())
+
+    async def _startup(self) -> None:
+        await self.bot.wait_until_ready()
+        await self._prepare_today()
+
+    def cog_unload(self) -> None:  # pragma: no cover - cleanup
+        self.daily_planner.cancel()
+        for task in self._tasks:
+            task.cancel()
+
+    @tasks.loop(time=time(hour=0, minute=1, tzinfo=PARIS_TZ))
+    async def daily_planner(self) -> None:
+        await self._prepare_today(force=True)
+
+    @daily_planner.before_loop
+    async def before_daily_planner(self) -> None:  # pragma: no cover - simple wait
+        await self.bot.wait_until_ready()
+
+    async def _prepare_today(self, force: bool = False) -> None:
+        today = datetime.now(PARIS_TZ).date()
+        state = _read_state()
+        if force or state.get("date") != today.isoformat():
+            sessions = _random_sessions()
+            state = {"date": today.isoformat(), "sessions": sessions}
+            await _write_state(state)
+        sessions = state.get("sessions", [])
+        for hm in sessions:
+            dt = _hm_to_dt(hm, today)
+            self._schedule_session(dt)
+
+    def _schedule_session(self, dt: datetime) -> None:
+        end_dt = dt + timedelta(minutes=XP_DOUBLE_VOICE_DURATION_MINUTES)
+        now = datetime.now(PARIS_TZ)
+        if end_dt <= now:
+            return
+        delay = max(0, (dt - now).total_seconds())
+        task = self.bot.loop.create_task(self._run_session(delay))
+        self._tasks.append(task)
+
+    async def _run_session(self, delay: float) -> None:
+        await asyncio.sleep(delay)
+        await self._start_session()
+        await asyncio.sleep(XP_DOUBLE_VOICE_DURATION_MINUTES * 60)
+        await self._end_session()
+
+    async def _start_session(self) -> None:
+        set_voice_bonus(True)
+        channel = self.bot.get_channel(XP_DOUBLE_VOICE_ANNOUNCE_CHANNEL_ID)
+        if channel:
+            try:
+                await channel.send(
+                    "Hey 🎉 À partir de maintenant, c’est DOUBLE XP en vocal ! Profitez-en 😉"
+                )
+            except Exception as e:  # pragma: no cover - network errors
+                logging.warning("[double_xp] Failed to send start message: %s", e)
+
+    async def _end_session(self) -> None:
+        set_voice_bonus(False)
+        channel = self.bot.get_channel(XP_DOUBLE_VOICE_ANNOUNCE_CHANNEL_ID)
+        if channel:
+            try:
+                await channel.send(
+                    "✅ La session Double XP vocale est terminée pour aujourd’hui, merci à ceux qui étaient présents !"
+                )
+            except Exception as e:  # pragma: no cover - network errors
+                logging.warning("[double_xp] Failed to send end message: %s", e)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(DoubleVoiceXP(bot))

--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -31,6 +31,7 @@ from utils.persistence import (
 from utils.metrics import measure
 from storage.xp_store import xp_store
 from utils.game_events import get_multiplier, record_participant
+from utils.voice_bonus import get_voice_multiplier
 
 # Fichiers de persistance
 VOICE_TIMES_FILE = os.path.join(DATA_DIR, "voice_times.json")
@@ -204,10 +205,11 @@ class XPCog(commands.Cog):
                 duration = now - start
                 xp_amount = int(duration.total_seconds() // 60)
                 if before.channel is not None:
-                    mult = get_multiplier(before.channel.id, member.id)
-                    if mult != 1.0:
-                        xp_amount = int(xp_amount * mult)
+                    event_mult = get_multiplier(before.channel.id, member.id)
+                    mult = get_voice_multiplier(event_mult)
+                    if event_mult != 1.0:
                         record_participant(before.channel.id, member.id)
+                    xp_amount = int(xp_amount * mult)
                 old_lvl, new_lvl, total_xp = await award_xp(member.id, xp_amount)
                 if new_lvl > old_lvl:
                     await self.bot.announce_level_up(

--- a/config.py
+++ b/config.py
@@ -107,6 +107,32 @@ ROULETTE_BOUNDARY_CHECK_INTERVAL_MINUTES: int = int(
 DATA_DIR: str = _resolve_data_dir()
 """Répertoire de stockage persistant."""
 
+# ── Double XP vocal ───────────────────────────────────────────
+XP_DOUBLE_VOICE_SESSIONS_PER_DAY: int = int(
+    os.getenv("XP_DOUBLE_VOICE_SESSIONS_PER_DAY", "2")
+)
+"""Nombre maximum de sessions Double XP vocal par jour."""
+
+XP_DOUBLE_VOICE_DURATION_MINUTES: int = int(
+    os.getenv("XP_DOUBLE_VOICE_DURATION_MINUTES", "60")
+)
+"""Durée d'une session Double XP vocal en minutes."""
+
+XP_DOUBLE_VOICE_START_HOUR: int = int(
+    os.getenv("XP_DOUBLE_VOICE_START_HOUR", "10")
+)
+"""Heure de début minimale pour une session (Europe/Paris)."""
+
+XP_DOUBLE_VOICE_END_HOUR: int = int(
+    os.getenv("XP_DOUBLE_VOICE_END_HOUR", "23")
+)
+"""Heure de début maximale pour une session (Europe/Paris)."""
+
+XP_DOUBLE_VOICE_ANNOUNCE_CHANNEL_ID: int = int(
+    os.getenv("XP_DOUBLE_VOICE_ANNOUNCE_CHANNEL_ID", str(ANNOUNCE_CHANNEL_ID))
+)
+"""Salon où sont annoncées les sessions Double XP vocal."""
+
 # ── Jeux organisés ────────────────────────────────────────────
 GAMES_DATA_DIR: str = os.getenv("GAMES_DATA_DIR", "/app/data/games")
 """Répertoire de persistance des événements de jeu."""

--- a/tests/test_voice_double_xp.py
+++ b/tests/test_voice_double_xp.py
@@ -1,0 +1,47 @@
+import asyncio
+import os
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import cogs.voice_double_xp as dx
+from utils.voice_bonus import get_voice_multiplier, set_voice_bonus
+
+
+def test_random_sessions_limits(monkeypatch):
+    with patch.object(dx.random, "randint", return_value=2), patch.object(
+        dx.random, "sample", return_value=[600, 1320]
+    ):
+        sessions = dx._random_sessions()
+    assert sessions == ["10:00", "22:00"]
+
+
+def test_multiplier_application():
+    set_voice_bonus(False)
+    assert get_voice_multiplier(1.0) == 1.0
+    set_voice_bonus(True)
+    assert get_voice_multiplier(1.0) == 2.0
+    assert get_voice_multiplier(3.0) == 3.0
+    set_voice_bonus(False)
+
+
+@pytest.mark.asyncio
+async def test_persistence_no_redraw(tmp_path, monkeypatch):
+    today = datetime.now(dx.PARIS_TZ).date().isoformat()
+    state_file = tmp_path / "double_voice_xp.json"
+    monkeypatch.setattr(dx, "STATE_FILE", str(state_file))
+    await dx._write_state({"date": today, "sessions": ["10:00"]})
+
+    bot = SimpleNamespace(loop=asyncio.get_event_loop(), get_channel=lambda cid: None)
+    with patch.object(dx.tasks.Loop, "start", lambda self, *a, **k: None):
+        with patch.object(dx.DoubleVoiceXP, "_run_session", AsyncMock()):
+            with patch.object(dx.random, "randint", side_effect=AssertionError("no redraw")):
+                cog = dx.DoubleVoiceXP(bot)
+                await cog._prepare_today()
+                await asyncio.sleep(0)
+    assert len(cog._tasks) == 1

--- a/utils/voice_bonus.py
+++ b/utils/voice_bonus.py
@@ -1,0 +1,26 @@
+"""Global state for temporary voice XP multipliers."""
+
+from __future__ import annotations
+
+DOUBLE_VOICE_XP_ACTIVE: bool = False
+
+
+def set_voice_bonus(active: bool) -> None:
+    """Activate or deactivate the global voice XP bonus."""
+    global DOUBLE_VOICE_XP_ACTIVE
+    DOUBLE_VOICE_XP_ACTIVE = active
+
+
+def get_voice_multiplier(base: float) -> float:
+    """Return the voice XP multiplier, capped at ×2 when bonus active.
+
+    Parameters
+    ----------
+    base: float
+        Existing multiplier from other mechanics.
+    """
+    if DOUBLE_VOICE_XP_ACTIVE and base < 2.0:
+        return 2.0
+    return base
+
+__all__ = ["set_voice_bonus", "get_voice_multiplier"]


### PR DESCRIPTION
## Summary
- allow two random daily double-voice-XP sessions with persistence
- expose voice XP bonus state and multiplier helper
- apply bonus multiplier in XP awards and load new cog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8ec24c3548324a071bf4d82e06423