### PR TITLE
Persist and reuse radio message

### DIFF
--- a/storage/radio_store.py
+++ b/storage/radio_store.py
@@ -1,0 +1,38 @@
+import json
+import logging
+from pathlib import Path
+from typing import Optional
+
+from utils.persist import atomic_write_json
+
+
+class RadioStore:
+    def __init__(self, data_dir: str):
+        self.data_file = Path(data_dir) / "radio.json"
+        Path(data_dir).mkdir(parents=True, exist_ok=True)
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            with self.data_file.open("r", encoding="utf-8") as f:
+                self.data = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            self.data = {}
+            self._save()
+
+    def _save(self) -> None:
+        try:
+            atomic_write_json(self.data_file, self.data)
+        except Exception as e:
+            logging.error("[RadioStore] Écriture échouée pour %s: %s", self.data_file, e)
+
+    def set_radio_message(self, channel_id: str, message_id: str) -> None:
+        self.data["message"] = {"channel_id": channel_id, "message_id": message_id}
+        self._save()
+
+    def get_radio_message(self) -> Optional[dict]:
+        return self.data.get("message")
+
+    def clear_radio_message(self) -> None:
+        self.data.pop("message", None)
+        self._save()

--- a/tests/test_radio_message_fetch.py
+++ b/tests/test_radio_message_fetch.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+from cogs.radio import RadioCog
+
+
+@pytest.mark.asyncio
+async def test_ensure_radio_message_uses_stored_id():
+    bot = SimpleNamespace(user=SimpleNamespace(id=1))
+    cog = RadioCog(bot)
+    channel = SimpleNamespace(id=123)
+    cog.store.set_radio_message(str(channel.id), "456")
+
+    btn = discord.ui.Button(custom_id="radio_24")
+    row = SimpleNamespace(children=[btn])
+    msg = SimpleNamespace(components=[row])
+
+    channel.fetch_message = AsyncMock(return_value=msg)
+    channel.history = AsyncMock()
+    channel.send = AsyncMock()
+
+    await cog._ensure_radio_message(channel)
+
+    channel.fetch_message.assert_awaited_once_with(456)
+    channel.history.assert_not_called()
+    channel.send.assert_not_called()


### PR DESCRIPTION
## Summary
- Add `RadioStore` to persist radio message IDs
- Update `RadioCog` to fetch and reuse stored message before scanning history
- Test that stored radio message is fetched instead of sending a new one

## Testing
- `ruff check cogs/radio.py storage/radio_store.py tests/test_radio_message_fetch.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa6dd362ec8324b76083722ff1d0b6