### PR TITLE
Ajout d'un avertissement si le classement est absent

### DIFF
--- a/cogs/daily_summary_poster.py
+++ b/cogs/daily_summary_poster.py
@@ -111,6 +111,7 @@ class DailySummaryPoster(commands.Cog):
     # ── Core logic ───────────────────────────────────────────
     async def _maybe_post(self, data: Dict[str, Any]) -> None:
         if not data:
+            logger.warning("[daily_summary] Données de classement absentes")
             return
         summary = self._read_summary()
         channel = self.bot.get_channel(ACTIVITY_SUMMARY_CH)


### PR DESCRIPTION
## Summary
- Journalise un avertissement dans `_maybe_post` lorsque les données de classement sont absentes avant de retourner.

## Testing
- `ruff check cogs/daily_summary_poster.py`
- `mypy cogs/daily_summary_poster.py` *(échoue : Incompatible types in assignment)*
- `pytest` *(processus interrompu)*

------
https://chatgpt.com/codex/tasks/task_e_68ba2707e2a88324bb4960770422f03a