### PR TITLE
Persist XP boosts across restarts

### DIFF
--- a/tests/test_xp_boost.py
+++ b/tests/test_xp_boost.py
@@ -22,3 +22,19 @@ async def test_boost_expiration(monkeypatch):
     old, new, total = await xp.award_xp(uid, 10)
     assert total == 10
     assert str(uid) not in xp.XP_BOOSTS
+
+
+@pytest.mark.asyncio
+async def test_boost_persistence(tmp_path, monkeypatch):
+    file_path = tmp_path / "xp_boosts.json"
+    monkeypatch.setattr(xp, "XP_BOOSTS_FILE", str(file_path))
+    xp.XP_BOOSTS.clear()
+
+    uid = 789
+    xp.add_xp_boost(uid, 60)
+    await xp.save_xp_boosts_to_disk()
+
+    xp.XP_BOOSTS.clear()
+    await xp.xp_bootstrap_cache()
+
+    assert str(uid) in xp.XP_BOOSTS


### PR DESCRIPTION
## Summary
- persist XP boosts to a JSON file and reload them on startup
- automatically save when boosts are added or expire
- test that XP boosts survive a restart

## Testing
- `ruff check cogs/xp.py tests/test_xp_boost.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa5877272883249e8b4b3f6534f0d5