### PR TITLE
Load pari_xp cog and package main

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -61,6 +61,9 @@ class RefugeBot(commands.Bot):
             if required not in loaded_names:
                 await self.load_extension(f"cogs.{required}")
 
+        # Explicitly load the pari_xp cog from the main package
+        await self.load_extension("main.cogs.pari_xp")
+
         # Sync application commands. Use guild-specific sync when ``GUILD_ID``
         # is defined so commands appear instantly on that server.
         if GUILD_ID:

--- a/main/__init__.py
+++ b/main/__init__.py
@@ -1,0 +1,1 @@
+"""Main package for additional cogs and utilities."""

--- a/main/cogs/__init__.py
+++ b/main/cogs/__init__.py
@@ -1,0 +1,1 @@
+"""Cogs for the main application."""


### PR DESCRIPTION
## Summary
- make `main` and its cogs a proper Python package
- load `main.cogs.pari_xp` during bot setup

## Testing
- `ruff check .`
- `pytest`
- `mypy bot.py main/__init__.py main/cogs/__init__.py` *(fails: incompatible types in utils/rate_limit.py)*

------
https://chatgpt.com/codex/tasks/task_e_68ab1b0363ac8324a5e5e35aad7db140