### PR TITLE
feat: adjust base message and voice xp

### DIFF
--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -10,7 +10,6 @@ import asyncio
 import io
 import logging
 import os
-import random
 from datetime import datetime, timezone, timedelta
 
 import discord
@@ -226,7 +225,7 @@ class XPCog(commands.Cog):
         bucket = self._message_cooldown.get_bucket(message)
         if bucket.update_rate_limit():
             return
-        amount = random.randint(5, 15)
+        amount = 8
         old_lvl, new_lvl, old_xp, new_xp = await award_xp(
             message.author.id,
             amount,
@@ -263,7 +262,7 @@ class XPCog(commands.Cog):
             start = voice_times.pop(uid, None)
             if start is not None:
                 duration = now - start
-                xp_amount = int(duration.total_seconds() // 60)
+                xp_amount = int(duration.total_seconds() // 60) * 3
                 if before.channel is not None:
                     event_mult = get_multiplier(before.channel.id, member.id)
                     mult = get_voice_multiplier(event_mult)

--- a/tests/test_xp_amounts.py
+++ b/tests/test_xp_amounts.py
@@ -1,0 +1,55 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from datetime import datetime, timedelta
+
+import cogs.xp as xp
+
+
+@pytest.mark.asyncio
+async def test_message_awards_8_xp(monkeypatch):
+    monkeypatch.setattr(xp, "schedule_checkpoint", AsyncMock())
+    award = AsyncMock(return_value=(0, 0, 0, 0))
+    monkeypatch.setattr(xp, "award_xp", award)
+    bot = SimpleNamespace(announce_level_up=AsyncMock())
+    cog = xp.XPCog(bot)
+    msg = SimpleNamespace(
+        author=SimpleNamespace(bot=False, id=1),
+        guild=SimpleNamespace(id=123),
+        channel=SimpleNamespace(id=456),
+    )
+    await cog.on_message(msg)
+    award.assert_awaited_once()
+    assert award.await_args.args[1] == 8
+
+
+@pytest.mark.asyncio
+async def test_voice_awards_3_xp_per_minute(monkeypatch):
+    monkeypatch.setattr(xp, "schedule_checkpoint", AsyncMock())
+    monkeypatch.setattr(xp, "get_multiplier", lambda *a, **k: 1.0)
+    monkeypatch.setattr(xp, "record_participant", lambda *a, **k: None)
+    monkeypatch.setattr(xp, "get_voice_multiplier", lambda m: m)
+    award = AsyncMock(return_value=(0, 0, 0, 0))
+    monkeypatch.setattr(xp, "award_xp", award)
+    bot = SimpleNamespace(announce_level_up=AsyncMock())
+    cog = xp.XPCog(bot)
+
+    xp.voice_times.clear()
+
+    fixed_now = datetime(2025, 1, 1, 12, 0, tzinfo=xp.PARIS_TZ)
+    class FixedDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+    monkeypatch.setattr(xp, "datetime", FixedDatetime)
+
+    member = SimpleNamespace(bot=False, id=42, guild=SimpleNamespace(id=1, get_channel=lambda _id: None))
+    uid = str(member.id)
+    xp.voice_times[uid] = fixed_now - timedelta(minutes=1)
+    before = SimpleNamespace(channel=SimpleNamespace(id=5))
+    after = SimpleNamespace(channel=None)
+
+    await cog.on_voice_state_update(member, before, after)
+    award.assert_awaited_once()
+    assert award.await_args.args[1] == 3


### PR DESCRIPTION
## Summary
- give 8 XP per message and 3 XP per minute in voice chats
- cover new XP amounts with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad102c80ac832487c9ec0932e70db5