### PR TITLE
Enable presence intent for status tracking

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -103,6 +103,7 @@ def create_bot() -> RefugeBot:
     intents: discord.Intents = discord.Intents(
         guilds=True,
         members=True,
+        presences=True,
         messages=True,
         reactions=True,
         voice_states=True,


### PR DESCRIPTION
## Summary
- allow bot to track member presence by enabling `presences` intent

## Testing
- `ruff check bot.py`
- `mypy bot.py`
- `pytest -q` *(fails: Task exception was never retrieved)*

------
https://chatgpt.com/codex/tasks/task_e_68ad154dbb888324aec764eba67c27db