### PR TITLE
Register PlayerTypeView on setup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,6 +15,7 @@ from utils.api_meter import api_meter
 from utils.channel_edit_manager import channel_edit_manager
 from utils.rename_manager import rename_manager
 from utils.rate_limit import GlobalRateLimiter
+from view import PlayerTypeView
 
 # global rate limiter instance
 limiter = GlobalRateLimiter()
@@ -45,6 +46,13 @@ class RefugeBot(commands.Bot):
         # ``AsyncMock`` in the tests, so awaiting is safe.
         await self.load_extension("cogs.pari_xp")
         await self.tree.sync()
+
+        # Register persistent views. ``add_view`` can only be called once per
+        # view instance; protect against duplicates when ``setup_hook`` runs
+        # multiple times during tests or restarts.
+        if not getattr(self, "_player_type_view_added", False):
+            self.add_view(PlayerTypeView())
+            self._player_type_view_added = True
 
     async def close(self) -> None:  # type: ignore[override]
         """Ensure background helpers are stopped before shutting down."""

--- a/tests/test_setup_hook_adds_view.py
+++ b/tests/test_setup_hook_adds_view.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from pathlib import Path
+
+import asyncio
+import discord
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+import bot
+import view
+
+
+@pytest.mark.asyncio
+async def test_setup_hook_registers_player_type_view_once(monkeypatch):
+    intents = discord.Intents.none()
+    test_bot = bot.RefugeBot(command_prefix="!", intents=intents)
+
+    # Patch background helpers to avoid side effects
+    monkeypatch.setattr(bot.xp_store, "start", AsyncMock())
+    monkeypatch.setattr(bot.rename_manager, "start", AsyncMock())
+    monkeypatch.setattr(bot.channel_edit_manager, "start", AsyncMock())
+    monkeypatch.setattr(bot.api_meter, "start", AsyncMock())
+    monkeypatch.setattr(bot.limiter, "start", MagicMock())
+    monkeypatch.setattr(bot, "reset_http_error_counter", AsyncMock())
+    monkeypatch.setattr(test_bot, "loop", asyncio.get_event_loop(), raising=False)
+
+    monkeypatch.setattr(test_bot, "load_extension", AsyncMock())
+    monkeypatch.setattr(test_bot.tree, "sync", AsyncMock())
+
+    add_view_mock = MagicMock()
+    monkeypatch.setattr(test_bot, "add_view", add_view_mock)
+
+    # First call registers the view
+    await test_bot.setup_hook()
+    # Second call should be idempotent
+    await test_bot.setup_hook()
+
+    add_view_mock.assert_called_once()
+    assert isinstance(add_view_mock.call_args.args[0], view.PlayerTypeView)
+
+    # Simulate a restart with a new instance
+    other_bot = bot.RefugeBot(command_prefix="!", intents=intents)
+    monkeypatch.setattr(other_bot, "loop", asyncio.get_event_loop(), raising=False)
+    monkeypatch.setattr(other_bot, "load_extension", AsyncMock())
+    monkeypatch.setattr(other_bot.tree, "sync", AsyncMock())
+
+    add_view_mock2 = MagicMock()
+    monkeypatch.setattr(other_bot, "add_view", add_view_mock2)
+
+    await other_bot.setup_hook()
+
+    add_view_mock2.assert_called_once()
+    assert isinstance(add_view_mock2.call_args.args[0], view.PlayerTypeView)
+


### PR DESCRIPTION
## Summary
- add persistent PlayerTypeView registration in bot setup_hook
- ensure idempotent view registration to prevent duplicates
- test view persistence across restarts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa5665929c83249799b004771e9c4c