### PR TITLE
Handle missing FFmpeg during stream playback

### DIFF
--- a/tests/test_play_stream_missing_ffmpeg.py
+++ b/tests/test_play_stream_missing_ffmpeg.py
@@ -1,0 +1,24 @@
+import logging
+import shutil
+
+from utils.voice import play_stream
+
+
+class DummyVoice:
+    def __init__(self) -> None:
+        self.play_called = False
+
+    def is_playing(self) -> bool:
+        return False
+
+    def play(self, source, after=None) -> None:  # pragma: no cover - only sets flag
+        self.play_called = True
+
+
+def test_play_stream_missing_ffmpeg(monkeypatch, caplog):
+    monkeypatch.setattr(shutil, "which", lambda cmd: None)
+    voice = DummyVoice()
+    with caplog.at_level(logging.WARNING):
+        play_stream(voice, "http://example.com")
+    assert "FFmpeg introuvable" in caplog.text
+    assert not voice.play_called

--- a/utils/voice.py
+++ b/utils/voice.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Optional, Callable
+import shutil
+from typing import Callable, Optional
 
 import discord
 
@@ -77,6 +78,9 @@ def play_stream(
 ) -> None:
     """Lance la lecture du flux ``stream_url`` si rien n'est joué."""
     if voice and not voice.is_playing():
+        if shutil.which("ffmpeg") is None:
+            logger.warning("FFmpeg introuvable: impossible de lire le flux %s", stream_url)
+            return
         source = discord.FFmpegPCMAudio(
             stream_url, before_options=FFMPEG_BEFORE, options=FFMPEG_OPTIONS
         )


### PR DESCRIPTION
## Summary
- avoid attempting to play streams when FFmpeg is absent
- add regression test for missing FFmpeg

## Testing
- `ruff check utils/voice.py tests/test_play_stream_missing_ffmpeg.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af254f69808324beacb5e2d8acfa1c