### PR TITLE
feat: add game reminder

### DIFF
--- a/cogs/game_events.py
+++ b/cogs/game_events.py
@@ -131,6 +131,18 @@ class GameEventsCog(commands.Cog):
         guild = self.bot.get_guild(evt.guild_id)
         if guild is None:
             return
+        if (
+            evt.state == "scheduled"
+            and not evt.reminder_sent
+            and now >= evt.time - timedelta(hours=1)
+        ):
+            channel = guild.get_channel(evt.channel_id)
+            if isinstance(channel, discord.TextChannel):
+                await channel.send(
+                    f"Rappel: {evt.game_name} commence dans une heure !"
+                )
+            evt.reminder_sent = True
+            await save_event(evt)
         # T-10 minutes: création salon vocal et DMs
         if evt.state == "scheduled" and now >= evt.time - timedelta(minutes=10):
             creator = guild.get_member(evt.creator_id)

--- a/utils/game_events.py
+++ b/utils/game_events.py
@@ -36,6 +36,7 @@ class GameEvent:
     started_at: Optional[datetime] = None
     ended_at: Optional[datetime] = None
     participants: Set[int] = field(default_factory=set)
+    reminder_sent: bool = False
     state: str = "scheduled"  # scheduled, waiting, running, finished, cancelled
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
 
@@ -54,6 +55,7 @@ class GameEvent:
             else None
         )
         d["participants"] = list(self.participants)
+        d["reminder_sent"] = self.reminder_sent
         return d
 
     @staticmethod
@@ -83,6 +85,7 @@ class GameEvent:
             started_at=parse_dt(data.get("started_at")),
             ended_at=parse_dt(data.get("ended_at")),
             participants=set(map(int, data.get("participants", []))),
+            reminder_sent=bool(data.get("reminder_sent", False)),
             state=data.get("state", "scheduled"),
             created_at=parse_dt(data.get("created_at")) or datetime.now(timezone.utc),
         )


### PR DESCRIPTION
## Summary
- add `reminder_sent` flag to game events and include in serialization
- send an hour-before reminder message for scheduled games

## Testing
- `ruff check utils/game_events.py cogs/game_events.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9126177f48324b28cac383b2e30b1