### PR TITLE
Fix leaderboard send call

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -285,7 +285,7 @@ class RouletteRefugeCog(commands.Cog):
             embed.add_field(name="Plus gros gain", value=f"<@{biggest[0]}> {biggest[1]} XP", inline=False)
         embed.add_field(name="Total misé", value=f"{total_bet} XP")
         embed.add_field(name="Total redistribué", value=f"{total_net} XP")
-        await channel send(embed=embed)
+        await channel.send(embed=embed)
 
     # -------------------------- Tasks --------------------------
     @tasks.loop(minutes=1)


### PR DESCRIPTION
## Summary
- fix awaiting channel send embed call on leaderboard

## Testing
- `ruff check .`
- `pytest` *(fails: module 'bot' has no attribute 'RefugeBot')*

------
https://chatgpt.com/codex/tasks/task_e_68aa45f3cd748324958d541e170a79a0