### PR TITLE
Remove VIP 24h item from shop

### DIFF
--- a/cogs/economy_ui.py
+++ b/cogs/economy_ui.py
@@ -30,7 +30,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_SHOP: dict[str, dict[str, typing.Any]] = {
     "ticket_royal": {"name": "Ticket Royal", "price": 500},
     "double_xp_1h": {"name": "Double XP 1h", "price": 300},
-    "vip_24h": {"name": "VIP 24h", "price": 500},
 }
 
 
@@ -68,13 +67,6 @@ class ShopView(discord.ui.View):
                 label="Double XP 1h",
                 style=discord.ButtonStyle.green,
                 custom_id="shop_buy:double_xp_1h",
-            )
-        )
-        self.add_item(
-            discord.ui.Button(
-                label="VIP 24h",
-                style=discord.ButtonStyle.green,
-                custom_id="shop_buy:vip_24h",
             )
         )
 
@@ -446,23 +438,6 @@ class EconomyUICog(commands.Cog):
             until = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
             boost_list.append({"type": "double_xp", "until": until})
             await save_boosts(boosts)
-        elif item_key == "vip_24h":
-            boosts = load_boosts()
-            key = str(user_id)
-            boost_list = boosts.setdefault(key, [])
-            until = (datetime.now(timezone.utc) + timedelta(hours=24)).isoformat()
-            boost_list.append({"type": "vip", "until": until})
-            await save_boosts(boosts)
-            role_id = getattr(config, "VIP_24H_ROLE_ID", 0)
-            if role_id and interaction.guild:
-                role = interaction.guild.get_role(role_id)
-                if role:
-                    try:
-                        await interaction.user.add_roles(
-                            role, reason="Achat VIP 24h"
-                        )
-                    except Exception:  # pragma: no cover - best effort
-                        logger.warning("Impossible d'ajouter le rôle VIP", exc_info=True)
 
         await transactions.add(
             {

--- a/data/economy/shop.json
+++ b/data/economy/shop.json
@@ -1,5 +1,4 @@
 {
   "ticket_royal": {"name": "Ticket Royal", "price": 500},
-  "double_xp_1h": {"name": "Double XP 1h", "price": 300},
-  "vip_24h": {"name": "VIP 24h", "price": 500}
+  "double_xp_1h": {"name": "Double XP 1h", "price": 300}
 }

--- a/tests/test_shop_buy.py
+++ b/tests/test_shop_buy.py
@@ -8,7 +8,6 @@ import cogs.economy_ui as economy_ui
 from cogs.economy_ui import EconomyUICog
 from storage import economy
 from storage.transaction_store import TransactionStore
-import config
 
 
 def _setup_paths(tmp_path, monkeypatch):
@@ -88,46 +87,6 @@ async def test_shop_buy_double_xp(tmp_path, monkeypatch):
     assert boosts["1"][0]["type"] == "double_xp"
     txs = await economy.transactions.all()
     assert txs[0]["item"] == "double_xp_1h"
-    send_mock.assert_awaited()
-    assert send_mock.call_args.kwargs["ephemeral"] is True
-
-
-@pytest.mark.asyncio
-async def test_shop_buy_vip(tmp_path, monkeypatch):
-    shop_file = _setup_paths(tmp_path, monkeypatch)
-    shop_file.write_text(
-        json.dumps({"vip_24h": {"name": "VIP 24h", "price": 2000}}),
-        encoding="utf-8",
-    )
-
-    monkeypatch.setattr(economy_ui.xp_adapter, "get_balance", lambda _uid: 3000)
-    add_xp_mock = AsyncMock()
-    monkeypatch.setattr(economy_ui.xp_adapter, "add_xp", add_xp_mock)
-    monkeypatch.setattr(config, "VIP_24H_ROLE_ID", 42)
-
-    role = SimpleNamespace(id=42)
-    guild = SimpleNamespace(id=321, get_role=lambda _id: role)
-
-    cog = EconomyUICog(object())
-
-    send_mock = AsyncMock()
-    user = SimpleNamespace(id=1, add_roles=AsyncMock())
-    interaction = SimpleNamespace(
-        data={"custom_id": "shop_buy:vip_24h"},
-        user=user,
-        guild=guild,
-        guild_id=321,
-        response=SimpleNamespace(send_message=send_mock),
-    )
-
-    await cog.on_interaction(interaction)
-
-    add_xp_mock.assert_awaited_once_with(1, amount=-2000, guild_id=321, source="shop")
-    user.add_roles.assert_awaited_once_with(role, reason="Achat VIP 24h")
-    boosts = economy.load_boosts()
-    assert boosts["1"][0]["type"] == "vip"
-    txs = await economy.transactions.all()
-    assert txs[0]["item"] == "vip_24h"
     send_mock.assert_awaited()
     assert send_mock.call_args.kwargs["ephemeral"] is True
 


### PR DESCRIPTION
## Summary
- remove `VIP 24h` from shop data and UI
- keep and test purchase flow for Ticket Royal and 1h Double XP items

## Testing
- `ruff check cogs/economy_ui.py tests/test_shop_buy.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ad0dd1c0f08324832bbe8609fe7cb2