### PR TITLE
feat: auto-start radio cog

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -32,6 +32,14 @@ class RadioCog(commands.Cog):
         self._original_name: Optional[str] = None
         self._previous_stream: Optional[str] = None
 
+    async def cog_load(self) -> None:
+        """Connecte la radio si le bot est déjà prêt lors du chargement du cog."""
+        if self.bot.is_ready():
+            text_channel = self.bot.get_channel(RADIO_TEXT_CHANNEL_ID)
+            if isinstance(text_channel, discord.abc.Messageable):
+                await self._ensure_radio_message(text_channel)
+            await self._connect_and_play()
+
     async def _connect_and_play(self) -> None:
         if not self.stream_url:
             logger.warning("RADIO_STREAM_URL non défini")

--- a/tests/test_radio_cog_load.py
+++ b/tests/test_radio_cog_load.py
@@ -1,0 +1,35 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cogs.radio import RadioCog
+
+
+@pytest.mark.asyncio
+async def test_cog_load_connects_when_bot_ready(monkeypatch):
+    bot = SimpleNamespace(
+        loop=asyncio.get_event_loop(),
+        is_ready=lambda: True,
+        get_channel=lambda cid: object(),
+    )
+    cog = RadioCog(bot)
+    cog._connect_and_play = AsyncMock()
+    cog._ensure_radio_message = AsyncMock()
+    import cogs.radio as radio_mod
+    monkeypatch.setattr(radio_mod.discord.abc, "Messageable", object)
+    await cog.cog_load()
+    cog._connect_and_play.assert_awaited_once()
+    cog._ensure_radio_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cog_load_skips_when_bot_not_ready():
+    bot = SimpleNamespace(loop=asyncio.get_event_loop(), is_ready=lambda: False)
+    cog = RadioCog(bot)
+    cog._connect_and_play = AsyncMock()
+    cog._ensure_radio_message = AsyncMock()
+    await cog.cog_load()
+    cog._connect_and_play.assert_not_called()
+    cog._ensure_radio_message.assert_not_called()


### PR DESCRIPTION
## Summary
- ensure RadioCog connects and posts control message when loaded after bot readiness
- add regression tests for RadioCog cog_load behavior

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa66cd90948324ae65df89838470e3