### PR TITLE
Restart rename manager worker when done

### DIFF
--- a/utils/rename_manager.py
+++ b/utils/rename_manager.py
@@ -27,7 +27,7 @@ class _RenameManager:
         self._worker: asyncio.Task | None = None
 
     async def start(self) -> None:
-        if self._worker is None:
+        if self._worker is None or self._worker.done():
             self._worker = asyncio.create_task(self._run())
 
     async def aclose(self) -> None:


### PR DESCRIPTION
## Summary
- allow rename manager to restart worker if previous task finished

## Testing
- `ruff check .` (fails: F401 unused imports, E722 bare except in storage/xp_store.py)
- `pytest` (81 passed, 1 warning in 99.16s; interrupted during teardown)


------
https://chatgpt.com/codex/tasks/task_e_68ba21a0bc4c8324844849539a2a72b2