### PR TITLE
feat: consolidate pari_xp level messages

### DIFF
--- a/tests/test_level_feed.py
+++ b/tests/test_level_feed.py
@@ -10,12 +10,30 @@ from storage.xp_store import xp_store
 from utils import level_feed
 
 
+class DummyMessage:
+    def __init__(self, *, content: str = "", embed: discord.Embed | None = None) -> None:
+        self.content = content
+        self.embed = embed
+
+    async def edit(
+        self, *, content: str | None = None, embed: discord.Embed | None = None
+    ) -> None:
+        if content is not None:
+            self.content = content
+        if embed is not None:
+            self.embed = embed
+
+
 class DummyChannel(discord.abc.Messageable):
     def __init__(self) -> None:
-        self.sent: list[str] = []
+        self.sent: list[DummyMessage] = []
 
-    async def send(self, content: str) -> None:  # type: ignore[override]
-        self.sent.append(content)
+    async def send(
+        self, content: str = "", *, embed: discord.Embed | None = None
+    ) -> DummyMessage:  # type: ignore[override]
+        msg = DummyMessage(content=content, embed=embed)
+        self.sent.append(msg)
+        return msg
 
     async def _get_channel(self):  # pragma: no cover - required by abc
         return self
@@ -45,6 +63,7 @@ def setup_router(monkeypatch):
     chan = DummyChannel()
     bot = DummyBot(chan)
     level_feed.router.setup(bot)
+    level_feed.router._pari_xp_messages.clear()
 
     async def fast_dispatch(key):
         await asyncio.sleep(0)
@@ -68,7 +87,8 @@ async def test_level_up_pari_xp(setup_router):
     await xp_store.add_xp(uid, 2500, guild_id=1, source="pari_xp")
     await asyncio.sleep(0)
     await asyncio.sleep(0)
-    assert chan.sent and "🤑" in chan.sent[0]
+    assert chan.sent and chan.sent[0].embed
+    assert chan.sent[0].embed.title == "🆙 Niveau augmenté !"
 
 
 @pytest.mark.asyncio
@@ -79,7 +99,8 @@ async def test_level_down_pari_xp(setup_router):
     await xp_store.add_xp(uid, -2500, guild_id=1, source="pari_xp")
     await asyncio.sleep(0)
     await asyncio.sleep(0)
-    assert chan.sent and chan.sent[0].startswith("⬇️")
+    assert chan.sent and chan.sent[0].embed
+    assert chan.sent[0].embed.title == "⬇️ Niveau diminué"
 
 
 @pytest.mark.asyncio
@@ -90,7 +111,7 @@ async def test_level_up_machine_a_sous(setup_router):
     await xp_store.add_xp(uid, 2500, guild_id=1, source="machine_a_sous")
     await asyncio.sleep(0)
     await asyncio.sleep(0)
-    assert chan.sent and "🎰" in chan.sent[0]
+    assert chan.sent and "🎰" in chan.sent[0].content
 
 
 @pytest.mark.asyncio
@@ -114,13 +135,53 @@ async def test_antispam_coalesce(setup_router):
     await asyncio.sleep(0)
     await asyncio.sleep(0)
     assert len(chan.sent) == 1
-    assert "niv. 14" in chan.sent[0]
+    assert chan.sent[0].embed and "niv. 14" in chan.sent[0].embed.description
+
+
+@pytest.mark.asyncio
+async def test_edit_message_on_repeated_level_up(setup_router):
+    chan = setup_router
+    uid = 6
+    xp_store.data[str(uid)] = {"xp": 14400, "level": 12}
+    await xp_store.add_xp(uid, 2500, guild_id=1, source="pari_xp")
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert len(chan.sent) == 1
+    msg = chan.sent[0]
+    assert msg.embed and "niv. 13" in msg.embed.description
+    await xp_store.add_xp(uid, 2700, guild_id=1, source="pari_xp")
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert len(chan.sent) == 1
+    assert chan.sent[0] is msg
+    assert msg.embed and "niv. 14" in msg.embed.description
+
+
+@pytest.mark.asyncio
+async def test_edit_message_on_repeated_level_down(setup_router):
+    chan = setup_router
+    uid = 7
+    xp_store.data[str(uid)] = {"xp": 16900, "level": 13}
+    await xp_store.add_xp(uid, -2000, guild_id=1, source="pari_xp")
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert len(chan.sent) == 1
+    msg = chan.sent[0]
+    assert msg.embed and "niv. 12" in msg.embed.description
+    await xp_store.add_xp(uid, -2000, guild_id=1, source="pari_xp")
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert len(chan.sent) == 1
+    assert chan.sent[0] is msg
+    assert msg.embed and "niv. 11" in msg.embed.description
 
 
 @pytest.mark.asyncio
 async def test_missing_permissions(monkeypatch, caplog):
     class ForbiddenChannel(DummyChannel):
-        async def send(self, content: str) -> None:
+        async def send(
+            self, content: str = "", *, embed: discord.Embed | None = None
+        ) -> DummyMessage:
             raise discord.Forbidden(mock.Mock(), "no perms")
 
     chan = ForbiddenChannel()


### PR DESCRIPTION
## Summary
- send level changes for `pari_xp` as embeds
- reuse and edit previous level messages instead of spamming new ones
- cover new behavior with tests

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aba44de06083248bd70d92ef511214