### PR TITLE
Use rate-limited message edits

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -21,13 +21,13 @@ from storage.xp_store import xp_store
 from utils.api_meter import api_meter
 from utils.channel_edit_manager import channel_edit_manager
 from utils.rename_manager import rename_manager
-from utils.rate_limit import GlobalRateLimiter
+from utils.rate_limit import GlobalRateLimiter, limiter as _limiter
 from view import PlayerTypeView
 from utils import level_feed
 
 
 # global rate limiter instance
-limiter: Final[GlobalRateLimiter] = GlobalRateLimiter()
+limiter: Final[GlobalRateLimiter] = _limiter
 
 
 async def reset_http_error_counter() -> None:

--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -21,6 +21,7 @@ from config import (
     DATA_DIR,
     MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES,
 )
+from utils.discord_utils import safe_message_edit
 logger = logging.getLogger(__name__)
 
 PARIS_TZ = "Europe/Paris"
@@ -260,7 +261,7 @@ class MachineASousView(discord.ui.View):
             ephemeral=True,
         )
         await asyncio.sleep(5)
-        await spin_msg.edit(content=msg, embed=None)
+        await safe_message_edit(spin_msg, content=msg, embed=None)
 
         if gain == "ticket":
             await self._single_spin(interaction, cog, free=True)

--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -24,6 +24,7 @@ from utils.timezones import TZ_PARIS
 from utils.storage import load_json
 from storage.roulette_store import RouletteStore
 from config import DATA_DIR
+from utils.discord_utils import safe_message_edit
 
 PARI_XP_DATA_DIR = "main/data/pari_xp/"
 CONFIG_PATH = PARI_XP_DATA_DIR + "config.json"
@@ -136,7 +137,7 @@ class RouletteRefugeCog(commands.Cog):
             if not message:
                 message = await self._find_hub_message(channel)
             if message:
-                await message.edit(embed=embed, view=view)
+                await safe_message_edit(message, embed=embed, view=view)
             else:
                 message = await channel.send(embed=embed, view=view)
                 self.state["hub_message_id"] = message.id
@@ -199,7 +200,7 @@ class RouletteRefugeCog(commands.Cog):
             message = await self._find_leaderboard_message(channel)
             state = self.state
         if message:
-            await message.edit(embed=embed)
+            await safe_message_edit(message, embed=embed)
         else:
             message = await channel.send(embed=embed)
             state["leaderboard_message_id"] = message.id
@@ -215,7 +216,7 @@ class RouletteRefugeCog(commands.Cog):
             if not msg_id:
                 return
             msg = await channel.fetch_message(int(msg_id))
-            await msg.edit(embed=self._build_leaderboard_embed())
+            await safe_message_edit(msg, embed=self._build_leaderboard_embed())
         except Exception:
             pass
 

--- a/utils/level_feed.py
+++ b/utils/level_feed.py
@@ -10,6 +10,7 @@ import discord
 
 from config import LEVEL_FEED_CHANNEL_ID, ENABLE_GAME_LEVEL_FEED
 from utils.messages import LEVEL_FEED_TEMPLATES
+from utils.discord_utils import safe_message_edit
 
 logger = logging.getLogger("level_feed")
 
@@ -102,7 +103,7 @@ class LevelFeedRouter:
             last_msg = self._pari_xp_messages.get(key)
             try:
                 if last_msg:
-                    await last_msg.edit(embed=embed)
+                    await safe_message_edit(last_msg, embed=embed)
                 else:
                     last_msg = await channel.send(embed=embed)
                     self._pari_xp_messages[key] = last_msg

--- a/utils/rate_limit.py
+++ b/utils/rate_limit.py
@@ -102,3 +102,10 @@ class GlobalRateLimiter:
                 self.errors.clear()
             self._requests = 0
             self._total_wait = 0.0
+
+
+# shared global rate limiter instance
+limiter = GlobalRateLimiter()
+
+
+__all__ = ["GlobalRateLimiter", "limiter"]


### PR DESCRIPTION
## Summary
- add safe_message_edit helper that skips no-op edits and uses global rate limiter
- expose shared GlobalRateLimiter instance and start it in bot setup
- use safe_message_edit across pari_xp, level_feed and machine_a_sous modules

## Testing
- `pytest`
- `ruff check utils/discord_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68ababb948d48324b813adbbebbb1b09