### PR TITLE
Refresh stats channels on startup and add test

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -45,6 +45,10 @@ class StatsCog(commands.Cog):
         except Exception:
             pass
         await self._apply_cache()
+        for guild in self.bot.guilds:
+            await self.update_members(guild)
+            await self.update_online(guild)
+            await self.update_voice(guild)
         self.refresh_members.start()
         self.refresh_online.start()
         self.refresh_voice.start()


### PR DESCRIPTION
## Summary
- Ensure stats cog updates member/online/voice channels during startup
- Add tests for stats channel updates, including startup behavior

## Testing
- `PYTHONPATH=. pytest tests/test_stats_update.py -q`
- `PYTHONPATH=. pytest -q` *(fails: tests/test_voice_double_xp.py::test_persistence_no_redraw)*

------
https://chatgpt.com/codex/tasks/task_e_68abba7be5888324887dc6a4f487fa8e