### PR TITLE
Use central Paris timezone for daily stats

### DIFF
--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -21,6 +21,7 @@ from config import (
     DATA_DIR,
     ANNOUNCE_CHANNEL_ID,
 )
+from utils.timezones import PARIS_TZ
 from utils.interactions import safe_respond
 from utils.persistence import (
     atomic_write_json_async,
@@ -221,7 +222,7 @@ class XPCog(commands.Cog):
         if message.author.bot or message.guild is None:
             return
         # Statistiques quotidiennes
-        today = datetime.now(timezone.utc).date().isoformat()
+        today = datetime.now(PARIS_TZ).date().isoformat()
         async with DAILY_LOCK:
             day = DAILY_STATS.setdefault(today, {})
             user = day.setdefault(str(message.author.id), {"messages": 0, "voice": 0})
@@ -260,7 +261,7 @@ class XPCog(commands.Cog):
             await schedule_checkpoint(save_voice_times_to_disk)
             return
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(PARIS_TZ)
         uid = str(member.id)
 
         # Déconnexion ou changement de salon : calculer la durée et attribuer l'XP

--- a/utils/timezones.py
+++ b/utils/timezones.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
-TZ_PARIS = ZoneInfo("Europe/Paris")
-PARIS = TZ_PARIS  # backward compatibility
+# Central timezone object for Europe/Paris
+PARIS_TZ = ZoneInfo("Europe/Paris")
+TZ_PARIS = PARIS_TZ  # backward compatibility
+PARIS = PARIS_TZ  # backward compatibility
 
 
 def now_paris() -> datetime:
     """Return current time in Europe/Paris timezone."""
-    return datetime.now(TZ_PARIS)
+    return datetime.now(PARIS_TZ)


### PR DESCRIPTION
## Summary
- Introduce shared `PARIS_TZ` ZoneInfo constant
- Record daily stats in Paris timezone for messages and voice activity

## Testing
- `ruff check cogs/xp.py utils/timezones.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ababf6860483248bce143ae5262fac