### PR TITLE
feat: update radio buttons and hip-hop command

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -89,7 +89,7 @@ class RadioCog(commands.Cog):
                     for comp in row.children:
                         if (
                             isinstance(comp, discord.ui.Button)
-                            and comp.custom_id == "radio_24"
+                            and comp.custom_id == "radio_hiphop"
                         ):
                             return
             except Exception as e:
@@ -104,7 +104,7 @@ class RadioCog(commands.Cog):
                     for comp in row.children:
                         if (
                             isinstance(comp, discord.ui.Button)
-                            and comp.custom_id == "radio_24"
+                            and comp.custom_id == "radio_hiphop"
                         ):
                             self.store.set_radio_message(
                                 str(getattr(channel, "id", 0)), str(msg.id)
@@ -212,9 +212,9 @@ class RadioCog(commands.Cog):
         )
 
     @app_commands.command(
-        name="radio_24", description="Revenir sur l'ancienne radio 24/7"
+        name="radio_hiphop", description="Revenir sur la radio Hip-Hop"
     )
-    async def radio_24(self, interaction: discord.Interaction) -> None:
+    async def radio_hiphop(self, interaction: discord.Interaction) -> None:
         channel = self.bot.get_channel(self.vc_id)
         self.stream_url = RADIO_STREAM_URL
         self._previous_stream = None
@@ -224,7 +224,7 @@ class RadioCog(commands.Cog):
         if isinstance(channel, discord.VoiceChannel):
             await self._rename_for_stream(channel, RADIO_STREAM_URL)
         await interaction.response.send_message(
-            "Radio changée pour la station 24/7"
+            "Radio changée pour la station Hip-Hop"
         )
 
     @commands.Cog.listener()

--- a/tests/test_radio_hiphop_command.py
+++ b/tests/test_radio_hiphop_command.py
@@ -13,7 +13,7 @@ from config import RADIO_RAP_STREAM_URL, RADIO_STREAM_URL, RADIO_VC_ID
 
 
 @pytest.mark.asyncio
-async def test_radio_24_command_restores_default(monkeypatch):
+async def test_radio_hiphop_command_restores_default(monkeypatch):
     class FakeVoiceChannel(SimpleNamespace):
         pass
 
@@ -33,7 +33,7 @@ async def test_radio_24_command_restores_default(monkeypatch):
         response=SimpleNamespace(send_message=AsyncMock()),
     )
 
-    await RadioCog.radio_24.callback(cog, interaction)
+    await RadioCog.radio_hiphop.callback(cog, interaction)
 
     assert cog.stream_url == RADIO_STREAM_URL
     assert cog._previous_stream is None

--- a/tests/test_radio_message_fetch.py
+++ b/tests/test_radio_message_fetch.py
@@ -14,7 +14,7 @@ async def test_ensure_radio_message_uses_stored_id():
     channel = SimpleNamespace(id=123)
     cog.store.set_radio_message(str(channel.id), "456")
 
-    btn = discord.ui.Button(custom_id="radio_24")
+    btn = discord.ui.Button(custom_id="radio_hiphop")
     row = SimpleNamespace(children=[btn])
     msg = SimpleNamespace(components=[row])
 

--- a/tests/test_radio_view_buttons.py
+++ b/tests/test_radio_view_buttons.py
@@ -13,10 +13,10 @@ from view import RadioView
 async def test_radio_view_buttons_call_commands():
     view = RadioView()
     mapping = {
-        "radio_24": "radio_24",
-        "radio_rock": "radio_rock",
-        "radio_rap": "radio_rap",
         "radio_rapfr": "radio_rapfr",
+        "radio_rap": "radio_rap",
+        "radio_rock": "radio_rock",
+        "radio_hiphop": "radio_hiphop",
     }
     for custom_id, cmd_name in mapping.items():
         button = next(

--- a/view.py
+++ b/view.py
@@ -200,11 +200,21 @@ class RadioView(discord.ui.View):
         if command:
             await command.callback(cog, interaction)
 
-    @discord.ui.button(label="24/7", style=discord.ButtonStyle.primary, custom_id="radio_24")
-    async def btn_radio_24(
+    @discord.ui.button(
+        label="Rap FR", style=discord.ButtonStyle.primary, custom_id="radio_rapfr"
+    )
+    async def btn_radio_rapfr(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ) -> None:
-        await self._dispatch(interaction, "radio_24")
+        await self._dispatch(interaction, "radio_rapfr")
+
+    @discord.ui.button(
+        label="Rap US", style=discord.ButtonStyle.primary, custom_id="radio_rap"
+    )
+    async def btn_radio_rap(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._dispatch(interaction, "radio_rap")
 
     @discord.ui.button(
         label="Rock", style=discord.ButtonStyle.secondary, custom_id="radio_rock"
@@ -214,19 +224,13 @@ class RadioView(discord.ui.View):
     ) -> None:
         await self._dispatch(interaction, "radio_rock")
 
-    @discord.ui.button(label="Rap", style=discord.ButtonStyle.primary, custom_id="radio_rap")
-    async def btn_radio_rap(
-        self, interaction: discord.Interaction, button: discord.ui.Button
-    ) -> None:
-        await self._dispatch(interaction, "radio_rap")
-
     @discord.ui.button(
-        label="Rap FR", style=discord.ButtonStyle.primary, custom_id="radio_rapfr"
+        label="Radio Hip-Hop", style=discord.ButtonStyle.primary, custom_id="radio_hiphop"
     )
-    async def btn_radio_rapfr(
+    async def btn_radio_hiphop(
         self, interaction: discord.Interaction, button: discord.ui.Button
     ) -> None:
-        await self._dispatch(interaction, "radio_rapfr")
+        await self._dispatch(interaction, "radio_hiphop")
 
 
 class RSVPView(discord.ui.View):


### PR DESCRIPTION
## Summary
- replace radio buttons with Rap FR, Rap US, Rock, and Radio Hip-Hop options
- rename legacy `radio_24` command to `radio_hiphop` and adjust stored message checks
- update tests for new radio button identifiers

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb16884e88324ba93681e620fffd5