### PR TITLE
Avoid duplicate RouletteRefugeCog on reload

### DIFF
--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -1034,4 +1034,5 @@ class RouletteRefugeCog(commands.Cog):
 
 
 async def setup(bot: commands.Bot):
-    await bot.add_cog(RouletteRefugeCog(bot))
+    if bot.get_cog("RouletteRefugeCog") is None:
+        await bot.add_cog(RouletteRefugeCog(bot))


### PR DESCRIPTION
## Summary
- Ensure `RouletteRefugeCog` is only added once in `pari_xp` setup to prevent `ClientException` when reloading the extension

## Testing
- `ruff check main/cogs/pari_xp.py`
- `pytest -q` *(warn: Task exception was never retrieved: AttributeError: 'types.SimpleNamespace' object has no attribute 'wait_until_ready')*


------
https://chatgpt.com/codex/tasks/task_e_68ad95722d44832490fb38aa217e7530