### PR TITLE
feat: configure roulette open hours

### DIFF
--- a/tests/test_pari_xp_daily_stats.py
+++ b/tests/test_pari_xp_daily_stats.py
@@ -54,6 +54,8 @@ async def test_post_daily_summary_uses_daily_stats(monkeypatch):
 
     cog = object.__new__(pari_xp.RouletteRefugeCog)
 
+    cog.config = {"open_hour": 9}
+
     async def _get_announce_channel():
         return None
 
@@ -92,3 +94,4 @@ async def test_post_daily_summary_uses_daily_stats(monkeypatch):
     assert "A (+5 XP)" in winners_field.value
     losers_field = next(f for f in sent["embed"].fields if f.name == "💸 Top 3 perdants")
     assert "B (-5 XP)" in losers_field.value
+    assert sent["embed"].footer.text == "Réouverture demain à 09:00 ⏰"

--- a/tests/test_pari_xp_open_hours.py
+++ b/tests/test_pari_xp_open_hours.py
@@ -1,0 +1,21 @@
+import importlib
+from pathlib import Path
+import sys
+
+
+def test_is_open_hours_respects_config_and_embed():
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    pari_xp = importlib.import_module("main.cogs.pari_xp")
+
+    cog = object.__new__(pari_xp.RouletteRefugeCog)
+    cog.config = {"open_hour": 10, "close_hour": 3}
+    tz = pari_xp.timezones.TZ_PARIS
+
+    assert cog._is_open_hours(pari_xp.datetime(2023, 1, 1, 10, 0, tzinfo=tz))
+    assert cog._is_open_hours(pari_xp.datetime(2023, 1, 2, 2, 59, tzinfo=tz))
+    assert not cog._is_open_hours(pari_xp.datetime(2023, 1, 1, 9, 59, tzinfo=tz))
+    assert not cog._is_open_hours(pari_xp.datetime(2023, 1, 2, 3, 0, tzinfo=tz))
+
+    cog._now = lambda: pari_xp.datetime(2023, 1, 1, 11, 0, tzinfo=tz)
+    desc = cog._build_hub_embed().description or ""
+    assert "ferme à ⏰ 03:00" in desc


### PR DESCRIPTION
## Summary
- use `open_hour`/`close_hour` config in `_is_open_hours` and hub embed
- format schedule messages with configured hours
- cover custom hours with tests

## Testing
- `ruff check main/cogs/pari_xp.py tests/test_pari_xp_daily_stats.py tests/test_pari_xp_open_hours.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb872a45c832482a26f4de549feeb