### PR TITLE
Make radio switch responses ephemeral and unify rock button color

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -168,7 +168,7 @@ class RadioCog(commands.Cog):
             if isinstance(channel, discord.VoiceChannel):
                 await self._rename_for_stream(channel, self.stream_url)
             await interaction.response.send_message(
-                "Radio changée pour la station précédente"
+                "Radio changée pour la station précédente", ephemeral=True
             )
             return
 
@@ -179,7 +179,7 @@ class RadioCog(commands.Cog):
         await self._connect_and_play()
         if isinstance(channel, discord.VoiceChannel):
             await rename_manager.request(channel, rename_name)
-        await interaction.response.send_message(user_message)
+        await interaction.response.send_message(user_message, ephemeral=True)
 
     async def radio_rap(self, interaction: discord.Interaction) -> None:
         await self._switch_stream(
@@ -215,7 +215,7 @@ class RadioCog(commands.Cog):
         if isinstance(channel, discord.VoiceChannel):
             await self._rename_for_stream(channel, RADIO_STREAM_URL)
         await interaction.response.send_message(
-            "Radio changée pour la station Hip-Hop"
+            "Radio changée pour la station Hip-Hop", ephemeral=True
         )
 
     @commands.Cog.listener()

--- a/view.py
+++ b/view.py
@@ -221,7 +221,7 @@ class RadioView(discord.ui.View):
         await self._dispatch(interaction, "radio_rap")
 
     @discord.ui.button(
-        label="Rock", style=discord.ButtonStyle.secondary, custom_id="radio_rock"
+        label="Rock", style=discord.ButtonStyle.primary, custom_id="radio_rock"
     )
     async def btn_radio_rock(
         self, interaction: discord.Interaction, button: discord.ui.Button


### PR DESCRIPTION
## Summary
- Ensure radio change confirmations are ephemeral
- Use primary style for rock radio button

## Testing
- `ruff check .`
- `mypy .` *(fails: GuildChannel has no attribute 'edit', and many more)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb4fa464483249a0dac14b12e5d87