### PR TITLE
Use fetch_channel for economy UI channel

### DIFF
--- a/cogs/economy_ui.py
+++ b/cogs/economy_ui.py
@@ -304,7 +304,16 @@ class EconomyUICog(commands.Cog):
         except Exception as e:  # pragma: no cover - best effort
             logger.warning("Lecture ui.json échouée: %s", e)
             ui_data = {}
-        channel = self.bot.get_channel(CHANNEL_ID)
+        try:
+            channel = await self.bot.fetch_channel(CHANNEL_ID)
+        except discord.NotFound:
+            logger.warning("Salon économie introuvable (%s)", CHANNEL_ID)
+            return
+        except discord.Forbidden:
+            logger.warning(
+                "Accès refusé au salon économie (%s)", CHANNEL_ID
+            )
+            return
         if not isinstance(channel, discord.TextChannel):
             logger.warning("Salon économie introuvable (%s)", CHANNEL_ID)
             return


### PR DESCRIPTION
## Summary
- use `fetch_channel` instead of cache-based `get_channel` when loading economy UI
- handle missing or inaccessible channel gracefully

## Testing
- `ruff check cogs/economy_ui.py`
- `pytest` *(fails: 12 failed, 92 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ad05be941883248d528f491287a2a5