### PR TITLE
feat: route roulette announcements to dedicated channel

### DIFF
--- a/main/data/pari_xp/config.json
+++ b/main/data/pari_xp/config.json
@@ -6,6 +6,7 @@
   "min_balance": 10,
   "enabled": true,
   "channel_id": 1408834276228730900,
+  "announce_channel_id": 1400552164979507263,
   "game_display_name": "🤑 Roulette Refuge",
   "timezone": "Europe/Paris",
   "open_hour": 8,


### PR DESCRIPTION
## Summary
- support dedicated announce channel for roulette
- announce open/close/last call and big wins in announce channel

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aaf5e6b7a483249776a3b6c6804fe3