### PR TITLE
Adjust stats update intervals

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -24,11 +24,13 @@ class StatsCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
         self.refresh_members.start()
-        self.refresh_activity.start()
+        self.refresh_online.start()
+        self.refresh_voice.start()
 
     def cog_unload(self) -> None:
         self.refresh_members.cancel()
-        self.refresh_activity.cancel()
+        self.refresh_online.cancel()
+        self.refresh_voice.cancel()
 
     async def update_members(self, guild: discord.Guild) -> None:
         """Met à jour le nombre de membres pour ``guild``."""
@@ -76,19 +78,25 @@ class StatsCog(commands.Cog):
                     channels[2], f"🔊 Voc : {voice}"
                 )
 
-    @tasks.loop(time=[time(hour=10), time(hour=22)])
+    @tasks.loop(minutes=2)
     async def refresh_members(self) -> None:
-        """Met à jour le nombre de membres deux fois par jour."""
+        """Met à jour le nombre de membres toutes les deux minutes."""
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
             await self.update_members(guild)
 
-    @tasks.loop(minutes=10)
-    async def refresh_activity(self) -> None:
-        """Met à jour l'activité du serveur toutes les dix minutes."""
+    @tasks.loop(minutes=1)
+    async def refresh_online(self) -> None:
+        """Met à jour le nombre d'utilisateurs en ligne chaque minute."""
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
             await self.update_online(guild)
+
+    @tasks.loop(hours=1)
+    async def refresh_voice(self) -> None:
+        """Met à jour le nombre d'utilisateurs en vocal toutes les heures."""
+        await self.bot.wait_until_ready()
+        for guild in self.bot.guilds:
             await self.update_voice(guild)
 
     @app_commands.command(name="stats_refresh", description="Met à jour les salons de statistiques.")

--- a/tests/test_stats_cog_starts_rename_manager.py
+++ b/tests/test_stats_cog_starts_rename_manager.py
@@ -22,4 +22,5 @@ async def test_stats_cog_starts_rename_manager(monkeypatch):
 
     cog = bot.add_cog.call_args.args[0]
     cog.refresh_members.cancel()
-    cog.refresh_activity.cancel()
+    cog.refresh_online.cancel()
+    cog.refresh_voice.cancel()

--- a/tests/test_stats_update.py
+++ b/tests/test_stats_update.py
@@ -70,7 +70,8 @@ async def test_update_stats_changes_channel_names(monkeypatch):
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
     cog = StatsCog(bot)
     cog.refresh_members.cancel()
-    cog.refresh_activity.cancel()
+    cog.refresh_online.cancel()
+    cog.refresh_voice.cancel()
 
     await cog.update_members(guild)
     await cog.update_online(guild)


### PR DESCRIPTION
## Summary
- Refresh member stats every 2 minutes
- Refresh online user stats every minute
- Refresh voice activity stats hourly

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68ab65b336a483248ee3878034df7413