### PR TITLE
Ensure stats cog starts rename manager

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -104,4 +104,5 @@ class StatsCog(commands.Cog):
 
 
 async def setup(bot: commands.Bot) -> None:
+    await rename_manager.start()
     await bot.add_cog(StatsCog(bot))

--- a/tests/test_stats_cog_starts_rename_manager.py
+++ b/tests/test_stats_cog_starts_rename_manager.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cogs import stats
+
+
+@pytest.mark.asyncio
+async def test_stats_cog_starts_rename_manager(monkeypatch):
+    bot = SimpleNamespace(
+        add_cog=AsyncMock(),
+        wait_until_ready=AsyncMock(),
+        guilds=[]
+    )
+    start_mock = AsyncMock()
+    monkeypatch.setattr("cogs.stats.rename_manager.start", start_mock)
+
+    await stats.setup(bot)
+
+    start_mock.assert_awaited_once()
+
+    cog = bot.add_cog.call_args.args[0]
+    cog.refresh_members.cancel()
+    cog.refresh_activity.cancel()


### PR DESCRIPTION
## Summary
- ensure stats cog starts the rename manager worker
- add regression test validating rename manager startup

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab56a97548832487dbad0ae75195d4