### PR TITLE
Match hub message title for reuse

### DIFF
--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -85,8 +85,8 @@ class RouletteRefugeCog(commands.Cog):
         async for msg in channel.history(limit=50):
             if msg.author == self.bot.user and msg.embeds:
                 embed = msg.embeds[0]
-                title = self.config.get("game_display_name", "🤑 Roulette Refuge")
-                if embed.title == title:
+                expected_title = f"🎰 {self.config.get('game_display_name', '🤑 Roulette Refuge')} 🎰"
+                if embed.title == expected_title:
                     self.state["hub_message_id"] = msg.id
                     await storage.save_json(storage.Path(STATE_PATH), self.state)
                     return msg


### PR DESCRIPTION
## Summary
- Match hub message search with the embed title constructed by `_build_hub_embed`

## Testing
- `pytest -q`
- `python main.py` *(fails: DISCORD_TOKEN environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68abb61522bc8324978349a6818f3677