### PR TITLE
Ensure rename manager before cached renames

### DIFF
--- a/cogs/stats.py
+++ b/cogs/stats.py
@@ -64,6 +64,7 @@ class StatsCog(commands.Cog):
             logger.exception("Erreur inattendue lors du démarrage de StatsCog")
 
     async def _apply_cache(self) -> None:
+        await _ensure_rename_manager_started()
         for guild in self.bot.guilds:
             gid = str(getattr(guild, "id", 0))
             data = self.cache.get(gid)


### PR DESCRIPTION
## Summary
- start rename manager before applying cached channel renames

## Testing
- `ruff check cogs/stats.py`
- `pytest -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68ba23780ea08324986fcd03d9a7cf03