### PR TITLE
Add async lock for transaction ledger to prevent race conditions

### DIFF
--- a/storage/transaction_store.py
+++ b/storage/transaction_store.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, List
+
+from utils.storage import load_json, save_json
+
+
+class TransactionStore:
+    """Simple JSON-backed transaction ledger.
+
+    Transactions are kept in memory and persisted to ``path``. To avoid race
+    conditions when multiple coroutines modify the ledger concurrently, all
+    mutating operations are protected by an :class:`asyncio.Lock`.
+    """
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+        # Load existing transactions or start with an empty list. ``load_json``
+        # returns ``{}`` when the file is missing or corrupted; ensure we get a
+        # list to avoid attribute errors.
+        data = load_json(self.path, [])
+        self.transactions: List[Any] = data if isinstance(data, list) else []
+        self._lock = asyncio.Lock()
+
+    async def add(self, transaction: Any) -> None:
+        """Append ``transaction`` to the ledger and persist to disk."""
+        async with self._lock:
+            self.transactions.append(transaction)
+            await save_json(self.path, self.transactions)
+
+    async def clear(self) -> None:
+        """Remove all transactions and persist the empty ledger."""
+        async with self._lock:
+            self.transactions.clear()
+            await save_json(self.path, self.transactions)
+
+    async def all(self) -> list[Any]:
+        """Return a shallow copy of the current transactions list."""
+        async with self._lock:
+            return list(self.transactions)

--- a/tests/test_transaction_store_concurrency.py
+++ b/tests/test_transaction_store_concurrency.py
@@ -1,0 +1,27 @@
+import asyncio
+import json
+
+import pytest
+
+from storage.transaction_store import TransactionStore
+
+
+@pytest.mark.asyncio
+async def test_concurrent_transaction_additions(tmp_path):
+    path = tmp_path / "transactions.json"
+    store = TransactionStore(path)
+
+    async def worker(i: int):
+        # Introduce a tiny delay to encourage task switching
+        await asyncio.sleep(0)
+        await store.add({"id": i})
+
+    await asyncio.gather(*(worker(i) for i in range(50)))
+
+    transactions = await store.all()
+    assert len(transactions) == 50
+    assert sorted(t["id"] for t in transactions) == list(range(50))
+
+    with path.open() as f:
+        data = json.load(f)
+    assert len(data) == 50


### PR DESCRIPTION
## Summary
- Add new `TransactionStore` with `asyncio.Lock` to serialize modifications and persistence of transactions
- Cover concurrent writes to the store with an async test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68aa59a0e088832482db03a941fa7564