### PR TITLE
refactor: improve voice and game event handling

### DIFF
--- a/cogs/game_events.py
+++ b/cogs/game_events.py
@@ -149,7 +149,11 @@ class GameEventsCog(commands.Cog):
             creator = guild.get_member(evt.creator_id)
             name = f"👥 {creator.display_name if creator else 'Joueur'}・{evt.game_name}"
             category = guild.get_channel(TEMP_VC_CATEGORY)
-            vc = await guild.create_voice_channel(name, category=category)
+            try:
+                vc = await guild.create_voice_channel(name, category=category)
+            except discord.HTTPException as e:
+                logger.error("[game] création salon échouée pour %s: %s", evt.id, e)
+                return
             set_voice_channel(evt, vc.id)
             await save_event(evt)
             for uid, status in evt.rsvps.items():

--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -132,8 +132,9 @@ class TempVCCog(commands.Cog):
             status = "Endormie"
         else:
             status = "Chat"
-
-        return f"{base} • {status}"
+        name = f"{base} • {status}"
+        # Discord limite les noms de salon à 100 caractères
+        return name[:100]
 
     async def _rename_channel(self, channel: discord.VoiceChannel) -> None:
         """Tâche différée effectuant le renommage du salon."""
@@ -249,6 +250,9 @@ class TempVCCog(commands.Cog):
                     )
                     TEMP_VC_IDS.discard(before.channel.id)
                     self._last_names.pop(before.channel.id, None)
+                    task = self._rename_tasks.pop(before.channel.id, None)
+                    if task:
+                        task.cancel()
                     save_temp_vc_ids(TEMP_VC_IDS)
 
         # 3) Renommage sur changement d'état vocal

--- a/tests/test_game_events_voice_channel.py
+++ b/tests/test_game_events_voice_channel.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import discord
 
 # Ensure project root is on sys.path when running this test in isolation
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -90,3 +91,44 @@ async def test_voice_channel_created_without_rsvp(monkeypatch):
     guild.create_voice_channel.assert_awaited_once()
     assert evt.voice_channel_id == vc.id
     assert evt.state == "waiting"
+
+
+@pytest.mark.asyncio
+async def test_voice_channel_creation_http_exception(monkeypatch):
+    EVENTS.clear()
+    now = datetime.now(timezone.utc)
+    evt = GameEvent(
+        id="e3",
+        guild_id=1,
+        creator_id=42,
+        game_type="FPS",
+        game_name="Apex",
+        time=now + timedelta(minutes=5),
+        channel_id=123,
+        message_id=456,
+    )
+    evt.rsvps = {"1": "yes"}
+    evt.reminder_sent = True
+
+    member_creator = SimpleNamespace(id=42, display_name="Alice", send=AsyncMock())
+    members = {42: member_creator, 1: SimpleNamespace(id=1, send=AsyncMock())}
+    http_exc = discord.HTTPException(SimpleNamespace(status=500, reason="fail"), "fail")
+    guild = SimpleNamespace(
+        get_member=lambda uid: members.get(uid),
+        create_voice_channel=AsyncMock(side_effect=http_exc),
+        get_channel=lambda cid: None,
+    )
+    bot = SimpleNamespace(get_guild=lambda gid: guild, add_view=lambda *a, **k: None)
+
+    with patch.object(game_cog.tasks.Loop, "start", lambda self, *a, **k: None):
+        with patch("cogs.game_events.load_events", lambda: None):
+            cog = game_cog.GameEventsCog(bot)
+
+    save_mock = AsyncMock()
+    with patch("cogs.game_events.save_event", save_mock):
+        await cog._process_event(evt, now)
+
+    guild.create_voice_channel.assert_awaited_once()
+    assert evt.voice_channel_id is None
+    assert evt.state == "scheduled"
+    save_mock.assert_not_awaited()

--- a/tests/test_temp_vc_channel_name_length.py
+++ b/tests/test_temp_vc_channel_name_length.py
@@ -1,0 +1,30 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import discord
+import pytest
+
+import cogs.temp_vc as temp_vc
+
+
+@pytest.mark.asyncio
+async def test_channel_name_truncated(monkeypatch):
+    loop = asyncio.get_running_loop()
+    bot = SimpleNamespace(get_channel=lambda _id: None, loop=loop)
+    monkeypatch.setattr(temp_vc.rename_manager, "start", AsyncMock())
+    monkeypatch.setattr(temp_vc, "save_temp_vc_ids", lambda ids: None)
+
+    with patch.object(temp_vc.tasks.Loop, "start", lambda self, *a, **k: None):
+        cog = temp_vc.TempVCCog(bot)
+
+    long_name = "X" * 150
+    player = SimpleNamespace(activities=[discord.Game(long_name)], voice=SimpleNamespace(self_mute=False))
+    channel = SimpleNamespace(members=[player])
+
+    cog._base_name_from_members = lambda members: "Base"
+
+    name = cog._compute_channel_name(channel)
+    assert len(name) == 100
+    assert name == "Base • " + long_name[:93]
+

--- a/utils/voice.py
+++ b/utils/voice.py
@@ -5,6 +5,8 @@ import discord
 
 from utils.audio import FFMPEG_BEFORE, FFMPEG_OPTIONS
 
+logger = logging.getLogger(__name__)
+
 
 async def fetch_voice_channel(
     bot: discord.Client, vc_id: int
@@ -20,7 +22,7 @@ async def fetch_voice_channel(
         except discord.HTTPException:
             channel = None
     if not isinstance(channel, discord.VoiceChannel):
-        logging.warning("Salon vocal %s introuvable", vc_id)
+        logger.warning("Salon vocal %s introuvable", vc_id)
         return None
     return channel
 
@@ -49,19 +51,19 @@ async def ensure_voice(
             else:
                 voice = await channel.connect(reconnect=True)
         except discord.Forbidden:
-            logging.warning(
+            logger.warning(
                 "Permissions insuffisantes pour se connecter au salon %s", vc_id
             )
         except discord.NotFound:
-            logging.warning(
+            logger.warning(
                 "Salon %s introuvable lors de la connexion", vc_id
             )
         except discord.HTTPException as e:
-            logging.error(
+            logger.error(
                 "Erreur HTTP lors de la connexion au salon %s: %s", vc_id, e
             )
         except Exception as e:  # pragma: no cover - sécurité supplémentaire
-            logging.exception(
+            logger.exception(
                 "Connexion au salon %s échouée: %s", vc_id, e
             )
     return voice


### PR DESCRIPTION
## Summary
- use module logger in voice utilities
- truncate long temporary voice channel names and cancel rename tasks on deletion
- guard game event voice channel creation against HTTP errors

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aa66eb8e2c8324b6067a875806c538