### PR TITLE
Add economy UI and banking tests

### DIFF
--- a/tests/test_bank_transfer.py
+++ b/tests/test_bank_transfer.py
@@ -1,0 +1,52 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, call
+
+import pytest
+
+import cogs.economy_ui as economy_ui
+from cogs.economy_ui import BankTransferModal
+from storage import economy
+from storage.transaction_store import TransactionStore
+
+
+@pytest.mark.asyncio
+async def test_bank_transfer_sends_dm(tmp_path, monkeypatch):
+    tx_file = tmp_path / "transactions.json"
+    store = TransactionStore(tx_file)
+    monkeypatch.setattr(economy, "transactions", store)
+    monkeypatch.setattr(economy_ui, "transactions", store)
+
+    monkeypatch.setattr(economy_ui.xp_adapter, "get_balance", lambda _uid: 1000)
+    add_xp_mock = AsyncMock()
+    monkeypatch.setattr(economy_ui.xp_adapter, "add_xp", add_xp_mock)
+
+    modal = BankTransferModal()
+    modal.amount = SimpleNamespace(value="200")
+    modal.beneficiary = SimpleNamespace(value="2")
+
+    recipient = SimpleNamespace(id=2, send=AsyncMock())
+    client = SimpleNamespace(get_user=lambda _id: recipient)
+
+    response = SimpleNamespace(send_message=AsyncMock())
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=1, mention="@User"),
+        guild=None,
+        guild_id=0,
+        client=client,
+        response=response,
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+    await modal.on_submit(interaction)
+
+    add_xp_mock.assert_has_awaits(
+        [
+            call(1, amount=-200, guild_id=0, source="bank_transfer"),
+            call(2, amount=200, guild_id=0, source="bank_transfer"),
+        ]
+    )
+    txs = await store.all()
+    assert txs[0]["type"] == "gift"
+    assert txs[1]["type"] == "receive"
+    response.send_message.assert_awaited_once()
+    recipient.send.assert_awaited_once()

--- a/tests/test_economy_ui_messages.py
+++ b/tests/test_economy_ui_messages.py
@@ -1,0 +1,52 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cogs.economy_ui as economy_ui
+from cogs.economy_ui import EconomyUICog
+from storage import economy
+
+
+@pytest.mark.asyncio
+async def test_ui_messages_recreated(tmp_path, monkeypatch):
+    # Patch file paths to temporary directory
+    monkeypatch.setattr(economy, "ECONOMY_DIR", tmp_path)
+    monkeypatch.setattr(economy_ui, "ECONOMY_DIR", tmp_path)
+    ui_file = tmp_path / "ui.json"
+    ui_file.write_text(json.dumps({"shop_message_id": 1, "bank_message_id": 2}), encoding="utf-8")
+    monkeypatch.setattr(economy, "UI_FILE", ui_file)
+    monkeypatch.setattr(economy_ui, "CHANNEL_ID", 123)
+
+    # Dummy channel behaving like discord.TextChannel
+    class DummyMessage(SimpleNamespace):
+        pass
+
+    class DummyChannel:
+        def __init__(self):
+            self.sent = []
+
+        async def fetch_message(self, message_id):
+            raise Exception("missing")
+
+        async def send(self, content, view):
+            msg = DummyMessage(id=100 + len(self.sent), pin=AsyncMock(), edit=AsyncMock())
+            self.sent.append(msg)
+            return msg
+
+    channel = DummyChannel()
+    # Make isinstance check succeed
+    monkeypatch.setattr(economy_ui.discord, "TextChannel", DummyChannel)
+
+    bot = SimpleNamespace(get_channel=lambda cid: channel if cid == 123 else None, add_view=lambda view: None)
+
+    cog = EconomyUICog(bot)
+    await cog.cog_load()
+
+    data = json.loads(ui_file.read_text(encoding="utf-8"))
+    assert data["shop_message_id"] == channel.sent[0].id
+    assert data["bank_message_id"] == channel.sent[1].id
+    assert len(channel.sent) == 2
+    for msg in channel.sent:
+        msg.pin.assert_awaited_once()

--- a/tests/test_machine_a_sous_free_ticket_priority.py
+++ b/tests/test_machine_a_sous_free_ticket_priority.py
@@ -1,5 +1,6 @@
 import asyncio
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -21,6 +22,8 @@ async def test_free_ticket_prioritized_over_store(tmp_path, monkeypatch):
     atomic_write_json(ticket_path, {"123": 1})
     et.TICKETS_FILE = ticket_path
     et.transactions = TransactionStore(tx_path)
+    consume_mock = MagicMock(side_effect=et.consume_free_ticket)
+    monkeypatch.setattr("cogs.machine_a_sous.machine_a_sous.consume_free_ticket", consume_mock)
 
     view = MachineASousView()
     flag = SimpleNamespace(free=None)
@@ -64,3 +67,4 @@ async def test_free_ticket_prioritized_over_store(tmp_path, monkeypatch):
     assert flag.free is True
     assert cog.store.has_ticket(uid)
     assert load_json(ticket_path, {}) == {}
+    consume_mock.assert_called_once()

--- a/tests/test_pari_xp_free_ticket.py
+++ b/tests/test_pari_xp_free_ticket.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from utils.storage import load_json
@@ -12,6 +13,8 @@ async def test_pari_xp_uses_free_ticket(tmp_path, monkeypatch):
     sys.path.append(str(Path(__file__).resolve().parent.parent))
     pari_xp = importlib.import_module("main.cogs.pari_xp")
     economy_tickets = importlib.import_module("utils.economy_tickets")
+    consume_mock = MagicMock(side_effect=pari_xp.consume_free_ticket)
+    monkeypatch.setattr(pari_xp, "consume_free_ticket", consume_mock)
 
     ticket_path = tmp_path / "tickets.json"
     tx_path = tmp_path / "transactions.json"
@@ -70,3 +73,4 @@ async def test_pari_xp_uses_free_ticket(tmp_path, monkeypatch):
     await asyncio.sleep(0)
     assert balance[123] == 140
     assert load_json(ticket_path, {}) == {}
+    consume_mock.assert_called_once()


### PR DESCRIPTION
## Summary
- test recreation of economy UI messages from ui.json
- cover bank transfer flow with XP updates, logging and DM
- ensure shop purchases and free ticket consumption are validated

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acd61d021c8324b9797a9c910636e2