### PR TITLE
Clean up rename manager memory on channel deletion

### DIFF
--- a/tests/test_rename_manager_deleted_channel.py
+++ b/tests/test_rename_manager_deleted_channel.py
@@ -30,6 +30,8 @@ async def test_skip_when_channel_deleted(monkeypatch, caplog):
     guild = SimpleNamespace(get_channel=lambda cid: None)
     channel = SimpleNamespace(id=123, name="old", guild=guild, edit=edit)
 
+    rm._last_per_channel[channel.id] = 0.0
+
     caplog.set_level(logging.DEBUG)
 
     await rm.request(channel, "new")
@@ -37,6 +39,7 @@ async def test_skip_when_channel_deleted(monkeypatch, caplog):
     await rm.aclose()
 
     assert called is False
+    assert channel.id not in rm._last_per_channel
     assert any(
         "deleted before rename" in record.getMessage() for record in caplog.records
     )

--- a/utils/rename_manager.py
+++ b/utils/rename_manager.py
@@ -23,6 +23,7 @@ class _RenameManager:
         self._queue: asyncio.Queue[int] = asyncio.Queue()
         self._pending: Dict[int, Tuple[discord.abc.GuildChannel, str]] = {}
         self._last_per_channel: Dict[int, float] = {}
+        # TODO: consider periodic cleanup for IDs that are never reused
         self._last_global: float = 0.0
         self._worker: asyncio.Task | None = None
 
@@ -89,6 +90,7 @@ class _RenameManager:
                         "[rename_manager] channel %s deleted before rename; skipping",
                         cid,
                     )
+                    self._last_per_channel.pop(cid, None)
                     self._queue.task_done()
                     continue
 


### PR DESCRIPTION
## Summary
- free `_last_per_channel` entries when a channel is deleted
- add a test for cleanup of deleted channels
- note potential periodic cleanup for unused channel IDs

## Testing
- `ruff check utils/rename_manager.py tests/test_rename_manager_deleted_channel.py`
- `mypy utils/rename_manager.py tests/test_rename_manager_deleted_channel.py`
- `pytest` *(interrupted after reporting 82 passed)*
- `PYTHONPATH=. pytest tests/test_rename_manager_deleted_channel.py`


------
https://chatgpt.com/codex/tasks/task_e_68ba26e6c38c832485b54803dfbef0a4