### PR TITLE
Reduce slot machine boundary check interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ La fréquence de vérification des noms de ces salons est définie par la consta
 `TEMP_VC_CHECK_INTERVAL_SECONDS` (30 secondes par défaut).
 
 La vérification de l'état de la machine à sous est contrôlée par la constante
-`MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES` (60 minutes par défaut).
+`MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES` (1 minute par défaut).
 
 ### Sauvegarde des sessions vocales
 

--- a/config.py
+++ b/config.py
@@ -116,7 +116,7 @@ ANNOUNCE_CHANNEL_ID: int = 1400552164979507263
 """Salon utilisé pour les annonces de la machine à sous."""
 
 MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES: int = int(
-    os.getenv("MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES", "60")
+    os.getenv("MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES", "1")
 )
 """Intervalle en minutes entre deux vérifications de l'état de la machine à sous."""
 


### PR DESCRIPTION
## Summary
- shorten slot machine boundary check interval to 1 minute for quicker closing
- document new default interval in README

## Testing
- `ruff check config.py`
- `mypy --hide-error-context --hide-error-codes --config-file mypy.ini .` *(fails: "GuildChannel" has no attribute "edit", etc.)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab7e1712308324b588e2c2b660fdfc