### PR TITLE
Implement shared free ticket system for games

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -22,6 +22,7 @@ from config import (
     MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES,
 )
 from utils.discord_utils import safe_message_edit
+from utils.economy_tickets import consume_free_ticket
 logger = logging.getLogger(__name__)
 
 PARIS_TZ = "Europe/Paris"
@@ -302,6 +303,11 @@ class MachineASousView(discord.ui.View):
         # Utilise d'abord un ticket disponible, même si l'utilisateur n'a pas
         # encore effectué son tirage quotidien. Cela permet d'utiliser un
         # ticket « en réserve » sans consommer l'essai journalier.
+        if consume_free_ticket(int(uid)):
+            await interaction.response.defer(ephemeral=True)
+            await self._single_spin(interaction, cog, free=True)
+            return
+
         if cog.store.use_ticket(uid):
             await interaction.response.defer(ephemeral=True)
             await self._single_spin(interaction, cog, free=True)

--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -25,6 +25,7 @@ from utils.storage import load_json
 from storage.roulette_store import RouletteStore
 from config import DATA_DIR
 from utils.discord_utils import safe_message_edit
+from utils.economy_tickets import consume_free_ticket
 
 PARI_XP_DATA_DIR = "main/data/pari_xp/"
 CONFIG_PATH = PARI_XP_DATA_DIR + "config.json"
@@ -772,7 +773,8 @@ class RouletteRefugeCog(commands.Cog):
                 outcome_color = random.choice(["rouge", "noir"])
                 segment = f"color_{outcome_color}"
                 payout = amount * 2 if color_choice == outcome_color else 0
-                delta = payout - amount
+                ticket_used = consume_free_ticket(user_id)
+                delta = payout if ticket_used else payout - amount
                 result = {
                     "payout": payout,
                     "delta": delta,
@@ -783,8 +785,11 @@ class RouletteRefugeCog(commands.Cog):
             else:
                 segment = self._draw_segment()
                 result = self._compute_result(amount, segment)
+                ticket_used = consume_free_ticket(user_id)
+                payout = int(cast(int, result["payout"]))
+                result["delta"] = payout if ticket_used else result["delta"]
+                delta = int(cast(int, result["delta"]))
             ts = self._now().isoformat()
-            delta = int(cast(int, result["delta"]))
             add_user_xp(
                 user_id,
                 delta,

--- a/tests/test_economy_consume_free_ticket.py
+++ b/tests/test_economy_consume_free_ticket.py
@@ -1,0 +1,25 @@
+import asyncio
+from pathlib import Path
+
+from utils.economy_tickets import consume_free_ticket
+import utils.economy_tickets as et
+from storage.transaction_store import TransactionStore
+from utils.persist import atomic_write_json
+from utils.storage import load_json
+
+
+async def test_consume_free_ticket(tmp_path):
+    ticket_path = tmp_path / "tickets.json"
+    tx_path = tmp_path / "transactions.json"
+    atomic_write_json(ticket_path, {"123": 1})
+    # Monkeypatch paths and transactions store
+    et.TICKETS_FILE = ticket_path
+    et.transactions = TransactionStore(tx_path)
+
+    assert consume_free_ticket(123) is True
+    assert consume_free_ticket(123) is False
+    # Allow async logging task to complete
+    await asyncio.sleep(0)
+    assert load_json(ticket_path, {}) == {}
+    txs = await et.transactions.all()
+    assert txs and txs[0]["type"] == "ticket_usage"

--- a/tests/test_machine_a_sous_free_ticket_priority.py
+++ b/tests/test_machine_a_sous_free_ticket_priority.py
@@ -1,0 +1,66 @@
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from cogs.machine_a_sous.machine_a_sous import MachineASousCog, MachineASousView
+from storage.roulette_store import RouletteStore
+import utils.economy_tickets as et
+from utils.persist import atomic_write_json
+from storage.transaction_store import TransactionStore
+from utils.storage import load_json
+
+
+@pytest.mark.asyncio
+async def test_free_ticket_prioritized_over_store(tmp_path, monkeypatch):
+    monkeypatch.setattr("cogs.machine_a_sous.machine_a_sous.is_open_now", lambda *a, **k: True)
+    monkeypatch.setattr("cogs.machine_a_sous.machine_a_sous.DATA_DIR", str(tmp_path))
+
+    ticket_path = tmp_path / "tickets.json"
+    tx_path = tmp_path / "transactions.json"
+    atomic_write_json(ticket_path, {"123": 1})
+    et.TICKETS_FILE = ticket_path
+    et.transactions = TransactionStore(tx_path)
+
+    view = MachineASousView()
+    flag = SimpleNamespace(free=None)
+
+    async def fake_single_spin(self, interaction, cog, free=False):
+        flag.free = free
+
+    view._single_spin = fake_single_spin.__get__(view, MachineASousView)  # type: ignore
+
+    bot = SimpleNamespace(wait_until_ready=asyncio.sleep)
+    cog = MachineASousCog(bot)
+    cog.store = RouletteStore(data_dir=str(tmp_path))
+    uid = "123"
+    cog.store.grant_ticket(uid)
+    assert cog.store.has_ticket(uid)
+
+    class DummyResponse:
+        async def defer(self, **kwargs):
+            pass
+
+        async def send_message(self, *args, **kwargs):
+            pass
+
+    class DummyFollowup:
+        async def send(self, *args, **kwargs):
+            pass
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=int(uid)),
+        guild=SimpleNamespace(),
+        guild_id=1,
+        client=SimpleNamespace(get_cog=lambda name: cog),
+        response=DummyResponse(),
+        followup=DummyFollowup(),
+    )
+
+    button = next(child for child in view.children if getattr(child, "custom_id", None) == "machineasous:play")
+    await button.callback(interaction)
+    await asyncio.sleep(0)
+
+    assert flag.free is True
+    assert cog.store.has_ticket(uid)
+    assert load_json(ticket_path, {}) == {}

