### PR TITLE
Remove radio slash commands

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -3,7 +3,6 @@ import logging
 from typing import Optional
 
 import discord
-from discord import app_commands
 from discord.ext import commands
 
 from config import (
@@ -182,7 +181,6 @@ class RadioCog(commands.Cog):
             await rename_manager.request(channel, rename_name)
         await interaction.response.send_message(user_message)
 
-    @app_commands.command(name="radio_rap", description="Basculer la radio sur le flux rap")
     async def radio_rap(self, interaction: discord.Interaction) -> None:
         await self._switch_stream(
             interaction,
@@ -191,7 +189,6 @@ class RadioCog(commands.Cog):
             "🔘・Radio-Rap",
         )
 
-    @app_commands.command(name="radio_rock", description="Basculer la radio sur le flux rock")
     async def radio_rock(self, interaction: discord.Interaction) -> None:
         await self._switch_stream(
             interaction,
@@ -200,9 +197,6 @@ class RadioCog(commands.Cog):
             "☢️・Radio-Rock",
         )
 
-    @app_commands.command(
-        name="radio_rapfr", description="Basculer la radio sur le flux rap français"
-    )
     async def radio_rapfr(self, interaction: discord.Interaction) -> None:
         await self._switch_stream(
             interaction,
@@ -211,9 +205,6 @@ class RadioCog(commands.Cog):
             "🔴・Radio-RapFR",
         )
 
-    @app_commands.command(
-        name="radio_hiphop", description="Revenir sur la radio Hip-Hop"
-    )
     async def radio_hiphop(self, interaction: discord.Interaction) -> None:
         channel = self.bot.get_channel(self.vc_id)
         self.stream_url = RADIO_STREAM_URL

--- a/tests/test_radio_rap.py
+++ b/tests/test_radio_rap.py
@@ -13,7 +13,7 @@ from config import RADIO_RAP_STREAM_URL, RADIO_STREAM_URL, RADIO_VC_ID
 
 
 @pytest.mark.asyncio
-async def test_radio_hiphop_command_restores_default(monkeypatch):
+async def test_radio_rap_toggles_stream(monkeypatch):
     class FakeVoiceChannel(SimpleNamespace):
         pass
 
@@ -22,8 +22,6 @@ async def test_radio_hiphop_command_restores_default(monkeypatch):
     bot = SimpleNamespace(loop=asyncio.get_event_loop(), get_channel=lambda cid: channel)
     cog = RadioCog(bot)
     cog._original_name = "Radio"
-    cog.stream_url = RADIO_RAP_STREAM_URL
-    cog.voice = SimpleNamespace(is_playing=lambda: True, stop=lambda: None)
     monkeypatch.setattr(cog, "_connect_and_play", AsyncMock())
     rename_mock = AsyncMock()
     monkeypatch.setattr(radio_mod.rename_manager, "request", rename_mock)
@@ -33,10 +31,20 @@ async def test_radio_hiphop_command_restores_default(monkeypatch):
         response=SimpleNamespace(send_message=AsyncMock()),
     )
 
-    await RadioCog.radio_hiphop.callback(cog, interaction)
+    await cog.radio_rap(interaction)
+
+    assert cog.stream_url == RADIO_RAP_STREAM_URL
+    assert cog._previous_stream == RADIO_STREAM_URL
+    rename_mock.assert_awaited_once_with(channel, "🔘・Radio-Rap")
+    interaction.response.send_message.assert_awaited_once()
+
+    interaction.response.send_message.reset_mock()
+    rename_mock.reset_mock()
+
+    await cog.radio_rap(interaction)
 
     assert cog.stream_url == RADIO_STREAM_URL
     assert cog._previous_stream is None
     rename_mock.assert_awaited_once_with(channel, "📻・Radio-HipHop")
-    cog._connect_and_play.assert_awaited_once()
     interaction.response.send_message.assert_awaited_once()
+

--- a/tests/test_radio_rapfr.py
+++ b/tests/test_radio_rapfr.py
@@ -13,7 +13,7 @@ from config import RADIO_RAP_FR_STREAM_URL, RADIO_STREAM_URL, RADIO_VC_ID
 
 
 @pytest.mark.asyncio
-async def test_radio_rapfr_command_toggles_stream(monkeypatch):
+async def test_radio_rapfr_toggles_stream(monkeypatch):
     class FakeVoiceChannel(SimpleNamespace):
         pass
 
