### PR TITLE
Clarify betting draw messaging

### DIFF
--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -701,7 +701,10 @@ class RouletteRefugeCog(commands.Cog):
             return
         self._bets_today[user_id] = count + 1
         _ = use_ticket_str.lower() == "oui"
-        await interaction.response.send_message("✅ Mise reçue. (Tirage à l'étape 6)", ephemeral=True)
+        await interaction.response.send_message(
+            "✅ Mise reçue. Tirage en cours…",
+            ephemeral=True,
+        )
         if color_choice:
             outcome_color = random.choice(["rouge", "noir"])
             segment = f"color_{outcome_color}"


### PR DESCRIPTION
## Summary
- Remove confusing step reference from pari XP bet confirmation
- Clearly indicate when the draw is happening

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab67c5233c83249bb5d605077d1f13