### PR TITLE
feat: configure Roulette Refuge data

### DIFF
--- a/data/pari_xp/config.json
+++ b/data/pari_xp/config.json
@@ -3,5 +3,37 @@
   "min_bet": 5,
   "cooldown_seconds": 15,
   "daily_bet_cap": 20,
-  "min_balance": 10
+  "min_balance": 10,
+  "enabled": true,
+  "channel_id": 1408834276228730900,
+  "game_display_name": "🤑 Roulette Refuge",
+  "timezone": "Europe/Paris",
+  "open_hour": 8,
+  "last_call_hour": 1,
+  "last_call_minute": 45,
+  "close_hour": 2,
+  "max_bet": null,
+  "daily_cap": 20,
+  "min_account_age_days": 2,
+  "min_balance_guard": 10,
+  "leaderboard_refresh_minutes": 7,
+  "announce_super_jackpot_ping_here": true,
+  "announce_big_win_mult_threshold": 5,
+  "announce_big_loss_xp_threshold": 100,
+  "probabilities": {
+    "lose_0x": 0.40,
+    "half_0_5x": 0.18,
+    "even_1x": 0.14,
+    "win_2x": 0.14,
+    "win_5x": 0.09,
+    "win_10x": 0.03,
+    "ticket_free": 0.003,
+    "double_xp_1h": 0.007,
+    "super_jackpot_plus_1000": 0.003
+  },
+  "segments_enabled": {
+    "ticket_free": true,
+    "double_xp_1h": true,
+    "xp_shared": false
+  }
 }

--- a/data/pari_xp/leaderboard.json
+++ b/data/pari_xp/leaderboard.json
@@ -1,1 +1,18 @@
-{}
+{
+  "month": null,
+  "top_net_gainers": [],
+  "top_net_losers": [],
+  "top_biggest_single_win": [],
+  "streaks": {
+    "win": [],
+    "loss": []
+  },
+  "daily_summary_cache": {
+    "date": null,
+    "top3_gainers": [],
+    "top3_losers": [],
+    "biggest_single_win": null,
+    "total_bet": 0,
+    "total_redistributed": 0
+  }
+}

--- a/data/pari_xp/state.json
+++ b/data/pari_xp/state.json
@@ -1,4 +1,8 @@
 {
   "hub_message_id": null,
-  "leaderboard_message_id": null
+  "leaderboard_message_id": null,
+  "is_open": false,
+  "last_open_announce_ts": null,
+  "last_close_announce_ts": null,
+  "last_lastcall_announce_ts": null
 }


### PR DESCRIPTION
## Summary
- add full Roulette Refuge configuration with probabilities, limits and announcements
- track open/close state and leaderboards

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aad09b4c608324bb035ba7bd9fa4d0