### PR TITLE
Ensure economy UI cog loads

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -63,7 +63,7 @@ class RefugeBot(commands.Bot):
             loaded_names.add(module.name)
 
         # Ensure required cogs are loaded even if not discovered
-        for required in ("machine_a_sous", "temp_vc"):
+        for required in ("economy_ui", "machine_a_sous", "temp_vc"):
             if required not in loaded_names:
                 await self.load_extension(f"cogs.{required}")
 


### PR DESCRIPTION
## Summary
- Always load economy_ui cog alongside other required cogs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acd4de6f348324b4af61c4f8d1ec9c