### PR TITLE
Remove duplicate pari_xp scheduler close actions

### DIFF
--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -379,9 +379,6 @@ class RouletteRefugeCog(commands.Cog):
             await self._announce_close(channel)
             await self._update_hub_state(False)
             await self._post_daily_summary(channel)
-            await self._announce_close(channel)
-            await self._update_hub_state(False)
-            await self._post_daily_summary(channel)
 
     @scheduler_task.before_loop
     async def _wait_ready_scheduler(self) -> None:


### PR DESCRIPTION
## Summary
- Avoid calling close announcements twice in `scheduler_task`

## Testing
- `python -m pytest tests/test_pari_xp_*`


------
https://chatgpt.com/codex/tasks/task_e_68bb83d4d87483248a9ebbbd02a19582