### PR TITLE
Use config role ID for privileged commands

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -20,6 +20,7 @@ from config import (
     MACHINE_A_SOUS_CHANNEL_ID as CHANNEL_ID,
     DATA_DIR,
     MACHINE_A_SOUS_BOUNDARY_CHECK_INTERVAL_MINUTES,
+    XP_VIEWER_ROLE_ID,
 )
 from utils.discord_utils import safe_message_edit
 from utils.economy_tickets import consume_any_ticket, consume_free_ticket
@@ -643,7 +644,7 @@ class MachineASousCog(commands.Cog):
         description="Accorder un ticket de machine à sous",
     )
     @app_commands.describe(member="Membre à créditer")
-    @app_commands.checks.has_role(1403510368340410550)
+    @app_commands.checks.has_role(XP_VIEWER_ROLE_ID)
     async def ticket(
         self, interaction: discord.Interaction, member: discord.Member
     ) -> None:

--- a/cogs/misc.py
+++ b/cogs/misc.py
@@ -13,7 +13,7 @@ from discord.ext import commands
 from utils.interactions import safe_respond
 from utils.metrics import measure
 from view import PlayerTypeView
-from config import CHANNEL_ROLES, OWNER_ID
+from config import CHANNEL_ROLES, OWNER_ID, XP_VIEWER_ROLE_ID
 logger = logging.getLogger(__name__)
 
 
@@ -22,7 +22,7 @@ class MiscCog(commands.Cog):
         self.bot = bot
 
     @app_commands.command(name="type_joueur", description="Choisir PC, Console ou Mobile")
-    @app_commands.checks.has_role(1403510368340410550)
+    @app_commands.checks.has_role(XP_VIEWER_ROLE_ID)
     async def type_joueur(self, interaction: discord.Interaction) -> None:
         with measure("slash:type_joueur"):
             if interaction.guild is None:

--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -19,6 +19,7 @@ from discord.ext import commands, tasks
 from config import (
     DATA_DIR,
     ANNOUNCE_CHANNEL_ID,
+    XP_VIEWER_ROLE_ID,
 )
 from utils.timezones import PARIS_TZ
 from utils.interactions import safe_respond
@@ -317,7 +318,7 @@ class XPCog(commands.Cog):
 
 
     @app_commands.command(name="don_xp", description="Donne de l'XP à un membre")
-    @app_commands.checks.has_role(1403510368340410550)
+    @app_commands.checks.has_role(XP_VIEWER_ROLE_ID)
     @app_commands.describe(
         membre="Membre qui reçoit l'XP",
         montant="Quantité d'XP à ajouter",

--- a/tests/test_don_xp_command.py
+++ b/tests/test_don_xp_command.py
@@ -7,8 +7,9 @@ from discord.app_commands import errors
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 import cogs.xp as xp
+from config import XP_VIEWER_ROLE_ID
 
-ROLE_ID = 1403510368340410550
+ROLE_ID = XP_VIEWER_ROLE_ID
 
 
 def _member_with_roles(role_ids):

--- a/tests/test_machine_a_sous_ticket_command.py
+++ b/tests/test_machine_a_sous_ticket_command.py
@@ -13,8 +13,9 @@ os.environ.setdefault("DISCORD_TOKEN", "dummy")
 from cogs.machine_a_sous.machine_a_sous import MachineASousCog
 from storage.roulette_store import RouletteStore
 from discord.app_commands import errors
+from config import XP_VIEWER_ROLE_ID
 
-ROLE_ID = 1403510368340410550
+ROLE_ID = XP_VIEWER_ROLE_ID
 
 
 def _member_with_roles(role_ids):


### PR DESCRIPTION
## Summary
- Centralize privileged command role checks using `XP_VIEWER_ROLE_ID`
- Update tests to use configurable role ID

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad875ab41883248db66671c5cf7ac7