### PR TITLE
Avoid duplicate registration of machine command

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -669,8 +669,10 @@ class MachineASousCog(commands.Cog):
 
     async def cog_unload(self):
         self.maintenance_loop.cancel()
+        self.bot.tree.remove_command(self.group.name)
 
 async def setup(bot: commands.Bot):
     cog = MachineASousCog(bot)
     await bot.add_cog(cog)
+    bot.tree.remove_command(cog.group.name)
     bot.tree.add_command(cog.group)


### PR DESCRIPTION
## Summary
- remove slot machine command before re-registering to prevent `CommandAlreadyRegistered`

## Testing
- `ruff check cogs/machine_a_sous/machine_a_sous.py`
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68acf9b87ec08324ab33dba91f4645e8