### PR TITLE
Respect manual open state in hub view

### DIFF
--- a/cogs/voice_double_xp.py
+++ b/cogs/voice_double_xp.py
@@ -87,6 +87,7 @@ class DoubleVoiceXP(commands.Cog):
         self.bot = bot
         self._tasks: List[asyncio.Task] = []
         self.state: Dict[str, Any] = {}
+        self._prepare_lock = asyncio.Lock()
         self.daily_planner.start()
         asyncio.create_task(self._startup())
 
@@ -110,7 +111,10 @@ class DoubleVoiceXP(commands.Cog):
 
     async def _prepare_today(self, force: bool = False) -> None:
         """Lire/initialiser l'état du jour puis planifier ou reprendre les sessions."""
+        async with self._prepare_lock:
+            await self._prepare_today_locked(force)
 
+    async def _prepare_today_locked(self, force: bool = False) -> None:
         # Cancel any previously scheduled tasks to avoid duplicates.
         for task in self._tasks:
             task.cancel()

--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -149,6 +149,7 @@ class RouletteRefugeCog(commands.Cog):
 
     def _build_hub_embed(self) -> discord.Embed:
         title = f"🎰 {self.config.get('game_display_name', '🤑 Roulette Refuge')} 🎰"
+        is_open = self.state.get("is_open", self._is_open_hours())
         lines = [
             "━━━━━━━━━━━━━━━",
             "💵 Mise minimum : 5 XP",
@@ -161,7 +162,7 @@ class RouletteRefugeCog(commands.Cog):
             "━━━━━━━━━━━━━━━",
             (
                 f"🟢 État : Ouvert — ferme à ⏰ {int(self.config.get('close_hour', 2)):02d}:00"
-                if self._is_open_hours()
+                if is_open
                 else f"🔴 État : Fermé — ouvre à ⏰ {int(self.config.get('open_hour', 8)):02d}:00"
             ),
         ]
@@ -169,7 +170,7 @@ class RouletteRefugeCog(commands.Cog):
 
     def _build_hub_view(self) -> discord.ui.View:
         cog = self
-        is_open = self._is_open_hours()
+        is_open = self.state.get("is_open", self._is_open_hours())
 
         class HubView(discord.ui.View):
             def __init__(self) -> None:

--- a/tests/test_pari_xp_open_hours.py
+++ b/tests/test_pari_xp_open_hours.py
@@ -1,6 +1,7 @@
 import importlib
 from pathlib import Path
 import sys
+import asyncio
 
 
 def test_is_open_hours_respects_config_and_embed():
@@ -9,6 +10,7 @@ def test_is_open_hours_respects_config_and_embed():
 
     cog = object.__new__(pari_xp.RouletteRefugeCog)
     cog.config = {"open_hour": 10, "close_hour": 3}
+    cog.state = {}
     tz = pari_xp.timezones.TZ_PARIS
 
     assert cog._is_open_hours(pari_xp.datetime(2023, 1, 1, 10, 0, tzinfo=tz))
@@ -19,3 +21,26 @@ def test_is_open_hours_respects_config_and_embed():
     cog._now = lambda: pari_xp.datetime(2023, 1, 1, 11, 0, tzinfo=tz)
     desc = cog._build_hub_embed().description or ""
     assert "ferme à ⏰ 03:00" in desc
+
+
+def test_hub_view_respects_state_override():
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    pari_xp = importlib.import_module("main.cogs.pari_xp")
+
+    cog = object.__new__(pari_xp.RouletteRefugeCog)
+    cog.config = {"open_hour": 10, "close_hour": 3}
+    cog.state = {"is_open": True}
+    cog._is_open_hours = lambda dt=None: False
+
+    desc = cog._build_hub_embed().description or ""
+    assert "🟢 État : Ouvert" in desc
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        async def run():
+            return cog._build_hub_view()
+        view = loop.run_until_complete(run())
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+    assert any(isinstance(c, pari_xp.ui.Button) for c in view.children)


### PR DESCRIPTION
## Summary
- ensure voice XP schedule prepares only once by locking `_prepare_today`

## Testing
- `pytest tests/test_voice_double_xp.py::test_persistence_no_redraw -q`
- `pytest -q`
- `ruff check .` *(fails: tests/test_stats_update.py F841)*
- `ruff check cogs/voice_double_xp.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac119a4e308324a7cdbcc5b78e5639