### PR TITLE
fix: load XP balance from disk for bank

### DIFF
--- a/tests/test_bank_transfer.py
+++ b/tests/test_bank_transfer.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, call
+import json
 
 import pytest
 
@@ -7,6 +8,7 @@ import cogs.economy_ui as economy_ui
 from cogs.economy_ui import BankTransferModal
 from storage import economy
 from storage.transaction_store import TransactionStore
+from storage.xp_store import XPStore
 
 
 @pytest.mark.asyncio
@@ -68,3 +70,51 @@ async def test_open_transfer_no_members():
     args, kwargs = response.send_message.await_args_list[0]
     assert kwargs.get("ephemeral") is True
     assert "Aucun membre" in args[0]
+
+
+@pytest.mark.asyncio
+async def test_bank_transfer_uses_persisted_balance(tmp_path, monkeypatch):
+    """The bank transfer should read the balance from disk if the XP store
+    hasn't been initialised yet."""
+
+    tx_file = tmp_path / "transactions.json"
+    store = TransactionStore(tx_file)
+    monkeypatch.setattr(economy, "transactions", store)
+    monkeypatch.setattr(economy_ui, "transactions", store)
+
+    # Prepare a lazy XP store with data for the sender but without loading it
+    xp_file = tmp_path / "data.json"
+    xp_file.write_text(json.dumps({"1": {"xp": 1000}}), encoding="utf-8")
+    xp_store = XPStore(str(xp_file))
+    monkeypatch.setattr(economy_ui.xp_adapter, "xp_store", xp_store)
+
+    add_xp_mock = AsyncMock()
+    monkeypatch.setattr(economy_ui.xp_adapter, "add_xp", add_xp_mock)
+
+    modal = BankTransferModal(beneficiary_id=2)
+    modal.amount = SimpleNamespace(value="200")
+
+    recipient = SimpleNamespace(id=2, send=AsyncMock())
+    client = SimpleNamespace(get_user=lambda _id: recipient)
+    response = SimpleNamespace(send_message=AsyncMock())
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=1, mention="@User"),
+        guild=None,
+        guild_id=0,
+        client=client,
+        response=response,
+        followup=SimpleNamespace(send=AsyncMock()),
+    )
+
+    await modal.on_submit(interaction)
+
+    add_xp_mock.assert_has_awaits(
+        [
+            call(1, amount=-200, guild_id=0, source="bank_transfer"),
+            call(2, amount=200, guild_id=0, source="bank_transfer"),
+        ]
+    )
+    response.send_message.assert_awaited_once()
+    txs = await store.all()
+    assert txs[0]["type"] == "gift"
+    assert txs[1]["type"] == "receive"

--- a/utils/xp_adapter.py
+++ b/utils/xp_adapter.py
@@ -2,11 +2,32 @@
 from __future__ import annotations
 
 from storage.xp_store import xp_store
+from utils.persistence import read_json_safe
 
 
 def get_balance(user_id: int) -> int:
-    """Return current XP balance for ``user_id``."""
-    return int(xp_store.data.get(str(user_id), {}).get("xp", 0))
+    """Return current XP balance for ``user_id``.
+
+    The underlying :mod:`storage.xp_store` lazily loads its data and may not
+    be initialised when this function is called.  If the requested user is not
+    present in the in-memory cache we fallback to reading the JSON file from
+    disk so that features like the bank can operate even before the XP store
+    is fully started.
+    """
+
+    uid = str(user_id)
+    if uid not in xp_store.data:
+        # Load the on-disk data lazily. ``read_json_safe`` returns ``{}`` on
+        # failure so this remains a best-effort operation.
+        try:
+            xp_store.data.update(read_json_safe(xp_store.path))
+        except Exception:
+            # If anything goes wrong we leave the cache untouched and return 0
+            # below. This mirrors the previous behaviour while avoiding hard
+            # failures during bot start-up.
+            pass
+
+    return int(xp_store.data.get(uid, {}).get("xp", 0))
 
 
 async def add_xp(user_id: int, amount: int, guild_id: int, source: str) -> None:


### PR DESCRIPTION
## Summary
- ensure bank uses stored XP by lazily loading data when balance is missing
- cover bank transfer with persisted balance in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad0faa5eb083248006b4c72a7f1b8c