### PR TITLE
Notify role on slot machine closure

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -497,6 +497,10 @@ class MachineASousCog(commands.Cog):
                 )
                 color = 0x2ECC71
             else:
+                content = (
+                    f"<@&{NOTIF_ROLE_ID}> 🎰 La **machine à sous ferme** maintenant — rendez-vous demain !"
+                )
+                allowed = discord.AllowedMentions(roles=True)
                 description = (
                     "💡 Les néons s’éteignent… ⛔\n"
                     "À demain pour de nouvelles mises et, peut-être, le gros lot 💰."

--- a/tests/test_machine_a_sous_state_message_close.py
+++ b/tests/test_machine_a_sous_state_message_close.py
@@ -1,0 +1,35 @@
+import discord
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from cogs.machine_a_sous.machine_a_sous import MachineASousCog, NOTIF_ROLE_ID
+
+
+@pytest.mark.asyncio
+async def test_post_state_message_mentions_role_when_closed(monkeypatch):
+    async def empty_history(limit=20):
+        if False:
+            yield None
+
+    channel = AsyncMock(spec=discord.TextChannel)
+    channel.id = 123
+    channel.send = AsyncMock(return_value=SimpleNamespace(id=456))
+    channel.history = lambda limit=20: empty_history(limit)
+
+    bot = SimpleNamespace(
+        get_channel=lambda _id: channel,
+        user=SimpleNamespace(id=999),
+    )
+
+    cog = MachineASousCog(bot)
+    monkeypatch.setattr(cog.store, "get_state_message", lambda: None)
+    monkeypatch.setattr(cog.store, "set_state_message", lambda *args: None)
+
+    await cog._post_state_message(False)
+
+    channel.send.assert_awaited_once()
+    _, kwargs = channel.send.await_args
+    assert f"<@&{NOTIF_ROLE_ID}>" in kwargs["content"]
+    assert isinstance(kwargs["embed"], discord.Embed)
+    assert kwargs["allowed_mentions"].roles


### PR DESCRIPTION
## Summary
- Ping the notification role when the slot machine closes
- Cover closed-state announcement with a test

## Testing
- `ruff check cogs/machine_a_sous/machine_a_sous.py tests/test_machine_a_sous_state_message_close.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab84445bd48324ac01794e09ba08b2