### PR TITLE
Use guild member count for stats

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -82,7 +82,9 @@ class StatsCog(commands.Cog):
     async def update_members(self, guild: discord.Guild) -> None:
         """Met à jour le nombre de membres pour ``guild``."""
         with measure("stats.update_members"):
-            members = sum(1 for m in guild.members if not getattr(m, "bot", False))
+            members = guild.member_count - sum(
+                1 for m in guild.members if getattr(m, "bot", False)
+            )
             channel = guild.get_channel(config.STATS_MEMBERS_CHANNEL_ID)
             if channel is not None:
                 await rename_manager.request(

--- a/tests/test_stats_update.py
+++ b/tests/test_stats_update.py
@@ -23,14 +23,13 @@ class DummyVoiceChannel:
 
 
 class DummyGuild:
-    def __init__(self, members, channels, voice_channels):
+    def __init__(self, members, channels, voice_channels, member_count=None):
         self.members = members
         self._channels = channels
         self.voice_channels = voice_channels
-
-    @property
-    def member_count(self):
-        return len(self.members)
+        self.member_count = (
+            member_count if member_count is not None else len(self.members)
+        )
 
     def get_channel(self, cid):
         return self._channels.get(cid)
@@ -57,6 +56,7 @@ async def test_update_stats_changes_channel_names(monkeypatch):
         ],
         channels,
         [voice_channel],
+        member_count=5,
     )
 
     async def fake_request(channel, name):
@@ -74,7 +74,7 @@ async def test_update_stats_changes_channel_names(monkeypatch):
     await cog.update_online(guild)
     await cog.update_voice(guild)
 
-    members = sum(1 for m in guild.members if not m.bot)
+    members = guild.member_count - sum(1 for m in guild.members if m.bot)
     assert ch1.name == f"👥 Membres : {members}"
     online = sum(
         1 for m in guild.members if not m.bot and m.status != discord.Status.offline


### PR DESCRIPTION
## Summary
- compute member stats using guild.member_count minus bots
- update stats test to provide member_count and assert new logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb943b9908324b1d8f98ef799a08f