### PR TITLE
Place game event voice channels in temporary category

### DIFF
--- a/cogs/game_events.py
+++ b/cogs/game_events.py
@@ -7,6 +7,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 
+from config import TEMP_VC_CATEGORY
 from utils.interactions import safe_respond
 from view import RSVPView
 from utils.game_events import (
@@ -134,7 +135,8 @@ class GameEventsCog(commands.Cog):
         if evt.state == "scheduled" and now >= evt.time - timedelta(minutes=10):
             creator = guild.get_member(evt.creator_id)
             name = f"👥 {creator.display_name if creator else 'Joueur'}・{evt.game_name}"
-            vc = await guild.create_voice_channel(name)
+            category = guild.get_channel(TEMP_VC_CATEGORY)
+            vc = await guild.create_voice_channel(name, category=category)
             set_voice_channel(evt, vc.id)
             await save_event(evt)
             for uid, status in evt.rsvps.items():


### PR DESCRIPTION
## Summary
- ensure temporary game voice channels are created under the configured category
- import TEMP_VC_CATEGORY constant for game event scheduling

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8f24a9d0483248d89b0751d2f261a