### PR TITLE
Use asyncio loop-independent tasks and fix xp adapter import

### DIFF
--- a/cogs/daily_awards.py
+++ b/cogs/daily_awards.py
@@ -54,8 +54,8 @@ class DailyAwards(commands.Cog):
         self.bot = bot
         self._task = None
         if ENABLE_DAILY_AWARDS:
-            self._task = self.bot.loop.create_task(self._scheduler())
-            self.bot.loop.create_task(self._startup_check())
+            self._task = asyncio.create_task(self._scheduler())
+            asyncio.create_task(self._startup_check())
 
     def cog_unload(self) -> None:  # pragma: no cover - cleanup
         if self._task:

--- a/cogs/daily_ranking.py
+++ b/cogs/daily_ranking.py
@@ -40,7 +40,7 @@ class DailyRankingAndRoles(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self._task = self.bot.loop.create_task(self._scheduler())
+        self._task = asyncio.create_task(self._scheduler())
 
     def cog_unload(self) -> None:
         self._task.cancel()

--- a/cogs/daily_summary_poster.py
+++ b/cogs/daily_summary_poster.py
@@ -49,8 +49,8 @@ class DailySummaryPoster(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self._task = self.bot.loop.create_task(self._scheduler())
-        self.bot.loop.create_task(self._startup_check())
+        self._task = asyncio.create_task(self._scheduler())
+        asyncio.create_task(self._startup_check())
 
     def cog_unload(self) -> None:  # pragma: no cover - cleanup
         self._task.cancel()

--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -576,7 +576,7 @@ class MachineASousCog(commands.Cog):
             self.bot.add_view(MachineASousView())
         except Exception as e:
             logger.error("[MachineASous] add_view échoué: %s", e)
-        self.bot.loop.create_task(self._init_after_ready())
+        asyncio.create_task(self._init_after_ready())
 
     async def cog_unload(self):
         self.maintenance_loop.cancel()

--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -53,7 +53,7 @@ class RadioCog(commands.Cog):
                 "Connexion au salon vocal échouée, nouvelle tentative planifiée"
             )
             if self._reconnect_task is None or self._reconnect_task.done():
-                self._reconnect_task = self.bot.loop.create_task(
+                self._reconnect_task = asyncio.create_task(
                     self._delayed_reconnect()
                 )
             return
@@ -63,7 +63,7 @@ class RadioCog(commands.Cog):
         if error:
             logger.warning("Erreur de lecture radio: %s", error)
         if self._reconnect_task is None or self._reconnect_task.done():
-            self._reconnect_task = self.bot.loop.create_task(self._delayed_reconnect())
+            self._reconnect_task = asyncio.create_task(self._delayed_reconnect())
 
     async def _delayed_reconnect(self) -> None:
         await asyncio.sleep(5)
@@ -223,7 +223,7 @@ class RadioCog(commands.Cog):
     ) -> None:
         if member.id == self.bot.user.id and after.channel is None:
             if self._reconnect_task is None or self._reconnect_task.done():
-                self._reconnect_task = self.bot.loop.create_task(
+                self._reconnect_task = asyncio.create_task(
                     self._delayed_reconnect()
                 )
             return
@@ -237,7 +237,7 @@ class RadioCog(commands.Cog):
         if self._reconnect_task and not self._reconnect_task.done():
             self._reconnect_task.cancel()
         if self.voice and self.voice.is_connected():
-            self.bot.loop.create_task(self.voice.disconnect())
+            asyncio.create_task(self.voice.disconnect())
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/cogs/rock_radio.py
+++ b/cogs/rock_radio.py
@@ -35,7 +35,7 @@ class RockRadioCog(commands.Cog):
         if error:
             logger.warning("Erreur de lecture rock radio: %s", error)
         if self._reconnect_task is None or self._reconnect_task.done():
-            self._reconnect_task = self.bot.loop.create_task(self._delayed_reconnect())
+            self._reconnect_task = asyncio.create_task(self._delayed_reconnect())
 
     async def _delayed_reconnect(self) -> None:
         await asyncio.sleep(5)
@@ -54,7 +54,7 @@ class RockRadioCog(commands.Cog):
     ) -> None:
         if member.id == self.bot.user.id and after.channel is None:
             if self._reconnect_task is None or self._reconnect_task.done():
-                self._reconnect_task = self.bot.loop.create_task(
+                self._reconnect_task = asyncio.create_task(
                     self._delayed_reconnect()
                 )
             return
@@ -68,7 +68,7 @@ class RockRadioCog(commands.Cog):
         if self._reconnect_task and not self._reconnect_task.done():
             self._reconnect_task.cancel()
         if self.voice and self.voice.is_connected():
-            self.bot.loop.create_task(self.voice.disconnect())
+            asyncio.create_task(self.voice.disconnect())
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -175,7 +175,7 @@ class TempVCCog(commands.Cog):
             task.cancel()
         if not await self._ensure_rename_worker():
             return
-        new_task = self.bot.loop.create_task(self._rename_channel(channel))
+        new_task = asyncio.create_task(self._rename_channel(channel))
         self._rename_tasks[channel.id] = new_task
 
     async def _create_temp_vc(self, member: discord.Member) -> discord.VoiceChannel:

--- a/cogs/voice_double_xp.py
+++ b/cogs/voice_double_xp.py
@@ -88,7 +88,7 @@ class DoubleVoiceXP(commands.Cog):
         self._tasks: List[asyncio.Task] = []
         self.state: Dict[str, Any] = {}
         self.daily_planner.start()
-        self.bot.loop.create_task(self._startup())
+        asyncio.create_task(self._startup())
 
     async def _startup(self) -> None:
         """Attendre le démarrage du bot et préparer les sessions du jour."""
@@ -157,13 +157,13 @@ class DoubleVoiceXP(commands.Cog):
         if end_dt <= now:
             return
         delay = max(0, (dt - now).total_seconds())
-        task = self.bot.loop.create_task(self._run_session(session, delay))
+        task = asyncio.create_task(self._run_session(session, delay))
         self._tasks.append(task)
 
     def _resume_session(self, session: Dict[str, Any], delay: float) -> None:
         """Reprendre une session déjà démarrée et programmée pour se terminer."""
         set_voice_bonus(True)
-        task = self.bot.loop.create_task(self._finish_session(session, delay))
+        task = asyncio.create_task(self._finish_session(session, delay))
         self._tasks.append(task)
 
     async def _finish_session(self, session: Dict[str, Any], delay: float) -> None:

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 from typing import Optional
@@ -27,7 +28,7 @@ class DiscordCriticalHandler(logging.Handler):
             await channel.send(f"```{message}```")
 
     def emit(self, record: logging.LogRecord) -> None:
-        self.bot.loop.create_task(self._send(self.format(record)))
+        asyncio.create_task(self._send(self.format(record)))
 
 
 def main() -> None:

--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -7,9 +7,12 @@ from typing import Optional
 from zoneinfo import ZoneInfo
 from discord import ui
 from discord import app_commands
-from utils.xp_adapter import get_user_xp, get_user_account_age_days
+from main.utils.xp_adapter import (
+    get_user_xp,
+    get_user_account_age_days,
+    add_user_xp,
+)
 import random
-from utils.xp_adapter import add_user_xp
 import inspect
 import re
 


### PR DESCRIPTION
## Summary
- replace deprecated `self.bot.loop.create_task` with `asyncio.create_task`
- import xp adapter from `main.utils` to avoid module collision

## Testing
- `python -m pytest`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_68aafe00a170832499148be0f064f22c