### PR TITLE
Add logging configuration and per-cog loggers

### DIFF
--- a/cogs/daily_ranking.py
+++ b/cogs/daily_ranking.py
@@ -21,6 +21,7 @@ from config import DATA_DIR, XP_VIEWER_ROLE_ID
 from utils.interactions import safe_respond
 from utils.persistence import read_json_safe, atomic_write_json, ensure_dir
 from .xp import DAILY_STATS, DAILY_LOCK, save_daily_stats_to_disk
+logger = logging.getLogger(__name__)
 
 try:
     from zoneinfo import ZoneInfo
@@ -104,18 +105,18 @@ class DailyRankingAndRoles(commands.Cog):
     async def _run_daily_task(self) -> None:
         now = datetime.now(PARIS_TZ)
         day = (now - timedelta(days=1)).date().isoformat()
-        logging.info("[daily_ranking] Calcul du classement pour %s", day)
+        logger.info("[daily_ranking] Calcul du classement pour %s", day)
         async with DAILY_LOCK:
             stats = DAILY_STATS.pop(day, {})
         if not stats:
-            logging.info("[daily_ranking] Aucune statistique pour %s", day)
+            logger.info("[daily_ranking] Aucune statistique pour %s", day)
             await save_daily_stats_to_disk()
             return
         ranking = self._compute_ranking(stats)
         ranking["date"] = day
         self._write_persistence(ranking)
         await save_daily_stats_to_disk()
