### PR TITLE
Ensure machine state message stays accurate

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -430,6 +430,7 @@ class MachineASousCog(commands.Cog):
         self._last_announced_state = self.current_view_enabled
         try:
             await self._ensure_poster_message()
+            await self._ensure_state_message(self.current_view_enabled)
         except Exception as err:
             logger.warning("[MachineASous] Init failed: %s", err)
         self.maintenance_loop.start()
@@ -554,8 +555,8 @@ class MachineASousCog(commands.Cog):
             ):
                 self.current_view_enabled = enabled_now
                 await self._replace_poster_message()
-                await self._post_state_message(enabled_now)
                 self._last_announced_state = enabled_now
+            await self._ensure_state_message(enabled_now)
         except Exception as e:
             logger.error("[MachineASous] maintenance_loop boundary erreur: %s", e)
 

--- a/tests/test_machine_a_sous_closed_startup.py
+++ b/tests/test_machine_a_sous_closed_startup.py
@@ -1,0 +1,40 @@
+import os
+import sys
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+from cogs.machine_a_sous.machine_a_sous import MachineASousCog
+
+
+@pytest.mark.asyncio
+async def test_init_posts_closed_message(monkeypatch):
+    monkeypatch.setattr(
+        'cogs.machine_a_sous.machine_a_sous.is_open_now',
+        lambda *_, **__: False,
+    )
+
+    bot = SimpleNamespace(
+        wait_until_ready=AsyncMock(),
+        loop=asyncio.get_event_loop(),
+    )
+
+    cog = MachineASousCog(bot)
+    cog._ensure_poster_message = AsyncMock()
+    post_mock = AsyncMock()
+    cog.maintenance_loop.start = MagicMock()
+
+    async def fake_ensure(opened: bool):
+        await post_mock(opened)
+
+    cog._ensure_state_message = AsyncMock(side_effect=fake_ensure)
+
+    await cog._init_after_ready()
+
+    post_mock.assert_awaited_once_with(False)


### PR DESCRIPTION
## Summary
- Ensure slot machine posts state message on startup
- Refresh state message regularly via maintenance loop
- Test closed-period startup posts "FERMÉE" message

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8360c8188324b225ce594a02d398