### PR TITLE
Handle embed removal in safe_message_edit

### DIFF
--- a/tests/test_machine_a_sous_final_message.py
+++ b/tests/test_machine_a_sous_final_message.py
@@ -1,0 +1,56 @@
+import os
+import sys
+from pathlib import Path
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+from cogs.machine_a_sous.machine_a_sous import MachineASousView
+
+
+@pytest.mark.asyncio
+async def test_single_spin_shows_gain(monkeypatch):
+    # Avoid real sleep and randomness
+    monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+    monkeypatch.setattr("random.choices", lambda *a, **k: [20])
+    monkeypatch.setattr(
+        "utils.discord_utils.limiter", SimpleNamespace(acquire=AsyncMock())
+    )
+
+    message = SimpleNamespace(
+        content="",
+        embeds=[SimpleNamespace(to_dict=lambda: {})],
+        edit=AsyncMock(),
+    )
+
+    class DummyFollowup:
+        async def send(self, *args, **kwargs):
+            return message
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=1, mention="@user"),
+        guild=None,
+        guild_id=1,
+        followup=DummyFollowup(),
+    )
+
+    view = MachineASousView()
+
+    async def fake_reward_xp_gain(self, interaction, cog, gain, free):
+        return (f"🎰 Résultat : **{gain} XP**.", False, None, 0, 0, 0, 0)
+
+    view._reward_xp_gain = fake_reward_xp_gain.__get__(view, MachineASousView)
+
+    cog = SimpleNamespace(bot=SimpleNamespace(), store=SimpleNamespace())
+
+    await view._single_spin(interaction, cog)
+
+    message.edit.assert_awaited_once()
+    assert "🎰 Résultat" in message.edit.await_args.kwargs["content"]
+    assert message.edit.await_args.kwargs["embed"] is None

--- a/tests/test_safe_message_edit_remove_embed.py
+++ b/tests/test_safe_message_edit_remove_embed.py
@@ -1,0 +1,30 @@
+import os
+import sys
+from pathlib import Path
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+from utils.discord_utils import safe_message_edit
+
+
+@pytest.mark.asyncio
+async def test_safe_message_edit_removes_embed(monkeypatch):
+    embed = SimpleNamespace(to_dict=lambda: {"a": 1})
+    message = SimpleNamespace(
+        content="hello",
+        embeds=[embed],
+        edit=AsyncMock(),
+        channel=SimpleNamespace(id=123),
+    )
+    monkeypatch.setattr(
+        "utils.discord_utils.limiter", SimpleNamespace(acquire=AsyncMock())
+    )
+
+    await safe_message_edit(message, embed=None)
+
+    message.edit.assert_awaited_once_with(embed=None)

--- a/utils/discord_utils.py
+++ b/utils/discord_utils.py
@@ -68,9 +68,16 @@ async def safe_message_edit(message: discord.Message, **kwargs) -> discord.Messa
 
     same_embed = True
     if "embed" in kwargs:
-        same_embed = len(current_embeds) == 1 and current_embeds[0].to_dict() == kwargs["embed"].to_dict()
+        embed = kwargs["embed"]
+        if embed is None:
+            same_embed = len(current_embeds) == 0
+        else:
+            same_embed = (
+                len(current_embeds) == 1
+                and current_embeds[0].to_dict() == embed.to_dict()
+            )
     elif "embeds" in kwargs:
-        new_embeds = kwargs["embeds"]
+        new_embeds = kwargs.get("embeds") or []
         same_embed = len(current_embeds) == len(new_embeds) and all(
             m.to_dict() == n.to_dict() for m, n in zip(current_embeds, new_embeds)
         )


### PR DESCRIPTION
## Summary
- Avoid calling `to_dict` when removing an embed
- Test removing embeds from messages and slot machine result updates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4154af108324a6d813ef9dbc935d