### PR TITLE
Fix machine state message channel

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -436,10 +436,10 @@ class MachineASousCog(commands.Cog):
         self.maintenance_loop.start()
 
     async def _post_state_message(self, opened: bool):
-        """Announce the open/closed state in the announce channel."""
-        ch = self.bot.get_channel(ANNOUNCE_CHANNEL_ID)
+        """Announce the open/closed state in the machine channel."""
+        ch = self.bot.get_channel(CHANNEL_ID)
         if not isinstance(ch, (discord.TextChannel, discord.Thread)):
-            logger.warning("[MachineASous] ANNOUNCE_CHANNEL_ID invalide.")
+            logger.warning("[MachineASous] CHANNEL_ID invalide.")
             return
         try:
             old = self.store.get_state_message()
@@ -518,9 +518,9 @@ class MachineASousCog(commands.Cog):
 
     async def _ensure_state_message(self, opened: bool):
         """Ensure a state message exists and matches the current status."""
-        ch = self.bot.get_channel(ANNOUNCE_CHANNEL_ID)
+        ch = self.bot.get_channel(CHANNEL_ID)
         if not isinstance(ch, (discord.TextChannel, discord.Thread)):
-            logger.warning("[MachineASous] ANNOUNCE_CHANNEL_ID invalide.")
+            logger.warning("[MachineASous] CHANNEL_ID invalide.")
             return
         stored = self.store.get_state_message()
         if stored:


### PR DESCRIPTION
## Summary
- ensure slot machine state messages post in the machine channel
- test that state message uses the configured machine channel

## Testing
- `ruff check cogs/machine_a_sous/machine_a_sous.py tests/test_machine_a_sous_state_message_close.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab888f4dec83249bd3455e6bfb1caa