### PR TITLE
feat: grant machine spin on roulette losing streak

### DIFF
--- a/main/data/pari_xp/config.json
+++ b/main/data/pari_xp/config.json
@@ -28,12 +28,10 @@
     "win_2x": 0.14,
     "win_5x": 0.09,
     "win_10x": 0.03,
-    "ticket_free": 0.003,
     "double_xp_1h": 0.007,
     "super_jackpot_plus_1000": 0.003
   },
   "segments_enabled": {
-    "ticket_free": true,
     "double_xp_1h": true,
     "xp_shared": false
   }

--- a/storage/roulette_store.py
+++ b/storage/roulette_store.py
@@ -73,6 +73,26 @@ class RouletteStore:
         self.data.get("claims", {}).pop(user_id, None)
         self._save()
 
+    # —— Tickets machine à sous ——
+    def grant_ticket(self, user_id: str):
+        tickets = self.data.setdefault("tickets", {})
+        tickets[user_id] = tickets.get(user_id, 0) + 1
+        self._save()
+
+    def has_ticket(self, user_id: str) -> bool:
+        return self.data.get("tickets", {}).get(user_id, 0) > 0
+
+    def use_ticket(self, user_id: str) -> bool:
+        tickets = self.data.get("tickets", {})
+        count = tickets.get(user_id, 0)
+        if count > 0:
+            tickets[user_id] = count - 1
+            if tickets[user_id] <= 0:
+                tickets.pop(user_id, None)
+            self._save()
+            return True
+        return False
+
     # ——— Rôles 24h ———
     def upsert_role_assignment(
         self,

--- a/tests/test_pari_xp_error.py
+++ b/tests/test_pari_xp_error.py
@@ -10,10 +10,8 @@ async def test_handle_bet_submission_exception(tmp_path, monkeypatch):
     pari_xp = importlib.import_module("main.cogs.pari_xp")
 
     # Ensure temp files to avoid touching real data
-    tickets_file = tmp_path / "tickets.json"
     tx_file = tmp_path / "tx.json"
     state_file = tmp_path / "state.json"
-    monkeypatch.setattr(pari_xp, "TICKETS_PATH", str(tickets_file))
     monkeypatch.setattr(pari_xp, "TX_PATH", str(tx_file))
     monkeypatch.setattr(pari_xp, "STATE_PATH", str(state_file))
 
@@ -33,6 +31,8 @@ async def test_handle_bet_submission_exception(tmp_path, monkeypatch):
     cog._bets_today_date = pari_xp.date.today()
     cog._now = lambda: pari_xp.datetime(2024, 1, 1, 12, 0, 0)
     cog._is_open_hours = lambda dt=None: True
+    cog.roulette_store = pari_xp.RouletteStore(data_dir=str(tmp_path))
+    cog._loss_streak = {}
 
     async def _get_channel():
         return None

--- a/tests/test_pari_xp_ticket.py
+++ b/tests/test_pari_xp_ticket.py
@@ -1,4 +1,3 @@
-import asyncio
 import importlib
 from pathlib import Path
 
@@ -6,33 +5,23 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_bet_with_ticket(tmp_path, monkeypatch):
+async def test_loss_streak_grants_machine_ticket(tmp_path, monkeypatch):
     import sys
     sys.path.append(str(Path(__file__).resolve().parent.parent))
     pari_xp = importlib.import_module("main.cogs.pari_xp")
 
-    tickets_file = tmp_path / "tickets.json"
-    tx_file = tmp_path / "tx.json"
-    state_file = tmp_path / "state.json"
-    monkeypatch.setattr(pari_xp, "TICKETS_PATH", str(tickets_file))
-    monkeypatch.setattr(pari_xp, "TX_PATH", str(tx_file))
-    monkeypatch.setattr(pari_xp, "STATE_PATH", str(state_file))
-
-    balance: dict[int, int] = {123: 100}
+    balance = {123: 1000}
 
     def fake_get_user_xp(uid: int) -> int:
         return balance.get(uid, 0)
 
-    def fake_add_user_xp(uid: int, amount: int, reason: str = "") -> None:
+    def fake_add_user_xp(uid: int, amount: int, guild_id: int = 0, source: str = "") -> None:
         balance[uid] = balance.get(uid, 0) + amount
 
     monkeypatch.setattr(pari_xp, "get_user_xp", fake_get_user_xp)
     monkeypatch.setattr(pari_xp, "add_user_xp", fake_add_user_xp)
     monkeypatch.setattr(pari_xp, "get_user_account_age_days", lambda uid: 10)
     monkeypatch.setattr(pari_xp, "apply_double_xp_buff", lambda uid, minutes=60: None)
-
-    tickets_file.write_text('[{"user_id": 123, "ts": "2024-01-01T00:00:00", "used": false}]')
-    tx_file.write_text('[]')
 
     cog = object.__new__(pari_xp.RouletteRefugeCog)
     cog.bot = object()
@@ -43,6 +32,8 @@ async def test_bet_with_ticket(tmp_path, monkeypatch):
     cog._bets_today_date = pari_xp.date.today()
     cog._now = lambda: pari_xp.datetime(2024, 1, 1, 12, 0, 0)
     cog._is_open_hours = lambda dt=None: True
+    cog.roulette_store = pari_xp.RouletteStore(data_dir=str(tmp_path))
+    cog._loss_streak = {}
 
     async def _get_channel():
         return None
@@ -64,8 +55,14 @@ async def test_bet_with_ticket(tmp_path, monkeypatch):
             pass
 
     class DummyFollowup:
+        def __init__(self):
+            self.sent = []
+
         async def send(self, *args, **kwargs):
-            pass
+            content = kwargs.get("content") or kwargs.get("embed")
+            if args:
+                content = args[0]
+            self.sent.append(content)
 
     class DummyInteraction:
         channel_id = 1
@@ -74,17 +71,16 @@ async def test_bet_with_ticket(tmp_path, monkeypatch):
         user = type("U", (), {"id": 123, "name": "Tester", "display_name": "Tester", "mention": "@Tester"})()
         response = DummyResponse()
         followup = DummyFollowup()
-        data = {
-            "components": [
-                {"components": [{"custom_id": "pari_xp_amount", "value": "20"}]},
-                {"components": [{"custom_id": "pari_xp_use_ticket", "value": "oui"}]},
-            ]
-        }
+        data = {"components": [{"components": [{"custom_id": "pari_xp_amount", "value": "20"}]}]}
 
     interaction = DummyInteraction()
 
-    await pari_xp.RouletteRefugeCog._handle_bet_submission(cog, interaction)
+    for _ in range(10):
+        cog._cooldowns = {}
+        await pari_xp.RouletteRefugeCog._handle_bet_submission(cog, interaction)
 
-    assert balance[123] == 100
-    tickets = pari_xp.storage.load_json(pari_xp.storage.Path(pari_xp.TICKETS_PATH), [])
-    assert tickets[0]["used"] is True
+    assert cog.roulette_store.has_ticket(str(interaction.user.id))
+    assert any(
+        isinstance(m, str) and "Ticket Gratuit" in m for m in interaction.followup.sent
+    )
+


### PR DESCRIPTION
## Summary
- track consecutive losses in Roulette Refuge and grant a machine ticket after 10
- allow Machine à sous to consume tickets and guarantee a winning free spin
- add ticket storage in RouletteStore and drop old ticket modal field

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab9fba31248324bcd1b3345d2aa500