### PR TITLE
fix: register commands and secure loops

### DIFF
--- a/cogs/economy_ui.py
+++ b/cogs/economy_ui.py
@@ -236,7 +236,10 @@ class EconomyUICog(commands.Cog):
 
     @tasks.loop(minutes=5)
     async def boosts_cleanup(self) -> None:
-        await self._cleanup_boosts_once()
+        try:
+            await self._cleanup_boosts_once()
+        except Exception:
+            logger.exception("Erreur dans boosts_cleanup")
 
     @boosts_cleanup.before_loop
     async def before_boosts_cleanup(self) -> None:

--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -671,4 +671,6 @@ class MachineASousCog(commands.Cog):
         self.maintenance_loop.cancel()
 
 async def setup(bot: commands.Bot):
-    await bot.add_cog(MachineASousCog(bot))
+    cog = MachineASousCog(bot)
+    await bot.add_cog(cog)
+    bot.tree.add_command(cog.group)

--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -259,4 +259,5 @@ class RadioCog(commands.Cog):
 
 
 async def setup(bot: commands.Bot) -> None:
+    bot.add_view(RadioView())
     await bot.add_cog(RadioCog(bot))

--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -158,21 +158,30 @@ class StatsCog(commands.Cog):
                     pass
             self.cache.clear()
         for guild in self.bot.guilds:
-            await self.update_members(guild)
+            try:
+                await self.update_members(guild)
+            except Exception:
+                logger.exception("Erreur refresh_members")
 
     @tasks.loop(minutes=15)
     async def refresh_online(self) -> None:
         """Met à jour le nombre d'utilisateurs en ligne toutes les 15 minutes."""
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
-            await self.update_online(guild)
+            try:
+                await self.update_online(guild)
+            except Exception:
+                logger.exception("Erreur refresh_online")
 
     @tasks.loop(minutes=3)
     async def refresh_voice(self) -> None:
         """Met à jour le nombre d'utilisateurs en vocal toutes les 3 minutes."""
         await self.bot.wait_until_ready()
         for guild in self.bot.guilds:
-            await self.update_voice(guild)
+            try:
+                await self.update_voice(guild)
+            except Exception:
+                logger.exception("Erreur refresh_voice")
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -293,12 +293,15 @@ class TempVCCog(commands.Cog):
 
     @tasks.loop(seconds=TEMP_VC_CHECK_INTERVAL_SECONDS)
     async def cleanup(self) -> None:
-        for channel_id in list(TEMP_VC_IDS):
-            channel = self.bot.get_channel(channel_id)
-            if isinstance(channel, discord.VoiceChannel):
-                await self._update_channel_name(channel)
-        await delete_untracked_temp_vcs(self.bot, TEMP_VC_CATEGORY, TEMP_VC_IDS)
-        save_temp_vc_ids(TEMP_VC_IDS)
+        try:
+            for channel_id in list(TEMP_VC_IDS):
+                channel = self.bot.get_channel(channel_id)
+                if isinstance(channel, discord.VoiceChannel):
+                    await self._update_channel_name(channel)
+            await delete_untracked_temp_vcs(self.bot, TEMP_VC_CATEGORY, TEMP_VC_IDS)
+            save_temp_vc_ids(TEMP_VC_IDS)
+        except Exception:
+            logger.exception("Erreur dans cleanup")
 
     @cleanup.before_loop
     async def before_cleanup(self) -> None:

--- a/cogs/voice_double_xp.py
+++ b/cogs/voice_double_xp.py
@@ -104,7 +104,10 @@ class DoubleVoiceXP(commands.Cog):
 
     @tasks.loop(time=time(hour=0, minute=1, tzinfo=PARIS_TZ))
     async def daily_planner(self) -> None:
-        await self._prepare_today(force=True)
+        try:
+            await self._prepare_today(force=True)
+        except Exception:
+            logger.exception("Erreur dans daily_planner")
 
     @daily_planner.before_loop
     async def before_daily_planner(self) -> None:  # pragma: no cover - simple wait


### PR DESCRIPTION
## Summary
- register machine ticket slash command group
- re-register RadioView persistent view
- add error handling for background loops

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68acf2275e148324af3fa9324b528427