### PR TITLE
Log les erreurs des tâches quotidiennes

### DIFF
--- a/cogs/daily_awards.py
+++ b/cogs/daily_awards.py
@@ -218,7 +218,10 @@ class DailyAwards(commands.Cog):
                 target += timedelta(days=1)
             await asyncio.sleep((target - now).total_seconds())
             data = read_json_safe(DAILY_RANK_FILE)
-            await self._maybe_award(data)
+            try:
+                await self._maybe_award(data)
+            except Exception:
+                logger.exception("[daily_awards] Échec de _maybe_award")
 
     async def _startup_check(self) -> None:
         await self.bot.wait_until_ready()

--- a/cogs/daily_ranking.py
+++ b/cogs/daily_ranking.py
@@ -125,7 +125,10 @@ class DailyRankingAndRoles(commands.Cog):
             if now >= target:
                 target += timedelta(days=1)
             await asyncio.sleep((target - now).total_seconds())
-            await self._run_daily_task()
+            try:
+                await self._run_daily_task()
+            except Exception:
+                logger.exception("[daily_ranking] Échec de _run_daily_task")
 
     async def _run_daily_task(self) -> None:
         now = datetime.now(PARIS_TZ)

--- a/cogs/daily_summary_poster.py
+++ b/cogs/daily_summary_poster.py
@@ -155,7 +155,10 @@ class DailySummaryPoster(commands.Cog):
                 target += timedelta(days=1)
             await asyncio.sleep((target - now).total_seconds())
             data = read_json_safe(DAILY_RANK_FILE)
-            await self._maybe_post(data)
+            try:
+                await self._maybe_post(data)
+            except Exception:
+                logger.exception("[daily_summary] Échec de _maybe_post")
 
     async def _startup_check(self) -> None:
         await self.bot.wait_until_ready()


### PR DESCRIPTION
## Summary
- Assure la continuité des tâches planifiées en journalisant toute exception dans `daily_ranking`, `daily_summary_poster` et `daily_awards`.

## Testing
- `ruff check cogs/daily_ranking.py cogs/daily_summary_poster.py cogs/daily_awards.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ace3bb8c8883248806de27623e6642