### PR TITLE
Handle empty bank transfer list

### DIFF
--- a/cogs/economy_ui.py
+++ b/cogs/economy_ui.py
@@ -266,6 +266,12 @@ class BankView(discord.ui.View):
             members = [
                 m for m in interaction.guild.members if m.id != interaction.user.id
             ]
+        if not members:
+            await interaction.response.send_message(
+                "Aucun membre disponible pour le virement.", ephemeral=True
+            )
+            return
+
         await interaction.response.send_message(
             view=BankTransferView(members), ephemeral=True
         )

--- a/tests/test_bank_transfer.py
+++ b/tests/test_bank_transfer.py
@@ -49,3 +49,22 @@ async def test_bank_transfer_sends_dm(tmp_path, monkeypatch):
     assert txs[1]["type"] == "receive"
     response.send_message.assert_awaited_once()
     recipient.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_open_transfer_no_members():
+    view = economy_ui.BankView()
+    response = SimpleNamespace(send_message=AsyncMock())
+    guild = SimpleNamespace(members=[SimpleNamespace(id=1)])
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=1),
+        guild=guild,
+        response=response,
+    )
+
+    await view.open_transfer.callback(interaction)
+
+    response.send_message.assert_awaited_once()
+    args, kwargs = response.send_message.await_args_list[0]
+    assert kwargs.get("ephemeral") is True
+    assert "Aucun membre" in args[0]


### PR DESCRIPTION
## Summary
- avoid Discord interaction failure when no other members are available for transfers
- add regression test for empty beneficiary list in bank transfer

## Testing
- `python -m pytest tests/test_bank_transfer.py -q`
- `python -m pytest tests/test_economy_ui_messages.py -q`
- `ruff check cogs/economy_ui.py tests/test_bank_transfer.py`
- `mypy cogs/economy_ui.py tests/test_bank_transfer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad0cef48c88324915e111d636e89ec