### PR TITLE
Use explicit channel IDs for stats channels

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -55,22 +55,24 @@ class StatsCog(commands.Cog):
             data = self.cache.get(gid)
             if not data:
                 continue
-            category = guild.get_channel(config.STATS_CATEGORY_ID)
-            if category is None:
-                continue
-            channels = getattr(category, "channels", [])
-            if len(channels) > 0 and "members" in data:
-                await rename_manager.request(
-                    channels[0], f"👥 Membres : {data['members']}"
-                )
-            if len(channels) > 1 and "online" in data:
-                await rename_manager.request(
-                    channels[1], f"🟢 En ligne : {data['online']}"
-                )
-            if len(channels) > 2 and "voice" in data:
-                await rename_manager.request(
-                    channels[2], f"🔊 Voc : {data['voice']}"
-                )
+            if "members" in data:
+                channel = guild.get_channel(config.STATS_MEMBERS_CHANNEL_ID)
+                if channel is not None:
+                    await rename_manager.request(
+                        channel, f"👥 Membres : {data['members']}"
+                    )
+            if "online" in data:
+                channel = guild.get_channel(config.STATS_ONLINE_CHANNEL_ID)
+                if channel is not None:
+                    await rename_manager.request(
+                        channel, f"🟢 En ligne : {data['online']}"
+                    )
+            if "voice" in data:
+                channel = guild.get_channel(config.STATS_VOICE_CHANNEL_ID)
+                if channel is not None:
+                    await rename_manager.request(
+                        channel, f"🔊 Voc : {data['voice']}"
+                    )
 
     def cog_unload(self) -> None:
         self.refresh_members.cancel()
@@ -80,14 +82,11 @@ class StatsCog(commands.Cog):
     async def update_members(self, guild: discord.Guild) -> None:
         """Met à jour le nombre de membres pour ``guild``."""
         with measure("stats.update_members"):
-            category = guild.get_channel(config.STATS_CATEGORY_ID)
-            if category is None:
-                return
             members = sum(1 for m in guild.members if not getattr(m, "bot", False))
-            channels = getattr(category, "channels", [])
-            if len(channels) > 0:
+            channel = guild.get_channel(config.STATS_MEMBERS_CHANNEL_ID)
+            if channel is not None:
                 await rename_manager.request(
-                    channels[0], f"👥 Membres : {members}"
+                    channel, f"👥 Membres : {members}"
                 )
             gid = str(getattr(guild, "id", 0))
             self.cache.setdefault(gid, {})["members"] = members
@@ -96,18 +95,15 @@ class StatsCog(commands.Cog):
     async def update_online(self, guild: discord.Guild) -> None:
         """Met à jour le nombre d'utilisateurs en ligne pour ``guild``."""
         with measure("stats.update_online"):
-            category = guild.get_channel(config.STATS_CATEGORY_ID)
-            if category is None:
-                return
             online = sum(
                 1
                 for m in guild.members
                 if not getattr(m, "bot", False) and m.status != discord.Status.offline
             )
-            channels = getattr(category, "channels", [])
-            if len(channels) > 1:
+            channel = guild.get_channel(config.STATS_ONLINE_CHANNEL_ID)
+            if channel is not None:
                 await rename_manager.request(
-                    channels[1], f"🟢 En ligne : {online}"
+                    channel, f"🟢 En ligne : {online}"
                 )
             gid = str(getattr(guild, "id", 0))
             self.cache.setdefault(gid, {})["online"] = online
@@ -116,17 +112,14 @@ class StatsCog(commands.Cog):
     async def update_voice(self, guild: discord.Guild) -> None:
         """Met à jour le nombre d'utilisateurs en vocal pour ``guild``."""
         with measure("stats.update_voice"):
-            category = guild.get_channel(config.STATS_CATEGORY_ID)
-            if category is None:
-                return
             voice = sum(
                 len([m for m in vc.members if not getattr(m, "bot", False)])
                 for vc in getattr(guild, "voice_channels", [])
             )
-            channels = getattr(category, "channels", [])
-            if len(channels) > 2:
+            channel = guild.get_channel(config.STATS_VOICE_CHANNEL_ID)
+            if channel is not None:
                 await rename_manager.request(
-                    channels[2], f"🔊 Voc : {voice}"
+                    channel, f"🔊 Voc : {voice}"
                 )
             gid = str(getattr(guild, "id", 0))
             self.cache.setdefault(gid, {})["voice"] = voice

--- a/config.py
+++ b/config.py
@@ -32,7 +32,9 @@ except AttributeError:
     pass
 
 # ── Salons statistiques ───────────────────────────────────────
-STATS_CATEGORY_ID = 1406435187520307350  # Catégorie "📊 Statistiques"
+STATS_MEMBERS_CHANNEL_ID = 1406435185813098537
+STATS_ONLINE_CHANNEL_ID = 1406435187520307350
+STATS_VOICE_CHANNEL_ID = 1406435190607184085
 
 # ── Rôles plateformes et notifications ───────────────────────
 ROLE_PC = 1400560541529018408

--- a/tests/test_stats_update.py
+++ b/tests/test_stats_update.py
@@ -11,11 +11,6 @@ class DummyChannel:
         self.name: str | None = None
 
 
-class DummyCategory:
-    def __init__(self, channels):
-        self.channels = channels
-
-
 class DummyMember:
     def __init__(self, status, bot=False):
         self.status = status
@@ -28,9 +23,9 @@ class DummyVoiceChannel:
 
 
 class DummyGuild:
-    def __init__(self, members, category, voice_channels):
+    def __init__(self, members, channels, voice_channels):
         self.members = members
-        self._category = category
+        self._channels = channels
         self.voice_channels = voice_channels
 
     @property
@@ -38,9 +33,7 @@ class DummyGuild:
         return len(self.members)
 
     def get_channel(self, cid):
-        if cid == config.STATS_CATEGORY_ID:
-            return self._category
-        return None
+        return self._channels.get(cid)
 
 
 @pytest.mark.asyncio
@@ -48,7 +41,11 @@ async def test_update_stats_changes_channel_names(monkeypatch):
     ch1 = DummyChannel()
     ch2 = DummyChannel()
     ch3 = DummyChannel()
-    category = DummyCategory([ch1, ch2, ch3])
+    channels = {
+        config.STATS_MEMBERS_CHANNEL_ID: ch1,
+        config.STATS_ONLINE_CHANNEL_ID: ch2,
+        config.STATS_VOICE_CHANNEL_ID: ch3,
+    }
     voice_channel = DummyVoiceChannel(
         [DummyMember(discord.Status.online), DummyMember(discord.Status.online, bot=True)]
     )
@@ -58,7 +55,7 @@ async def test_update_stats_changes_channel_names(monkeypatch):
             DummyMember(discord.Status.offline),
             DummyMember(discord.Status.online, bot=True),
         ],
-        category,
+        channels,
         [voice_channel],
     )
 


### PR DESCRIPTION
## Summary
- define dedicated constants for stats channels
- fetch and rename stats channels directly by ID
- update tests for new channel layout

## Testing
- `ruff check config.py cogs/stats.py tests/test_stats_update.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb071e0fc8324add6b58efa93e636