### PR TITLE
Handle rename manager cancellation correctly

### DIFF
--- a/tests/test_rename_manager_aclose.py
+++ b/tests/test_rename_manager_aclose.py
@@ -1,0 +1,23 @@
+import os
+import sys
+import asyncio
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+from utils.rename_manager import _RenameManager
+
+
+@pytest.mark.asyncio
+async def test_aclose_finishes_without_blocking():
+    rm = _RenameManager()
+    await rm.start()
+    # ensure the worker coroutine starts and waits for queue
+    await asyncio.sleep(0)
+
+    await asyncio.wait_for(rm.aclose(), timeout=0.5)
+
+    assert rm._worker is None or rm._worker.done()

--- a/utils/rename_manager.py
+++ b/utils/rename_manager.py
@@ -140,6 +140,8 @@ class _RenameManager:
                         break
 
                 self._queue.task_done()
+            except asyncio.CancelledError:
+                raise
             except Exception:
                 logging.exception("[rename_manager] worker encountered an error")
                 if cid is not None:


### PR DESCRIPTION
## Summary
- ensure `_run` re-raises `asyncio.CancelledError`
- add test for rename manager aclose not blocking

## Testing
- `pytest tests/test_rename_manager_aclose.py tests/test_rename_manager_deleted_channel.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba22b3d8708324b479b6a30d3d823c