### PR TITLE
Warn when channel edit worker inactive

### DIFF
--- a/tests/test_channel_edit_manager.py
+++ b/tests/test_channel_edit_manager.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call
 
+import logging
 import pytest
 import pytest_asyncio
 
@@ -64,3 +65,12 @@ async def test_channel_edit_manager_respects_global_interval(monkeypatch, edit_m
     assert delays == [pytest.approx(3, abs=0.1)]
     ch1.edit.assert_awaited_once()
     ch2.edit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_channel_edit_manager_warns_if_worker_inactive(caplog):
+    mgr = cem._ChannelEditManager()
+    channel = SimpleNamespace(id=1, name="Old", edit=AsyncMock())
+    with caplog.at_level(logging.WARNING):
+        await mgr.request(channel, name="New")
+    assert "worker inactive" in caplog.text

--- a/utils/channel_edit_manager.py
+++ b/utils/channel_edit_manager.py
@@ -46,6 +46,11 @@ class _ChannelEditManager:
         else:
             self._pending[channel.id] = (channel, kwargs)
             await self._queue.put(channel.id)
+        if self._worker is None or self._worker.done():
+            logging.warning(
+                "[channel_edit_manager] worker inactive; edit for %s may not run",
+                channel.id,
+            )
 
     async def _run(self) -> None:
         while True:


### PR DESCRIPTION
## Summary
- log a warning if `channel_edit_manager` receives a request while its worker isn't running
- add regression test for warning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab7c1336e083249c75b91867a0e35e