### PR TITLE
Refactor daily ranking to use xp module

### DIFF
--- a/tests/test_daily_ranking_startup_recovery.py
+++ b/tests/test_daily_ranking_startup_recovery.py
@@ -23,7 +23,7 @@ async def test_startup_recovers_and_awards(tmp_path):
     bot = SimpleNamespace(wait_until_ready=AsyncMock())
     cog = DailyRankingAndRoles.__new__(DailyRankingAndRoles)
     cog.bot = bot
-    with patch("cogs.daily_ranking.save_daily_stats_to_disk", new_callable=AsyncMock):
+    with patch("cogs.xp.save_daily_stats_to_disk", new_callable=AsyncMock):
         await DailyRankingAndRoles._startup_check(cog)
 
     data = daily_ranking.read_json_safe(str(rank_file))


### PR DESCRIPTION
## Summary
- import the XP cog module directly in daily ranking
- update daily ranking to reference xp stats and persistence helpers
- adjust startup recovery test for new xp import

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b7775356288324a0329b11d48326ec