### PR TITLE
Restore TZ_PARIS timezone constant for pari_xp cog

### DIFF
--- a/utils/timezones.py
+++ b/utils/timezones.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-PARIS = ZoneInfo("Europe/Paris")
+TZ_PARIS = ZoneInfo("Europe/Paris")
+PARIS = TZ_PARIS  # backward compatibility
 
 
 def now_paris() -> datetime:
     """Return current time in Europe/Paris timezone."""
-    return datetime.now(PARIS)
+    return datetime.now(TZ_PARIS)


### PR DESCRIPTION
## Summary
- reintroduce `TZ_PARIS` constant and alias `PARIS`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab210e5e488324909c21defa9447f0