### PR TITLE
Use configured guild ID for daily awards

### DIFF
--- a/cogs/daily_awards.py
+++ b/cogs/daily_awards.py
@@ -13,6 +13,7 @@ from discord.ext import commands
 
 from config import (
     AWARD_ANNOUNCE_CHANNEL_ID,
+    GUILD_ID,
     MVP_ROLE_ID,
     WRITER_ROLE_ID,
     VOICE_ROLE_ID,
@@ -67,8 +68,9 @@ class DailyAwards(commands.Cog):
 
     # ── Role management ─────────────────────────────────────
     async def _reset_and_assign(self, winners: Dict[str, int | None]) -> None:
-        guild = self.bot.guilds[0] if self.bot.guilds else None
+        guild = self.bot.get_guild(GUILD_ID)
         if not guild:
+            logger.warning("[daily_awards] Guilde %s introuvable", GUILD_ID)
             return
         roles = {
             "mvp": guild.get_role(MVP_ROLE_ID),
@@ -111,8 +113,11 @@ class DailyAwards(commands.Cog):
                 logger.exception("[daily_awards] Erreur inattendue lors de l'attribution: %s", e)
 
     async def _mention_or_name(self, uid: int) -> str:
-        guild = self.bot.guilds[0] if self.bot.guilds else None
-        member = guild.get_member(uid) if guild else None
+        guild = self.bot.get_guild(GUILD_ID)
+        if not guild:
+            logger.warning("[daily_awards] Guilde %s introuvable", GUILD_ID)
+            return str(uid)
+        member = guild.get_member(uid)
         if member:
             return member.mention
         user = self.bot.get_user(uid)

--- a/tests/test_daily_awards.py
+++ b/tests/test_daily_awards.py
@@ -58,7 +58,7 @@ async def test_roles_reassigned():
     )
 
     cog = DailyAwards.__new__(DailyAwards)
-    cog.bot = SimpleNamespace(guilds=[guild])
+    cog.bot = SimpleNamespace(get_guild=lambda _id: guild)
 
     winners = {"mvp": winner_mvp.id, "msg": winner_msg.id, "vc": winner_vc.id}
     await DailyAwards._reset_and_assign(cog, winners)


### PR DESCRIPTION
## Summary
- fetch guild via `get_guild` using `GUILD_ID`
- handle missing guild in `DailyAwards` utilities
- update test for new `get_guild` usage

## Testing
- `pytest`
- `ruff check cogs/daily_awards.py tests/test_daily_awards.py`


------
https://chatgpt.com/codex/tasks/task_e_68b77806fd8883248c54e1e712d6dfbf