### PR TITLE
Update member statistics every ten minutes

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -9,7 +9,6 @@ effectuer les changements.
 import discord
 from discord.ext import commands, tasks
 from discord import app_commands
-from datetime import time
 
 import config
 from config import XP_VIEWER_ROLE_ID
@@ -76,9 +75,9 @@ class StatsCog(commands.Cog):
                     channels[2], f"🔊 Voc : {voice}"
                 )
 
-    @tasks.loop(time=[time(hour=10), time(hour=22)])
+    @tasks.loop(minutes=10)
     async def refresh_members(self) -> None:
-        """Met à jour le nombre de membres deux fois par jour."""
+        """Met à jour le nombre de membres toutes les dix minutes."""
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
             await self.update_members(guild)
@@ -104,4 +103,5 @@ class StatsCog(commands.Cog):
 
 
 async def setup(bot: commands.Bot) -> None:
+    await rename_manager.start()
     await bot.add_cog(StatsCog(bot))

--- a/tests/test_stats_cog_starts_rename_manager.py
+++ b/tests/test_stats_cog_starts_rename_manager.py
@@ -1,0 +1,27 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cogs import stats
+
+
+@pytest.mark.asyncio
+async def test_stats_cog_starts_rename_manager(monkeypatch):
+    bot = SimpleNamespace(
+        add_cog=AsyncMock(),
+        wait_until_ready=AsyncMock(),
+        guilds=[]
+    )
+    start_mock = AsyncMock()
+    monkeypatch.setattr("cogs.stats.rename_manager.start", start_mock)
+
+    await stats.setup(bot)
+
+    start_mock.assert_awaited_once()
+
+    cog = bot.add_cog.call_args.args[0]
+    assert cog.refresh_members.minutes == 10
+    assert cog.refresh_activity.minutes == 10
+    cog.refresh_members.cancel()
+    cog.refresh_activity.cancel()


### PR DESCRIPTION
## Summary
- refresh member count every ten minutes alongside activity stats
- assert stats loops run every ten minutes

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab56a97548832487dbad0ae75195d4