--- a/tests/test_pari_xp_free_ticket.py
+++ b/tests/test_pari_xp_free_ticket.py
@@ -1,0 +1,72 @@
+import asyncio
+import importlib
+from pathlib import Path
+
+import pytest
+from utils.storage import load_json
+
+
+@pytest.mark.asyncio
+async def test_pari_xp_uses_free_ticket(tmp_path, monkeypatch):
+    import sys
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    pari_xp = importlib.import_module("main.cogs.pari_xp")
+    economy_tickets = importlib.import_module("utils.economy_tickets")
+
+    ticket_path = tmp_path / "tickets.json"
+    tx_path = tmp_path / "transactions.json"
+    economy_tickets.TICKETS_FILE = ticket_path
+    from storage.transaction_store import TransactionStore
+    economy_tickets.transactions = TransactionStore(tx_path)
+    # give free ticket
+    from utils.persist import atomic_write_json
+    atomic_write_json(ticket_path, {"123": 1})
+
+    balance = {123: 100}
+
+    def fake_get_user_xp(uid: int) -> int:
+        return balance.get(uid, 0)
+
+    def fake_add_user_xp(uid: int, amount: int, guild_id: int = 0, source: str = "") -> None:
+        balance[uid] = balance.get(uid, 0) + amount
+
+    monkeypatch.setattr(pari_xp, "get_user_xp", fake_get_user_xp)
+    monkeypatch.setattr(pari_xp, "add_user_xp", fake_add_user_xp)
+    monkeypatch.setattr(pari_xp, "get_user_account_age_days", lambda uid: 10)
+    monkeypatch.setattr(pari_xp, "apply_double_xp_buff", lambda uid, minutes=60: None)
+
+    cog = object.__new__(pari_xp.RouletteRefugeCog)
+    cog.bot = object()
+    cog.config = {"channel_id": 1, "min_bet": 5, "daily_cap": 20, "min_balance_guard": 10}
+    cog.state = {}
+    cog._cooldowns = {}
+    cog._bets_today = {}
+    cog._bets_today_date = pari_xp.date.today()
+    cog._now = lambda: pari_xp.datetime(2024, 1, 1, 12, 0, 0)
+    cog._is_open_hours = lambda dt=None: True
+    cog.roulette_store = pari_xp.RouletteStore(data_dir=str(tmp_path))
+    cog._loss_streak = {}
+    cog._draw_segment = lambda: "win_2x"
+
+    class DummyResponse:
+        async def send_message(self, *args, **kwargs):
+            pass
+
+    class DummyFollowup:
+        async def send(self, *args, **kwargs):
+            pass
+
+    class DummyInteraction:
+        channel_id = 1
+        guild_id = 0
+        user = type("U", (), {"id": 123, "name": "Tester", "display_name": "Tester", "mention": "@Tester"})()
+        response = DummyResponse()
+        followup = DummyFollowup()
+        data = {"components": [{"components": [{"custom_id": "pari_xp_amount", "value": "20"}]}]}
+
+    interaction = DummyInteraction()
+
+    await pari_xp.RouletteRefugeCog._handle_bet_submission(cog, interaction)
+    await asyncio.sleep(0)
+    assert balance[123] == 140
+    assert load_json(ticket_path, {}) == {}

--- a/utils/economy_tickets.py
+++ b/utils/economy_tickets.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Dict
+
+from storage.economy import TICKETS_FILE, transactions
+from utils.storage import load_json
+from utils.persist import atomic_write_json
+
+
+def consume_free_ticket(user_id: int) -> bool:
+    """Consume one free ticket for ``user_id`` if available.
+
+    Returns ``True`` if a ticket was consumed.
+    Updates ``data/economy/tickets.json`` and logs the usage in
+    ``transactions.json``.
+    """
+    tickets: Dict[str, int] = load_json(TICKETS_FILE, {})
+    key = str(user_id)
+    count = int(tickets.get(key, 0))
+    if count <= 0:
+        return False
+
+    count -= 1
+    if count:
+        tickets[key] = count
+    else:
+        tickets.pop(key, None)
+    atomic_write_json(TICKETS_FILE, tickets)
+
+    asyncio.create_task(
+        transactions.add(
+            {
+                "type": "ticket_usage",
+                "user_id": user_id,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+    )
+    return True


### PR DESCRIPTION
## Summary
- add utility to consume free economy tickets and log usage
- allow pari_xp and machine_a_sous to use free tickets before charging XP
- add tests for free ticket consumption and priority

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acd12583fc8324a88e5c8ccc37c47e