@@ -31,7 +31,7 @@ async def test_radio_rapfr_command_toggles_stream(monkeypatch):
         response=SimpleNamespace(send_message=AsyncMock()),
     )
 
-    await RadioCog.radio_rapfr.callback(cog, interaction)
+    await cog.radio_rapfr(interaction)
 
     assert cog.stream_url == RADIO_RAP_FR_STREAM_URL
     assert cog._previous_stream == RADIO_STREAM_URL
@@ -41,7 +41,7 @@ async def test_radio_rapfr_command_toggles_stream(monkeypatch):
     interaction.response.send_message.reset_mock()
     rename_mock.reset_mock()
 
-    await RadioCog.radio_rapfr.callback(cog, interaction)
+    await cog.radio_rapfr(interaction)
 
     assert cog.stream_url == RADIO_STREAM_URL
     assert cog._previous_stream is None

--- a/tests/test_radio_rock.py
+++ b/tests/test_radio_rock.py
@@ -9,11 +9,11 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import cogs.radio as radio_mod
 from cogs.radio import RadioCog
-from config import RADIO_RAP_STREAM_URL, RADIO_STREAM_URL, RADIO_VC_ID
+from config import ROCK_RADIO_STREAM_URL, RADIO_STREAM_URL, RADIO_VC_ID
 
 
 @pytest.mark.asyncio
-async def test_radio_rap_command_toggles_stream(monkeypatch):
+async def test_radio_rock_toggles_stream(monkeypatch):
     class FakeVoiceChannel(SimpleNamespace):
         pass
 
@@ -31,20 +31,19 @@ async def test_radio_rap_command_toggles_stream(monkeypatch):
         response=SimpleNamespace(send_message=AsyncMock()),
     )
 
-    await RadioCog.radio_rap.callback(cog, interaction)
+    await cog.radio_rock(interaction)
 
-    assert cog.stream_url == RADIO_RAP_STREAM_URL
+    assert cog.stream_url == ROCK_RADIO_STREAM_URL
     assert cog._previous_stream == RADIO_STREAM_URL
-    rename_mock.assert_awaited_once_with(channel, "🔘・Radio-Rap")
+    rename_mock.assert_awaited_once_with(channel, "☢️・Radio-Rock")
     interaction.response.send_message.assert_awaited_once()
 
     interaction.response.send_message.reset_mock()
     rename_mock.reset_mock()
 
-    await RadioCog.radio_rap.callback(cog, interaction)
+    await cog.radio_rock(interaction)
 
     assert cog.stream_url == RADIO_STREAM_URL
     assert cog._previous_stream is None
     rename_mock.assert_awaited_once_with(channel, "📻・Radio-HipHop")
     interaction.response.send_message.assert_awaited_once()
-

--- a/tests/test_radio_view_buttons.py
+++ b/tests/test_radio_view_buttons.py
@@ -10,7 +10,7 @@ from view import RadioView
 
 
 @pytest.mark.asyncio
-async def test_radio_view_buttons_call_commands():
+async def test_radio_view_buttons_call_methods():
     view = RadioView()
     mapping = {
         "radio_rapfr": "radio_rapfr",
@@ -23,7 +23,7 @@ async def test_radio_view_buttons_call_commands():
             child for child in view.children if getattr(child, "custom_id", None) == custom_id
         )
         mock = AsyncMock()
-        cog = SimpleNamespace(**{cmd_name: SimpleNamespace(callback=mock)})
+        cog = SimpleNamespace(**{cmd_name: mock})
         interaction = SimpleNamespace(
             client=SimpleNamespace(get_cog=lambda name, c=cog: c)
         )

--- a/view.py
+++ b/view.py
@@ -1,5 +1,6 @@
 import logging
 import discord
+from discord import app_commands
 
 from config import ROLE_PC, ROLE_CONSOLE, ROLE_MOBILE, ROLE_NOTIFICATION
 
@@ -198,7 +199,10 @@ class RadioView(discord.ui.View):
             return
         command = getattr(cog, cmd, None)
         if command:
-            await command.callback(cog, interaction)
+            if isinstance(command, app_commands.Command):
+                await command.callback(cog, interaction)
+            else:
+                await command(interaction)
 
     @discord.ui.button(
         label="Rap FR", style=discord.ButtonStyle.primary, custom_id="radio_rapfr"


### PR DESCRIPTION
## Summary
- make radio station handlers internal functions instead of slash commands
- ensure `RadioView` dispatches to these internal handlers
- update tests to drop `/radio_*` references

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68abb2c59aa08324b98d254094d3d5a5