### PR TITLE
Scan full history for radio message

### DIFF
--- a/storage/radio_store.py
+++ b/storage/radio_store.py
@@ -26,8 +26,11 @@ class RadioStore:
         except Exception as e:
             logging.error("[RadioStore] Écriture échouée pour %s: %s", self.data_file, e)
 
-    def set_radio_message(self, channel_id: str, message_id: str) -> None:
-        self.data["message"] = {"channel_id": channel_id, "message_id": message_id}
+    def set_radio_message(self, channel_id: int | str, message_id: int | str) -> None:
+        self.data["message"] = {
+            "channel_id": str(channel_id),
+            "message_id": str(message_id),
+        }
         self._save()
 
     def get_radio_message(self) -> Optional[dict]:

--- a/tests/test_radio_message_beyond_limit.py
+++ b/tests/test_radio_message_beyond_limit.py
@@ -1,0 +1,51 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from cogs.radio import RadioCog
+
+
+@pytest.mark.asyncio
+async def test_ensure_radio_message_finds_message_beyond_limit():
+    bot = SimpleNamespace(user=SimpleNamespace(id=1))
+    cog = RadioCog(bot)
+    set_radio_message = MagicMock()
+    store = SimpleNamespace(
+        get_radio_message=lambda: None,
+        set_radio_message=set_radio_message,
+        clear_radio_message=MagicMock(),
+    )
+    cog.store = store
+
+    btn = discord.ui.Button(custom_id="radio_hiphop")
+    row = SimpleNamespace(children=[btn])
+    recent = SimpleNamespace(
+        id=999,
+        author=SimpleNamespace(id=1),
+        components=[row],
+        delete=AsyncMock(),
+    )
+    old = SimpleNamespace(
+        id=998,
+        author=SimpleNamespace(id=1),
+        components=[row],
+        delete=AsyncMock(),
+    )
+    non_bot = SimpleNamespace(author=SimpleNamespace(id=2), components=[])
+
+    async def history(limit=None):
+        for _ in range(60):
+            yield non_bot
+        yield recent
+        yield old
+
+    channel = SimpleNamespace(id=123, history=history, send=AsyncMock())
+
+    await cog._ensure_radio_message(channel)
+
+    channel.send.assert_not_called()
+    set_radio_message.assert_called_once_with(channel.id, recent.id)
+    recent.delete.assert_not_awaited()
+    old.delete.assert_awaited_once()

--- a/tests/test_radio_message_fetch.py
+++ b/tests/test_radio_message_fetch.py
@@ -11,27 +11,33 @@ from cogs.radio import RadioCog
 async def test_ensure_radio_message_uses_stored_id():
     bot = SimpleNamespace(user=SimpleNamespace(id=1))
     cog = RadioCog(bot)
+    set_radio_message = MagicMock()
     store = SimpleNamespace(
         get_radio_message=lambda: {"channel_id": "123", "message_id": "456"},
-        set_radio_message=MagicMock(),
+        set_radio_message=set_radio_message,
         clear_radio_message=MagicMock(),
     )
     cog.store = store
-    channel = SimpleNamespace(id=123)
 
     btn = discord.ui.Button(custom_id="radio_hiphop")
     row = SimpleNamespace(children=[btn])
-    msg = SimpleNamespace(components=[row])
+    msg = SimpleNamespace(
+        id=456,
+        author=SimpleNamespace(id=1),
+        components=[row],
+        delete=AsyncMock(),
+    )
 
-    channel.fetch_message = AsyncMock(return_value=msg)
-    channel.history = AsyncMock()
-    channel.send = AsyncMock()
+    async def history(limit=None):
+        yield msg
+
+    channel = SimpleNamespace(id=123, history=history, send=AsyncMock())
 
     await cog._ensure_radio_message(channel)
 
-    channel.fetch_message.assert_awaited_once_with(456)
-    channel.history.assert_not_called()
     channel.send.assert_not_called()
+    set_radio_message.assert_not_called()
+    msg.delete.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -46,7 +52,7 @@ async def test_ensure_radio_message_creates_message_with_buttons():
     )
     cog.store = store
 
-    async def empty_history(limit: int = 50):
+    async def empty_history(limit=None):
         if False:
             yield None
 
@@ -59,7 +65,7 @@ async def test_ensure_radio_message_creates_message_with_buttons():
     await cog._ensure_radio_message(channel)
 
     channel.send.assert_awaited_once()
-    set_radio_message.assert_called_once_with(str(channel.id), "456")
+    set_radio_message.assert_called_once_with(channel.id, 456)
     view = channel.send.await_args.kwargs["view"]
     assert any(
         getattr(child, "custom_id", None) == "radio_hiphop" for child in view.children


### PR DESCRIPTION
## Summary
- Search entire channel history for radio message buttons and delete older duplicates
- Persist radio message IDs as strings even when provided as integers
- Add tests ensuring long-history lookup and existing message reuse

## Testing
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68abb8855bd0832491dc7a384bd987eb