### PR TITLE
Handle Discord's 100-character limit for temp voice channel names

### DIFF
--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -127,7 +127,10 @@ class TempVCCog(commands.Cog):
                 break
 
         if game_name:
-            status = game_name
+            # Discord limite les noms de salon à 100 caractères ; on réserve
+            # l'espace pour la base et le séparateur «  • ».
+            max_status_len = 100 - len(base) - 3
+            status = game_name[:max_status_len]
         elif any(m.voice and m.voice.self_mute for m in channel.members):
             status = "Endormie"
         else:

--- a/tests/test_temp_vc_long_game_trunc.py
+++ b/tests/test_temp_vc_long_game_trunc.py
@@ -1,0 +1,30 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import discord
+import pytest
+
+import cogs.temp_vc as temp_vc
+
+
+@pytest.mark.asyncio
+async def test_long_game_name_truncated(monkeypatch):
+    loop = asyncio.get_running_loop()
+    bot = SimpleNamespace(get_channel=lambda _id: None, loop=loop)
+    monkeypatch.setattr(temp_vc.rename_manager, "start", AsyncMock())
+    monkeypatch.setattr(temp_vc, "save_temp_vc_ids", lambda ids: None)
+
+    with patch.object(temp_vc.tasks.Loop, "start", lambda self, *a, **k: None):
+        cog = temp_vc.TempVCCog(bot)
+
+    long_name = "Y" * 200
+    player = SimpleNamespace(activities=[discord.Game(long_name)], voice=SimpleNamespace(self_mute=False))
+    channel = SimpleNamespace(members=[player])
+
+    cog._base_name_from_members = lambda members: "PC"
+
+    name = cog._compute_channel_name(channel)
+    expected_len = 100 - len("PC • ")
+    assert len(name) == 100
+    assert name == "PC • " + long_name[:expected_len]


### PR DESCRIPTION
## Summary
- Trim game-based status to respect Discord's 100 character channel name limit
- Document the constraint in code
- Test channel name generation with an extremely long game name

## Testing
- `PYTHONPATH=. pytest tests/test_temp_vc_channel_name_length.py tests/test_temp_vc_long_game_trunc.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aa69d5222c83249415583e6388b111