### PR TITLE
Fix APIMeter start invocation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -38,7 +38,7 @@ class RefugeBot(commands.Bot):
         await xp_store.start()
         await rename_manager.start()
         await channel_edit_manager.start()
-        await api_meter.start()
+        await api_meter.start(self)
         limiter.start()
         await reset_http_error_counter()
 

--- a/tests/test_setup_hook_adds_view.py
+++ b/tests/test_setup_hook_adds_view.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import asyncio
 import discord
 import pytest
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 os.environ.setdefault("DISCORD_TOKEN", "dummy")
@@ -38,9 +38,9 @@ async def test_setup_hook_registers_player_type_view_once(monkeypatch):
     await test_bot.setup_hook()
     # Second call should be idempotent
     await test_bot.setup_hook()
-
     add_view_mock.assert_called_once()
     assert isinstance(add_view_mock.call_args.args[0], view.PlayerTypeView)
+    bot.api_meter.start.assert_has_awaits([call(test_bot), call(test_bot)])
 
     # Simulate a restart with a new instance
     other_bot = bot.RefugeBot(command_prefix="!", intents=intents)
@@ -52,7 +52,7 @@ async def test_setup_hook_registers_player_type_view_once(monkeypatch):
     monkeypatch.setattr(other_bot, "add_view", add_view_mock2)
 
     await other_bot.setup_hook()
-
     add_view_mock2.assert_called_once()
     assert isinstance(add_view_mock2.call_args.args[0], view.PlayerTypeView)
+    bot.api_meter.start.assert_has_awaits([call(test_bot), call(test_bot), call(other_bot)])
 

--- a/tests/test_setup_hook_syncs_tree.py
+++ b/tests/test_setup_hook_syncs_tree.py
@@ -33,5 +33,5 @@ async def test_setup_hook_syncs_tree(monkeypatch):
     monkeypatch.setattr(test_bot.tree, "sync", sync_mock)
 
     await test_bot.setup_hook()
-
+    bot.api_meter.start.assert_awaited_once_with(test_bot)
     sync_mock.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Pass the bot instance to the API meter's `start` method to avoid missing-argument errors
- Extend setup_hook tests to assert the API meter is started with the bot

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa5f2984f48324a5dea42797caac47