### PR TITLE
Add machine ticket slash command

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -638,6 +638,23 @@ class MachineASousCog(commands.Cog):
     )
 
     @group.command(
+        name="ticket",
+        description="Accorder un ticket de machine à sous",
+    )
+    @app_commands.describe(member="Membre à créditer")
+    @app_commands.checks.has_role(1403510368340410550)
+    async def ticket(
+        self, interaction: discord.Interaction, member: discord.Member
+    ) -> None:
+        with measure("slash:machine_ticket"):
+            self.store.grant_ticket(str(member.id))
+            self.store.unmark_claimed(str(member.id))
+            await interaction.response.send_message(
+                f"✅ Ticket accordé à {member.mention}.",
+                ephemeral=True,
+            )
+
+    @group.command(
         name="refresh",
         description="Republier le message de la machine à sous",
     )

--- a/tests/test_machine_a_sous_ticket_command.py
+++ b/tests/test_machine_a_sous_ticket_command.py
@@ -1,0 +1,55 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from pathlib import Path
+import os
+
+import pytest
+
+import sys
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+from cogs.machine_a_sous.machine_a_sous import MachineASousCog
+from storage.roulette_store import RouletteStore
+from discord.app_commands import errors
+
+ROLE_ID = 1403510368340410550
+
+
+def _member_with_roles(role_ids):
+    roles = [SimpleNamespace(id=r) for r in role_ids]
+    return SimpleNamespace(
+        roles=roles,
+        get_role=lambda i: next((r for r in roles if r.id == i), None),
+    )
+
+
+def test_ticket_check_requires_role():
+    check = MachineASousCog.ticket.checks[0]
+    with_role = SimpleNamespace(user=_member_with_roles([ROLE_ID]))
+    without_role = SimpleNamespace(user=_member_with_roles([]))
+    assert check(with_role)
+    with pytest.raises(errors.MissingRole):
+        check(without_role)
+
+
+@pytest.mark.asyncio
+async def test_ticket_command_grants_ticket(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "cogs.machine_a_sous.machine_a_sous.DATA_DIR", str(tmp_path)
+    )
+    bot = SimpleNamespace(wait_until_ready=asyncio.sleep)
+    cog = MachineASousCog(bot)
+    cog.store = RouletteStore(data_dir=str(tmp_path))
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=1),
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    member = SimpleNamespace(id=123, mention="@user")
+
+    await MachineASousCog.ticket.callback(cog, interaction, member)
+
+    assert cog.store.has_ticket(str(member.id))
+


### PR DESCRIPTION
## Summary
- allow admins to grant slot machine tickets via `/machine ticket`
- cover ticket command with tests

## Testing
- `ruff check cogs/machine_a_sous/machine_a_sous.py tests/test_machine_a_sous_ticket_command.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac42a3c81083248c9de474ad256c72