### PR TITLE
chore: use main entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY . .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Lancement du bot
-CMD ["python", "bot.py"]
+CMD ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 This Discord bot requires the Opus audio codec library and FFmpeg for voice features.
 
+## Entrypoint
+
+The bot launches via [`main.py`](./main.py). Docker images and Procfile run:
+
+```bash
+python main.py
+```
+
 ## System dependencies
 
 Install `libopus0` and `ffmpeg` on Debian/Ubuntu:


### PR DESCRIPTION
## Summary
- run main.py instead of bot.py in Docker container
- document the main.py entrypoint in the README

## Testing
- `pytest`
- `apt-get update`
- `apt-get install -y docker.io`
- `service docker start` *(fails: docker: unrecognized service)*
- `docker build -t test .` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b545ac88324a01b2a75ae08307b