### PR TITLE
Update statistics category ID

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -78,23 +78,23 @@ class StatsCog(commands.Cog):
                     channels[2], f"🔊 Voc : {voice}"
                 )
 
-    @tasks.loop(minutes=2)
+    @tasks.loop(time=time(hour=0))
     async def refresh_members(self) -> None:
-        """Met à jour le nombre de membres toutes les deux minutes."""
+        """Met à jour le nombre de membres une fois par jour."""
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
             await self.update_members(guild)
 
-    @tasks.loop(minutes=1)
+    @tasks.loop(minutes=15)
     async def refresh_online(self) -> None:
-        """Met à jour le nombre d'utilisateurs en ligne chaque minute."""
+        """Met à jour le nombre d'utilisateurs en ligne toutes les 15 minutes."""
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
             await self.update_online(guild)
 
-    @tasks.loop(hours=1)
+    @tasks.loop(minutes=3)
     async def refresh_voice(self) -> None:
-        """Met à jour le nombre d'utilisateurs en vocal toutes les heures."""
+        """Met à jour le nombre d'utilisateurs en vocal toutes les 3 minutes."""
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
             await self.update_voice(guild)

--- a/config.py
+++ b/config.py
@@ -32,7 +32,7 @@ except AttributeError:
     pass
 
 # ── Salons statistiques ───────────────────────────────────────
-STATS_CATEGORY_ID = 1406408038692294676  # Catégorie "📊 Statistiques"
+STATS_CATEGORY_ID = 1406435187520307350  # Catégorie "📊 Statistiques"
 
 # ── Rôles plateformes et notifications ───────────────────────
 ROLE_PC = 1400560541529018408


### PR DESCRIPTION
## Summary
- use new channel ID for stats category
- adjust statistics channel refresh intervals: members daily, online every 15 min, voice every 3 min

## Testing
- `ruff check cogs/stats.py`
- `pytest`
- `DISCORD_TOKEN=dummy python main.py` *(fails: Cannot connect to host discord.com: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9e5b30cc8324ac29b2cbdc65398f