### PR TITLE
Stop bot from pinning messages

### DIFF
--- a/cogs/game_events.py
+++ b/cogs/game_events.py
@@ -180,16 +180,12 @@ class GameEventsCog(commands.Cog):
                     maybe_mentions = [f"<@{u}>" for u, s in evt.rsvps.items() if s == "maybe"]
                     desc = "\n".join(yes_mentions) or "Personne"
                     desc += "\nPeut-être : " + (", ".join(maybe_mentions) or "aucun")
-                    msg = await channel.send(
+                    await channel.send(
                         f"C'est parti pour **{evt.game_name}** !\n"
                         f"Salon vocal: {vc.mention if vc else 'n/a'}\n"
                         f"Joueurs: {desc}\n"
                         "Multiplicateurs: ✅ x2, 🤔 x1.5, autres x1",
                     )
-                    try:
-                        await msg.pin()
-                    except discord.HTTPException:
-                        pass
                 evt.started_at = now
                 evt.state = "running"
                 await save_event(evt)

--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -196,10 +196,6 @@ class RouletteRefugeCog(commands.Cog):
             await message.edit(embed=embed)
         else:
             message = await channel.send(embed=embed)
-            try:
-                await message.pin()
-            except Exception:
-                pass
             state["leaderboard_message_id"] = message.id
             await storage.save_json(storage.Path(STATE_PATH), state)
             self.state = state


### PR DESCRIPTION
## Summary
- Prevent leaderboard postings from being pinned
- Avoid pinning game event announcements

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab44b638d48324ba7cdc12f8728f5d