### PR TITLE
Fix duplicate double XP announcements

### DIFF
--- a/cogs/voice_double_xp.py
+++ b/cogs/voice_double_xp.py
@@ -110,6 +110,11 @@ class DoubleVoiceXP(commands.Cog):
     async def _prepare_today(self, force: bool = False) -> None:
         """Lire/initialiser l'état du jour puis planifier ou reprendre les sessions."""
 
+        # Cancel any previously scheduled tasks to avoid duplicates.
+        for task in self._tasks:
+            task.cancel()
+        self._tasks.clear()
+
         today = datetime.now(PARIS_TZ).date()
         state = _read_state()
         if force or state.get("date") != today.isoformat():


### PR DESCRIPTION
## Summary
- avoid duplicate double XP session announcements by cancelling previously scheduled tasks
- add regression test for repeated double XP planning

## Testing
- `ruff check cogs/voice_double_xp.py tests/test_voice_double_xp.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9d4ba8ffc8324b611d1e52a946758