### PR TITLE
Enable presence intent

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ def main() -> None:
         reactions=True,
         voice_states=True,
         message_content=True,
+        presences=True,
     )
     token = os.getenv("DISCORD_TOKEN")
     if not token:


### PR DESCRIPTION
## Summary
- enable presence intent in main startup

## Testing
- `ruff check main.py`
- `pytest`
- `python main.py` *(fails: DISCORD_TOKEN environment variable not set)*

------
https://chatgpt.com/codex/tasks/task_e_68bb80bb1e608324adb270baf1f3f165