### PR TITLE
Simplify radio message detection

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -85,7 +85,7 @@ class RadioCog(commands.Cog):
 
         def is_radio_message(msg: discord.Message) -> bool:
             return any(
-                isinstance(comp, discord.ui.Button) and comp.custom_id == "radio_hiphop"
+                getattr(comp, "custom_id", "") == "radio_hiphop"
                 for row in getattr(msg, "components", [])
                 for comp in getattr(row, "children", [])
             )


### PR DESCRIPTION
## Summary
- Simplify radio message detection to rely solely on button `custom_id`

## Testing
- `pytest` *(fails: assertion errors in unrelated XP and economy tests)*
- `PYTHONPATH=. pytest tests/test_radio_message_fetch.py tests/test_radio_message_beyond_limit.py tests/test_radio_cog_load.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad07fa7e4483248e2bc46f74b3cdf1