### PR TITLE
Add minimal utils stubs for XP roulette feature

### DIFF
--- a/main/utils/storage.py
+++ b/main/utils/storage.py
@@ -1,0 +1,14 @@
+import json
+import os
+def load_json(path, default):
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return default
+
+def save_json(path, data):
+    tmp = path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+    os.replace(tmp, path)

--- a/main/utils/timezones.py
+++ b/main/utils/timezones.py
@@ -1,0 +1,2 @@
+from zoneinfo import ZoneInfo
+TZ_PARIS = ZoneInfo("Europe/Paris")

--- a/main/utils/xp_adapter.py
+++ b/main/utils/xp_adapter.py
@@ -1,0 +1,15 @@
+def get_user_xp(user_id: int) -> int:
+    """Retourne le solde XP actuel du joueur. TODO: brancher au système XP."""
+    raise NotImplementedError
+
+def add_user_xp(user_id: int, amount: int, reason: str = "pari_xp") -> None:
+    """Crédite/débite XP (+/-). TODO: brancher au système XP."""
+    raise NotImplementedError
+
+def get_user_account_age_days(user_id: int) -> int:
+    """Retourne l'ancienneté du compte en jours. TODO."""
+    raise NotImplementedError
+
+def apply_double_xp_buff(user_id: int, minutes: int = 60) -> None:
+    """Placeholder, ne rien implémenter réellement."""
+    raise NotImplementedError


### PR DESCRIPTION
## Summary
- add stub storage, timezone, and XP adapter utilities for new XP roulette feature
- split storage imports to satisfy style check

## Testing
- `pytest`
- `ruff check main/utils/storage.py main/utils/timezones.py main/utils/xp_adapter.py`


------
https://chatgpt.com/codex/tasks/task_e_68aad26b9e948324b6778f05b4ea75a7