### PR TITLE
fix: cancel rename task after deleting temporary channel

### DIFF
--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -241,6 +241,9 @@ class TempVCCog(commands.Cog):
                         "Suppression du salon %s échouée", before.channel.id
                     )
                 else:
+                    task = self._rename_tasks.pop(before.channel.id, None)
+                    if task:
+                        task.cancel()
                     logger.info(
                         "[temp_vc] deleted temporary channel '%s' (ID %s) after %s (%s) left",
                         before.channel.name,
@@ -250,9 +253,6 @@ class TempVCCog(commands.Cog):
                     )
                     TEMP_VC_IDS.discard(before.channel.id)
                     self._last_names.pop(before.channel.id, None)
-                    task = self._rename_tasks.pop(before.channel.id, None)
-                    if task:
-                        task.cancel()
                     save_temp_vc_ids(TEMP_VC_IDS)
 
         # 3) Renommage sur changement d'état vocal


### PR DESCRIPTION
## Summary
- cancel pending rename task when deleting an empty temporary voice channel
- test that rename task is popped and cancelled on deletion

## Testing
- `PYTHONPATH=. pytest tests/test_temp_vc_cleanup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa690a08588324a44af8766590ca29