### PR TITLE
Add persistent radio station controls

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -16,7 +16,7 @@ from utils.rate_limit import GlobalRateLimiter
 from storage.xp_store import xp_store
 from utils.rename_manager import rename_manager
 from utils.channel_edit_manager import channel_edit_manager
-from view import PlayerTypeView
+from view import PlayerTypeView, RadioView
 from utils.api_meter import api_meter, APICallCtx
 
 load_dotenv(override=True)
@@ -57,6 +57,7 @@ intents.presences = True
 class RefugeBot(commands.Bot):
     async def setup_hook(self) -> None:
         self.add_view(PlayerTypeView())
+        self.add_view(RadioView())
         await xp_store.start()
         extensions = [
             "cogs.role_reminder",

--- a/tests/test_radio_view_buttons.py
+++ b/tests/test_radio_view_buttons.py
@@ -1,0 +1,31 @@
+from types import SimpleNamespace
+from pathlib import Path
+from unittest.mock import AsyncMock
+import sys
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from view import RadioView
+
+
+@pytest.mark.asyncio
+async def test_radio_view_buttons_call_commands():
+    view = RadioView()
+    mapping = {
+        "radio_24": "radio_24",
+        "radio_rock": "radio_rock",
+        "radio_rap": "radio_rap",
+        "radio_rapfr": "radio_rapfr",
+    }
+    for custom_id, cmd_name in mapping.items():
+        button = next(
+            child for child in view.children if getattr(child, "custom_id", None) == custom_id
+        )
+        mock = AsyncMock()
+        cog = SimpleNamespace(**{cmd_name: SimpleNamespace(callback=mock)})
+        interaction = SimpleNamespace(
+            client=SimpleNamespace(get_cog=lambda name, c=cog: c)
+        )
+        await button.callback(interaction)
+        mock.assert_awaited_once()

--- a/view.py
+++ b/view.py
@@ -183,6 +183,52 @@ class PlayerTypeView(discord.ui.View):
             )
 
 
+class RadioView(discord.ui.View):
+    """Boutons pour sélectionner la station radio."""
+
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+
+    async def _dispatch(self, interaction: discord.Interaction, cmd: str) -> None:
+        cog = interaction.client.get_cog("RadioCog")
+        if not cog:
+            await interaction.response.send_message(
+                "❌ Radio indisponible.", ephemeral=True
+            )
+            return
+        command = getattr(cog, cmd, None)
+        if command:
+            await command.callback(cog, interaction)
+
+    @discord.ui.button(label="24/7", style=discord.ButtonStyle.primary, custom_id="radio_24")
+    async def btn_radio_24(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._dispatch(interaction, "radio_24")
+
+    @discord.ui.button(
+        label="Rock", style=discord.ButtonStyle.secondary, custom_id="radio_rock"
+    )
+    async def btn_radio_rock(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._dispatch(interaction, "radio_rock")
+
+    @discord.ui.button(label="Rap", style=discord.ButtonStyle.primary, custom_id="radio_rap")
+    async def btn_radio_rap(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._dispatch(interaction, "radio_rap")
+
+    @discord.ui.button(
+        label="Rap FR", style=discord.ButtonStyle.primary, custom_id="radio_rapfr"
+    )
+    async def btn_radio_rapfr(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._dispatch(interaction, "radio_rapfr")
+
+
 class RSVPView(discord.ui.View):
     """Boutons RSVP pour les événements de jeu."""
 


### PR DESCRIPTION
## Summary
- add persistent `RadioView` buttons for station selection
- ensure radio control message exists on startup
- test button callbacks invoke respective radio commands

## Testing
- `ruff check cogs/radio.py view.py bot.py tests/test_radio_view_buttons.py`
- `pytest -q`
- `ruff check .` *(fails: tests/test_xp_boost.py:1:8 F401)*

------
https://chatgpt.com/codex/tasks/task_e_68a9126d7db08324ad424bb9a81d58fb