### PR TITLE
feat: prioritize popular games in temporary voice names

### DIFF
--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -114,19 +114,19 @@ class TempVCCog(commands.Cog):
         base = self._base_name_from_members(channel.members)
 
         # Priorité : nom du jeu > "Endormie" > "Chat"
-        game_name = None
+        game_counts: Dict[str, int] = {}
         for m in channel.members:
             for act in m.activities:
                 if isinstance(act, discord.Game) or (
                     isinstance(act, discord.Activity)
                     and act.type is discord.ActivityType.playing
                 ):
-                    game_name = act.name
+                    game_counts[act.name] = game_counts.get(act.name, 0) + 1
                     break
-            if game_name:
-                break
 
-        if game_name:
+        if game_counts:
+            # Choisit le jeu le plus représenté dans le salon
+            game_name = max(game_counts, key=game_counts.get)
             # Discord limite les noms de salon à 100 caractères ; on réserve
             # l'espace pour la base et le séparateur «  • ».
             max_status_len = 100 - len(base) - 3

--- a/tests/test_temp_vc_game_priority.py
+++ b/tests/test_temp_vc_game_priority.py
@@ -29,3 +29,30 @@ def test_game_name_has_priority_over_sleep_and_chat():
 
     assert cog._compute_channel_name(channel) == "Base • Minecraft"
 
+
+def test_most_common_game_name_used():
+    channel = SimpleNamespace(members=[])
+    bot = SimpleNamespace(get_channel=lambda _id: None)
+
+    with patch.object(temp_vc.tasks.Loop, "start", lambda self, *a, **k: None):
+        cog = temp_vc.TempVCCog(bot)
+
+    cog._base_name_from_members = lambda members: "Base"
+
+    player1 = SimpleNamespace(
+        activities=[discord.Game("Minecraft")],
+        voice=SimpleNamespace(self_mute=False),
+    )
+    player2 = SimpleNamespace(
+        activities=[discord.Game("Minecraft")],
+        voice=SimpleNamespace(self_mute=False),
+    )
+    player3 = SimpleNamespace(
+        activities=[discord.Game("Fortnite")],
+        voice=SimpleNamespace(self_mute=False),
+    )
+
+    channel.members = [player1, player2, player3]
+
+    assert cog._compute_channel_name(channel) == "Base • Minecraft"
+


### PR DESCRIPTION
## Summary
- pick the most popular game among members when renaming temporary voice channels
- test channel naming picks majority game over other statuses

## Testing
- `PYTHONPATH=. pytest -q`
- `ruff check cogs/temp_vc.py tests/test_temp_vc_game_priority.py`


------
https://chatgpt.com/codex/tasks/task_e_68ada3ad4c248324a1c1810b4bb9c961