### PR TITLE
Send slot machine state updates to announce channel

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -436,10 +436,10 @@ class MachineASousCog(commands.Cog):
         self.maintenance_loop.start()
 
     async def _post_state_message(self, opened: bool):
-        """Announce the open/closed state in the machine channel."""
-        ch = self.bot.get_channel(CHANNEL_ID)
+        """Announce the open/closed state in the announcement channel."""
+        ch = self.bot.get_channel(ANNOUNCE_CHANNEL_ID)
         if not isinstance(ch, (discord.TextChannel, discord.Thread)):
-            logger.warning("[MachineASous] CHANNEL_ID invalide.")
+            logger.warning("[MachineASous] ANNOUNCE_CHANNEL_ID invalide.")
             return
         try:
             old = self.store.get_state_message()
@@ -518,9 +518,9 @@ class MachineASousCog(commands.Cog):
 
     async def _ensure_state_message(self, opened: bool):
         """Ensure a state message exists and matches the current status."""
-        ch = self.bot.get_channel(CHANNEL_ID)
+        ch = self.bot.get_channel(ANNOUNCE_CHANNEL_ID)
         if not isinstance(ch, (discord.TextChannel, discord.Thread)):
-            logger.warning("[MachineASous] CHANNEL_ID invalide.")
+            logger.warning("[MachineASous] ANNOUNCE_CHANNEL_ID invalide.")
             return
         stored = self.store.get_state_message()
         if stored:

--- a/tests/test_machine_a_sous_state_message_close.py
+++ b/tests/test_machine_a_sous_state_message_close.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock, MagicMock
 from cogs.machine_a_sous.machine_a_sous import (
     MachineASousCog,
     NOTIF_ROLE_ID,
-    CHANNEL_ID,
+    ANNOUNCE_CHANNEL_ID,
 )
 
 
@@ -33,7 +33,7 @@ async def test_post_state_message_mentions_role_when_closed(monkeypatch):
 
     await cog._post_state_message(False)
 
-    get_channel_mock.assert_called_once_with(CHANNEL_ID)
+    get_channel_mock.assert_called_once_with(ANNOUNCE_CHANNEL_ID)
     channel.send.assert_awaited_once()
     _, kwargs = channel.send.await_args
     assert f"<@&{NOTIF_ROLE_ID}>" in kwargs["content"]


### PR DESCRIPTION
## Summary
- send slot machine open/close updates to the announcement channel
- adjust test to new channel constant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab8bb8dc1c8324956dae45c97e9e59