### PR TITLE
fix: refresh slot poster when reopening

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -421,16 +421,22 @@ class MachineASousCog(commands.Cog):
                 ch = self.bot.get_channel(stored_ch_id)
                 if isinstance(ch, (discord.TextChannel, discord.Thread)):
                     try:
-                        await ch.fetch_message(int(poster.get("message_id", 0)))
+                        msg = await ch.fetch_message(int(poster.get("message_id", 0)))
+                        has_view = bool(msg.components)
+                        if has_view != self.current_view_enabled:
+                            await self._replace_poster_message()
                         return
                     except discord.NotFound as e:
                         logger.debug("Poster message missing: %s", e)
         existing = await self._find_existing_poster()
         if existing:
-            self.store.set_poster(
-                channel_id=str(existing.channel.id),
-                message_id=str(existing.id),
-            )
+            if bool(existing.components) != self.current_view_enabled:
+                await self._replace_poster_message()
+            else:
+                self.store.set_poster(
+                    channel_id=str(existing.channel.id),
+                    message_id=str(existing.id),
+                )
         else:
             await self._replace_poster_message()
 

--- a/tests/test_machine_a_sous_restart_open.py
+++ b/tests/test_machine_a_sous_restart_open.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from pathlib import Path
+
+import pytest
+import discord
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+from cogs.machine_a_sous.machine_a_sous import MachineASousCog
+
+
+@pytest.mark.asyncio
+async def test_restart_open_replaces_closed_poster(monkeypatch):
+    monkeypatch.setattr(
+        "cogs.machine_a_sous.machine_a_sous.is_open_now", lambda *_, **__: True
+    )
+
+    channel = AsyncMock(spec=discord.TextChannel)
+    channel.id = 123
+    channel.fetch_message = AsyncMock(return_value=SimpleNamespace(components=[]))
+
+    get_channel_mock = MagicMock(return_value=channel)
+    bot = SimpleNamespace(
+        get_channel=get_channel_mock,
+        wait_until_ready=AsyncMock(),
+        loop=asyncio.get_event_loop(),
+    )
+
+    cog = MachineASousCog(bot)
+    monkeypatch.setattr(
+        cog.store,
+        "get_poster",
+        lambda: {"channel_id": str(channel.id), "message_id": "456"},
+    )
+    monkeypatch.setattr(cog.store, "set_poster", lambda *args, **kwargs: None)
+    cog._replace_poster_message = AsyncMock()
+    cog._ensure_state_message = AsyncMock()
+    cog.maintenance_loop.start = MagicMock()
+
+    await cog._init_after_ready()
+
+    cog._replace_poster_message.assert_awaited_once()


### PR DESCRIPTION
## Summary
- ensure slot machine poster message matches open state after restart
- add regression test for poster refresh when bot restarts while open

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac1a95d8308324bc79cfb2438ed15c