### PR TITLE
Load temp voice channel cog

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -45,6 +45,7 @@ class RefugeBot(commands.Bot):
         # Load Machine à sous cog.  ``load_extension`` is patched to an
         # ``AsyncMock`` in the tests, so awaiting is safe.
         await self.load_extension("cogs.machine_a_sous")
+        await self.load_extension("cogs.temp_vc")
         await self.tree.sync()
 
         # Register persistent views. ``add_view`` can only be called once per


### PR DESCRIPTION
## Summary
- load temporary voice channel cog in RefugeBot

## Testing
- `ruff check bot.py`
- `pytest -q`
- `mypy bot.py` *(fails: command hung)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6d08e1048324a8e9b66af3c10072