### PR TITLE
Run slot machine check hourly

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ La fréquence de vérification des noms de ces salons est définie par la consta
 `TEMP_VC_CHECK_INTERVAL_SECONDS` (30 secondes par défaut).
 
 La vérification de l'état de la machine à sous est contrôlée par la constante
-`MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES` (5 minutes par défaut).
+`MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES` (60 minutes par défaut).
 
 ### Sauvegarde des sessions vocales
 

--- a/config.py
+++ b/config.py
@@ -112,7 +112,7 @@ ANNOUNCE_CHANNEL_ID: int = 1400552164979507263
 """Salon utilisé pour les annonces de la machine à sous."""
 
 MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES: int = int(
-    os.getenv("MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES", "5")
+    os.getenv("MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES", "60")
 )
 """Intervalle en minutes entre deux vérifications de l'état de la machine à sous."""
 


### PR DESCRIPTION
## Summary
- check slot machine open/close state every hour
- document hourly interval

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab463c82c483248694184211d56857