### PR TITLE
Restrict JSON ignore scope and document secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,10 +5,13 @@ venv/
 
 # Local data and JSON files
 data/*
-*.json
+data/**/*.json
+/app/data/**/*.json
 # Allow committing Roulette Refuge data
 !data/pari_xp/
 !data/pari_xp/*.json
+# Allow necessary configuration files
+!config.json
 
 # Secret files
 /app/data/*

--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ essentielles pour exécuter le bot :
 
 Adaptez ces valeurs selon votre déploiement avant de lancer le bot.
 
+## Gestion des secrets
+
+Ne stockez jamais de jetons, de clés API ou d'autres informations sensibles dans le dépôt. Utilisez des variables d'environnement ou un gestionnaire de secrets dédié. Le fichier `.env` est ignoré par Git ; servez-vous du modèle `.env.example` pour documenter les paramètres requis.
+
 ## Données persistantes
 
 Certaines fonctionnalités (XP, roulette, salons temporaires…) écrivent des


### PR DESCRIPTION
## Summary
- limit JSON ignore to sensitive data directories and allow required config files
- document best practices for managing secrets

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa521c8c888324873acdf986623f37