-        logging.info("[daily_ranking] Classement %s sauvegardé", day)
+        logger.info("[daily_ranking] Classement %s sauvegardé", day)
 
     @app_commands.command(
         name="test_classement1", description="Prévisualise le classement du jour"
@@ -139,4 +140,3 @@ class DailyRankingAndRoles(commands.Cog):
 
 async def setup(bot: commands.Bot) -> None:  # pragma: no cover - integration
     await bot.add_cog(DailyRankingAndRoles(bot))
-

--- a/cogs/daily_summary_poster.py
+++ b/cogs/daily_summary_poster.py
@@ -22,6 +22,7 @@ from discord.ext import commands
 from config import ACTIVITY_SUMMARY_CH, DATA_DIR, XP_VIEWER_ROLE_ID
 from utils.interactions import safe_respond
 from utils.persistence import read_json_safe, atomic_write_json, ensure_dir
+logger = logging.getLogger(__name__)
 
 try:
     from zoneinfo import ZoneInfo
@@ -119,7 +120,7 @@ class DailySummaryPoster(commands.Cog):
             try:
                 channel = await self.bot.fetch_channel(ACTIVITY_SUMMARY_CH)
             except Exception:
-                logging.exception(
+                logger.exception(
                     "[daily_summary] Salon %s introuvable", ACTIVITY_SUMMARY_CH
                 )
                 self._write_summary(
@@ -133,14 +134,14 @@ class DailySummaryPoster(commands.Cog):
                 await channel.fetch_message(message_id)
                 return  # already posted and message exists
             except discord.NotFound:
-                logging.warning(
+                logger.warning(
                     "[daily_summary] Message %s introuvable, re-publication", message_id
                 )
 
         message = self._build_message(data)
         msg = await channel.send(message)
         self._write_summary({"date": data.get("date"), "message_id": msg.id})
-        logging.info("[daily_summary] Classement %s publié", data.get("date"))
+        logger.info("[daily_summary] Classement %s publié", data.get("date"))
 
     # ── Tasks ────────────────────────────────────────────────
     async def _scheduler(self) -> None:
@@ -181,4 +182,3 @@ class DailySummaryPoster(commands.Cog):
 
 async def setup(bot: commands.Bot) -> None:  # pragma: no cover - integration
     await bot.add_cog(DailySummaryPoster(bot))
-

--- a/cogs/first_message.py
+++ b/cogs/first_message.py
@@ -19,6 +19,7 @@ from utils.persistence import (
     ensure_dir,
     read_json_safe,
 )
+logger = logging.getLogger(__name__)
 
 FIRST_WIN_FILE = os.path.join(DATA_DIR, "first_win.json")
 ensure_dir(DATA_DIR)
@@ -46,7 +47,7 @@ class FirstMessageCog(commands.Cog):
                 try:
                     self._save_task.result()
                 except Exception:  # pragma: no cover - logging
-                    logging.exception("[FirstMessage] Échec de la sauvegarde d'état")
+                    logger.exception("[FirstMessage] Échec de la sauvegarde d'état")
             else:
                 self._save_task.cancel()
 
@@ -92,14 +93,14 @@ class FirstMessageCog(commands.Cog):
         task = asyncio.create_task(self._save_state(), name="first_message_save")
         task.add_done_callback(self._handle_save_task_result)
         self._save_task = task
-        logging.info("[FirstMessage] Challenge réinitialisé")
+        logger.info("[FirstMessage] Challenge réinitialisé")
 
     def _handle_save_task_result(self, task: asyncio.Task) -> None:
         """Log les erreurs potentielles de la tâche de sauvegarde."""
         try:
             task.result()
         except Exception:  # pragma: no cover - logging
-            logging.exception("[FirstMessage] Erreur lors de la sauvegarde de l'état")
+            logger.exception("[FirstMessage] Erreur lors de la sauvegarde de l'état")
 
     # ── Tasks ────────────────────────────────────────────────
     @tasks.loop(time=time(hour=8))
@@ -135,7 +136,7 @@ class FirstMessageCog(commands.Cog):
             f"🎉 Félicitations {message.author.mention}, tu es le premier de la journée et tu gagnes 400 XP !",
         )
         await self._save_state()
-        logging.info(
+        logger.info(
             "[FirstMessage] %s a gagné le challenge du premier message", message.author
         )
 

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -15,6 +15,7 @@ from utils.interactions import safe_respond
 from utils.metrics import measure
 from view import PlayerTypeView
 from config import CHANNEL_ROLES, OWNER_ID
+logger = logging.getLogger(__name__)
 
 
 class MiscCog(commands.Cog):
@@ -74,17 +75,17 @@ class MiscCog(commands.Cog):
             try:
                 await interaction.response.defer(thinking=True, ephemeral=True)
             except discord.Forbidden:
-                logging.warning(
+                logger.warning(
                     "Permissions insuffisantes pour différer la réponse de purge."
                 )
             except discord.NotFound:
-                logging.warning(
+                logger.warning(
                     "Interaction de purge introuvable lors du defer."
                 )
             except discord.HTTPException as e:
-                logging.error("Erreur HTTP lors du defer de purge: %s", e)
+                logger.error("Erreur HTTP lors du defer de purge: %s", e)
             except Exception as e:
-                logging.exception("purge defer failed: %s", e)
+                logger.exception("purge defer failed: %s", e)
             if interaction.user.id != OWNER_ID:
                 await interaction.followup.send("❌ Commande réservée au propriétaire.", ephemeral=True)
                 return
@@ -116,17 +117,17 @@ class MiscCog(commands.Cog):
                     )
                     return
             except discord.Forbidden:
-                logging.warning(
+                logger.warning(
                     "Permissions insuffisantes pour la purge en masse."
                 )
             except discord.NotFound:
-                logging.warning(
+                logger.warning(
                     "Salon ou messages introuvables pour la purge en masse."
                 )
             except discord.HTTPException as e:
-                logging.warning("Purge bulk échouée (HTTP): %s", e)
+                logger.warning("Purge bulk échouée (HTTP): %s", e)
             except Exception as e:
-                logging.exception(
+                logger.exception(
                     "Purge bulk échouée, fallback lent. Raison: %s", e
                 )
             count = 0
@@ -138,22 +139,22 @@ class MiscCog(commands.Cog):
                         await msg.delete()
                         count += 1
                     except discord.Forbidden:
-                        logging.warning(
+                        logger.warning(
                             "Permissions insuffisantes pour supprimer un message %s",
                             msg.id,
                         )
                     except discord.NotFound:
-                        logging.warning(
+                        logger.warning(
                             "Message déjà supprimé: %s",
                             msg.id,
                         )
                     except discord.HTTPException as ee:
-                        logging.error(
+                        logger.error(
                             "Erreur HTTP lors de la suppression d'un message: %s",
                             ee,
                         )
                     except Exception as ee:
-                        logging.exception(
+                        logger.exception(
                             "Suppression d'un message échouée: %s",
                             ee,
                         )
@@ -161,24 +162,24 @@ class MiscCog(commands.Cog):
                     f"🧹 {count} messages supprimés (mode lent).", ephemeral=True
                 )
             except discord.Forbidden:
-                logging.warning(
+                logger.warning(
                     "Permissions insuffisantes pour lire l'historique lors de la purge lente."
                 )
                 await interaction.followup.send(
                     "❌ Impossible de supprimer les messages.", ephemeral=True
                 )
             except discord.NotFound:
-                logging.warning("Salon introuvable lors de la purge lente.")
+                logger.warning("Salon introuvable lors de la purge lente.")
                 await interaction.followup.send(
                     "❌ Impossible de supprimer les messages.", ephemeral=True
                 )
             except discord.HTTPException as ee:
-                logging.error("Erreur HTTP lors de la purge lente: %s", ee)
+                logger.error("Erreur HTTP lors de la purge lente: %s", ee)
                 await interaction.followup.send(
                     "❌ Impossible de supprimer les messages.", ephemeral=True
                 )
             except Exception as ee:
-                logging.exception("Erreur inattendue lors de la purge lente: %s", ee)
+                logger.exception("Erreur inattendue lors de la purge lente: %s", ee)
                 await interaction.followup.send(
                     "❌ Impossible de supprimer les messages.", ephemeral=True
                 )

--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -17,6 +17,7 @@ from config import (
 from utils.rename_manager import rename_manager
 from utils.voice import ensure_voice, play_stream
 from view import RadioView
+logger = logging.getLogger(__name__)
 
 
 class RadioCog(commands.Cog):
@@ -33,14 +34,14 @@ class RadioCog(commands.Cog):
 
     async def _connect_and_play(self) -> None:
         if not self.stream_url:
-            logging.warning("RADIO_STREAM_URL non défini")
+            logger.warning("RADIO_STREAM_URL non défini")
             return
         self.voice = await ensure_voice(self.bot, self.vc_id, self.voice)
         play_stream(self.voice, self.stream_url, after=self._after_play)
 
     def _after_play(self, error: Optional[Exception]) -> None:
         if error:
-            logging.warning("Erreur de lecture radio: %s", error)
+            logger.warning("Erreur de lecture radio: %s", error)
         if self._reconnect_task is None or self._reconnect_task.done():
             self._reconnect_task = self.bot.loop.create_task(self._delayed_reconnect())
 
@@ -63,7 +64,7 @@ class RadioCog(commands.Cog):
                         ):
                             return
         except Exception as e:
-            logging.warning("Impossible de vérifier le message radio: %s", e)
+            logger.warning("Impossible de vérifier le message radio: %s", e)
             return
         await channel.send("Changement de radio", view=RadioView())
 

--- a/cogs/rock_radio.py
+++ b/cogs/rock_radio.py
@@ -7,6 +7,7 @@ from discord.ext import commands
 
 from config import ROCK_RADIO_STREAM_URL, ROCK_RADIO_VC_ID
 from utils.voice import ensure_voice, play_stream
+logger = logging.getLogger(__name__)
 
 
 class RockRadioCog(commands.Cog):
@@ -25,14 +26,14 @@ class RockRadioCog(commands.Cog):
 
     async def _connect_and_play(self) -> None:
         if not self.stream_url:
-            logging.warning("ROCK_RADIO_STREAM_URL non défini")
+            logger.warning("ROCK_RADIO_STREAM_URL non défini")
             return
         self.voice = await ensure_voice(self.bot, self.vc_id, self.voice)
         play_stream(self.voice, self.stream_url, after=self._after_play)
 
     def _after_play(self, error: Optional[Exception]) -> None:
         if error:
-            logging.warning("Erreur de lecture rock radio: %s", error)
+            logger.warning("Erreur de lecture rock radio: %s", error)
         if self._reconnect_task is None or self._reconnect_task.done():
             self._reconnect_task = self.bot.loop.create_task(self._delayed_reconnect())
 

--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -18,6 +18,7 @@ from config import (
 from storage.temp_vc_store import load_temp_vc_ids, save_temp_vc_ids
 from utils.temp_vc_cleanup import delete_untracked_temp_vcs, TEMP_VC_NAME_RE
 from utils.rename_manager import rename_manager
+logger = logging.getLogger(__name__)
 
 # IDs des salons vocaux temporaires connus
 TEMP_VC_IDS: Set[int] = set(load_temp_vc_ids())
@@ -55,7 +56,7 @@ class TempVCCog(commands.Cog):
         if rename_manager._worker is None:
             async def _ensure_rename_worker() -> None:
                 await rename_manager.start()
-                logging.info("[temp_vc] rename_manager worker démarré")
+                logger.info("[temp_vc] rename_manager worker démarré")
 
             asyncio.create_task(_ensure_rename_worker())
 
@@ -193,7 +194,7 @@ class TempVCCog(commands.Cog):
                 try:
                     await before.channel.delete(reason="Salon temporaire vide")
                 except discord.HTTPException:
-                    logging.exception(
+                    logger.exception(
                         "Suppression du salon %s échouée", before.channel.id
                     )
                 else:
@@ -237,4 +238,3 @@ class TempVCCog(commands.Cog):
 
 async def setup(bot: commands.Bot) -> None:
     await bot.add_cog(TempVCCog(bot))
-

--- a/cogs/voice_double_xp.py
+++ b/cogs/voice_double_xp.py
@@ -26,6 +26,7 @@ from config import (
 )
 from utils.persistence import read_json_safe, atomic_write_json_async, ensure_dir
 from utils.voice_bonus import set_voice_bonus
+logger = logging.getLogger(__name__)
 
 try:
     from zoneinfo import ZoneInfo
@@ -49,7 +50,7 @@ def _read_state() -> dict:
     try:
         return read_json_safe(STATE_FILE)
     except Exception:  # pragma: no cover - unexpected error
-        logging.exception("[double_xp] failed to read state file")
+        logger.exception("[double_xp] failed to read state file")
         return {}
 
 
@@ -58,7 +59,7 @@ async def _write_state(data: dict) -> None:
     try:
         await atomic_write_json_async(STATE_FILE, data)
     except Exception:  # pragma: no cover - disk errors
-        logging.exception("[double_xp] failed to write state file")
+        logger.exception("[double_xp] failed to write state file")
 
 
 def _random_sessions() -> List[str]:
@@ -187,7 +188,7 @@ class DoubleVoiceXP(commands.Cog):
         session["end"] = end_dt.isoformat()
         await _write_state(self.state)
         set_voice_bonus(True)
-        logging.info(
+        logger.info(
             "[double_xp] session started at %s", end_dt.isoformat()
         )
         channel = self.bot.get_channel(XP_DOUBLE_VOICE_ANNOUNCE_CHANNEL_ID)
@@ -197,7 +198,7 @@ class DoubleVoiceXP(commands.Cog):
                     "Hey 🎉 À partir de maintenant, c’est DOUBLE XP en vocal ! Profitez-en 😉"
                 )
             except Exception as e:  # pragma: no cover - network errors
-                logging.warning("[double_xp] Failed to send start message: %s", e)
+                logger.warning("[double_xp] Failed to send start message: %s", e)
 
     async def _end_session(
         self, session: Dict[str, Any], announce: bool = True
@@ -208,7 +209,7 @@ class DoubleVoiceXP(commands.Cog):
         session["ended"] = True
         await _write_state(self.state)
         set_voice_bonus(False)
-        logging.info("[double_xp] session ended")
+        logger.info("[double_xp] session ended")
         channel = self.bot.get_channel(XP_DOUBLE_VOICE_ANNOUNCE_CHANNEL_ID)
         if announce and channel:
             try:
@@ -216,7 +217,7 @@ class DoubleVoiceXP(commands.Cog):
                     "✅ La session Double XP vocale est terminée pour aujourd’hui, merci à ceux qui étaient présents !"
                 )
             except Exception as e:  # pragma: no cover - network errors
-                logging.warning("[double_xp] Failed to send end message: %s", e)
+                logger.warning("[double_xp] Failed to send end message: %s", e)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/cogs/welcome.py
+++ b/cogs/welcome.py
@@ -4,6 +4,7 @@ import discord
 from discord.ext import commands
 
 from config import CHANNEL_ROLES, CHANNEL_WELCOME
+logger = logging.getLogger(__name__)
 
 
 class WelcomeCog(commands.Cog):
@@ -27,20 +28,20 @@ class WelcomeCog(commands.Cog):
                     "Ravi de t’avoir parmi nous ! 🎮"
                 )
             except discord.Forbidden:
-                logging.warning(
+                logger.warning(
                     "[welcome] Permissions insuffisantes pour envoyer le message de bienvenue"
                 )
             except discord.NotFound:
-                logging.warning(
+                logger.warning(
                     "[welcome] Salon de bienvenue introuvable pour l'envoi du message"
                 )
             except discord.HTTPException as e:
-                logging.error(
+                logger.error(
                     "[welcome] Erreur HTTP lors de l'envoi du message de bienvenue: %s",
                     e,
                 )
             except Exception:
-                logging.exception(
+                logger.exception(
                     "[welcome] Échec d'envoi du message de bienvenue pour %s", member.id
                 )
 

--- a/main.py
+++ b/main.py
@@ -1,9 +1,33 @@
 from __future__ import annotations
 
+import logging
 import os
+from typing import Optional
+
 import discord
 
 from bot import RefugeBot
+
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+)
+
+
+class DiscordCriticalHandler(logging.Handler):
+    def __init__(self, bot: discord.Client, channel_id: int) -> None:
+        super().__init__(level=logging.CRITICAL)
+        self.bot = bot
+        self.channel_id = channel_id
+
+    async def _send(self, message: str) -> None:
+        channel = self.bot.get_channel(self.channel_id)
+        if channel:
+            await channel.send(f"```{message}```")
+
+    def emit(self, record: logging.LogRecord) -> None:
+        self.bot.loop.create_task(self._send(self.format(record)))
 
 
 def main() -> None:
@@ -12,6 +36,15 @@ def main() -> None:
     if not token:
         raise RuntimeError("DISCORD_TOKEN environment variable not set")
     bot = RefugeBot(command_prefix="!", intents=intents)
+
+    channel_id: Optional[str] = os.getenv("CRITICAL_LOG_CHANNEL_ID")
+    if channel_id:
+        handler = DiscordCriticalHandler(bot, int(channel_id))
+        handler.setFormatter(
+            logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+        )
+        logging.getLogger().addHandler(handler)
+
     bot.run(token)
 
 


### PR DESCRIPTION
## Summary
- configure structured INFO-level logging in main entrypoint
- add optional Discord channel handler for critical logs
- ensure all cogs use module-level `logging.getLogger(__name__)`

## Testing
- `ruff check .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa5c21a8288324b6eb4bc907f1b5eb