### PR TITLE
fix: remove duplicate segment assignment

### DIFF
--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -607,7 +607,6 @@ class RouletteRefugeCog(commands.Cog):
                 outcome_color = random.choice(["rouge", "noir"])
                 segment = f"color_{outcome_color}"
                 payout = amount * 2 if color_choice == outcome_color else 0
-                segment = f"color_{outcome_color}"
                 result = {
                     "payout": payout,
                     "delta": payout - amount,


### PR DESCRIPTION
## Summary
- remove duplicated `segment` assignment in color bet logic
- ensure `segment` remains defined for transaction recording

## Testing
- `ruff check main/cogs/pari_xp.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb850477988324bff9567be60c3b58