### PR TITLE
Add daily leaderboard with role rewards

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -65,7 +65,12 @@ class RefugeBot(commands.Bot):
             loaded_names.add(module.name)
 
         # Ensure required cogs are loaded even if not discovered
-        for required in ("economy_ui", "machine_a_sous", "temp_vc"):
+        for required in (
+            "economy_ui",
+            "machine_a_sous",
+            "temp_vc",
+            "daily_leaderboard",
+        ):
             if required not in loaded_names:
                 await self.load_extension(f"cogs.{required}")
 

--- a/cogs/daily_leaderboard.py
+++ b/cogs/daily_leaderboard.py
@@ -1,0 +1,223 @@
+"""Classement quotidien : attribution de rôles et annonce des gagnants."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import datetime, time, timedelta
+from typing import Any, Dict
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from config import (
+    ANNOUNCE_CHANNEL_ID,
+    DATA_DIR,
+    ENABLE_DAILY_AWARDS,
+    GUILD_ID,
+    MVP_ROLE_ID,
+    TOP_MSG_ROLE_ID,
+    TOP_VC_ROLE_ID,
+)
+from utils.timezones import PARIS_TZ
+from utils.persistence import read_json_safe, atomic_write_json_async, ensure_dir
+from utils.interactions import safe_respond
+
+from cogs.xp import DAILY_STATS, DAILY_LOCK, save_daily_stats_to_disk
+
+logger = logging.getLogger(__name__)
+
+DAILY_WINNERS_FILE = os.path.join(DATA_DIR, "daily_winners.json")
+ensure_dir(DATA_DIR)
+
+
+class DailyLeaderboard(commands.Cog):
+    """Calcule et publie le classement quotidien."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._startup_task = asyncio.create_task(self._startup_recovery())
+        if ENABLE_DAILY_AWARDS:
+            self.daily_reset.start()
+
+    def cog_unload(self) -> None:  # pragma: no cover - cleanup
+        if self.daily_reset.is_running():
+            self.daily_reset.cancel()
+        self._startup_task.cancel()
+
+    async def _startup_recovery(self) -> None:
+        await self.bot.wait_until_ready()
+        today = datetime.now(PARIS_TZ).date()
+        async with DAILY_LOCK:
+            pending = [
+                day
+                for day in DAILY_STATS.keys()
+                if datetime.fromisoformat(day).date() < today
+            ]
+        for day in sorted(pending):
+            try:
+                data = await self._calculate_daily_winners(day)
+                if data:
+                    await self._save_winners(day, data)
+            except Exception:
+                logger.exception("[daily_leaderboard] Échec récupération pour %s", day)
+
+    @tasks.loop(time=time(hour=0, minute=1, tzinfo=PARIS_TZ))
+    async def daily_reset(self) -> None:
+        """Tâche quotidienne qui calcule les gagnants du jour précédent."""
+        day = (datetime.now(PARIS_TZ) - timedelta(days=1)).date().isoformat()
+        data = await self._calculate_daily_winners(day)
+        if not data:
+            return
+        await self._save_winners(day, data)
+        if ENABLE_DAILY_AWARDS:
+            guild = self.bot.get_guild(GUILD_ID) if GUILD_ID else (self.bot.guilds[0] if self.bot.guilds else None)
+            if guild:
+                await self._update_daily_roles(guild, data["winners"])
+            await self._announce_winners(data)
+
+    @daily_reset.before_loop
+    async def before_daily_reset(self) -> None:  # pragma: no cover - startup
+        await self.bot.wait_until_ready()
+
+    async def _save_winners(self, day: str, data: Dict[str, Any]) -> None:
+        existing = read_json_safe(DAILY_WINNERS_FILE)
+        existing[day] = data
+        try:
+            await atomic_write_json_async(DAILY_WINNERS_FILE, existing)
+        except OSError as e:  # pragma: no cover - log
+            logger.exception("[daily_leaderboard] Échec sauvegarde gagnants: %s", e)
+
+    async def _calculate_daily_winners(self, date: str) -> Dict[str, Any] | None:
+        """Calcule les gagnants à partir des statistiques journalières."""
+        async with DAILY_LOCK:
+            stats = DAILY_STATS.pop(date, None)
+        await save_daily_stats_to_disk()
+        if not stats:
+            logger.info("[daily_leaderboard] Aucune statistique pour %s", date)
+            return None
+        msg_sorted = sorted(stats.items(), key=lambda x: x[1].get("messages", 0), reverse=True)
+        vc_sorted = sorted(stats.items(), key=lambda x: x[1].get("voice", 0), reverse=True)
+
+        def score(item: tuple[str, Dict[str, int]]) -> float:
+            s = item[1]
+            return s.get("messages", 0) + s.get("voice", 0) / 60.0
+
+        mvp_sorted = sorted(stats.items(), key=score, reverse=True)
+
+        top_msg = [
+            {"id": int(uid), "count": int(data.get("messages", 0))}
+            for uid, data in msg_sorted[:3]
+        ]
+        top_vc = [
+            {"id": int(uid), "minutes": int(data.get("voice", 0) // 60)}
+            for uid, data in vc_sorted[:3]
+        ]
+        top_mvp = [
+            {
+                "id": int(uid),
+                "score": round(score((uid, data)), 2),
+                "messages": int(data.get("messages", 0)),
+                "voice": int(data.get("voice", 0) // 60),
+            }
+            for uid, data in mvp_sorted[:3]
+        ]
+        winners = {
+            "msg": top_msg[0]["id"] if top_msg else None,
+            "vc": top_vc[0]["id"] if top_vc else None,
+            "mvp": top_mvp[0]["id"] if top_mvp else None,
+        }
+        return {"top3": {"msg": top_msg, "vc": top_vc, "mvp": top_mvp}, "winners": winners}
+
+    async def _update_daily_roles(self, guild: discord.Guild, winners: Dict[str, int | None]) -> None:
+        """Réinitialise et attribue les rôles quotidiens."""
+        roles = {
+            "msg": guild.get_role(TOP_MSG_ROLE_ID),
+            "vc": guild.get_role(TOP_VC_ROLE_ID),
+            "mvp": guild.get_role(MVP_ROLE_ID),
+        }
+        for member in guild.members:
+            to_remove = [r for r in roles.values() if r and r in member.roles]
+            if to_remove:
+                try:
+                    await member.remove_roles(*to_remove, reason="Réinitialisation des rôles journaliers")
+                except discord.Forbidden:
+                    logger.warning("[daily_leaderboard] Permissions insuffisantes pour retirer un rôle")
+                except discord.HTTPException as e:
+                    logger.error("[daily_leaderboard] Erreur HTTP lors du retrait d'un rôle: %s", e)
+                except Exception:
+                    logger.exception("[daily_leaderboard] Erreur inattendue lors du retrait d'un rôle")
+        for key, uid in winners.items():
+            role = roles.get(key)
+            if not role or not uid:
+                continue
+            member = guild.get_member(int(uid))
+            if not member:
+                continue
+            try:
+                await member.add_roles(role, reason="Attribution classement quotidien")
+            except discord.Forbidden:
+                logger.warning("[daily_leaderboard] Permissions insuffisantes pour attribuer un rôle")
+            except discord.HTTPException as e:
+                logger.error("[daily_leaderboard] Erreur HTTP lors de l'attribution: %s", e)
+            except Exception:
+                logger.exception("[daily_leaderboard] Erreur inattendue lors de l'attribution du rôle")
+
+    async def _announce_winners(self, data: Dict[str, Any]) -> None:
+        channel = self.bot.get_channel(ANNOUNCE_CHANNEL_ID)
+        if not channel:
+            logger.warning("[daily_leaderboard] Salon %s introuvable", ANNOUNCE_CHANNEL_ID)
+            return
+        winners = data.get("winners", {})
+        lines = ["🏆 **Gagnants du jour**", ""]
+        lines.append(
+            f"👑 MVP : <@{winners['mvp']}>" if winners.get("mvp") else "👑 MVP : Aucun"
+        )
+        lines.append(
+            f"📜 Top messages : <@{winners['msg']}>" if winners.get("msg") else "📜 Top messages : Aucun"
+        )
+        lines.append(
+            f"🎤 Top vocal : <@{winners['vc']}>" if winners.get("vc") else "🎤 Top vocal : Aucun"
+        )
+        try:
+            await channel.send("\n".join(lines))
+        except discord.Forbidden:
+            logger.warning("[daily_leaderboard] Permissions insuffisantes pour envoyer l'annonce")
+        except discord.HTTPException as e:
+            logger.error("[daily_leaderboard] Erreur HTTP lors de l'annonce: %s", e)
+        except Exception:
+            logger.exception("[daily_leaderboard] Erreur inattendue lors de l'annonce")
+
+    @app_commands.command(name="classement_jour", description="Affiche le classement du jour en cours")
+    async def classement_jour(self, interaction: discord.Interaction) -> None:
+        today = datetime.now(PARIS_TZ).date().isoformat()
+        async with DAILY_LOCK:
+            stats = dict(DAILY_STATS.get(today, {}))
+        if not stats:
+            await safe_respond(interaction, "Aucune activité aujourd'hui.", ephemeral=True)
+            return
+        msg_sorted = sorted(stats.items(), key=lambda x: x[1].get("messages", 0), reverse=True)
+        vc_sorted = sorted(stats.items(), key=lambda x: x[1].get("voice", 0), reverse=True)
+
+        def score(item: tuple[str, Dict[str, int]]) -> float:
+            s = item[1]
+            return s.get("messages", 0) + s.get("voice", 0) / 60.0
+
+        mvp_sorted = sorted(stats.items(), key=score, reverse=True)
+        lines = ["🏆 **Classement du jour**", ""]
+        if msg_sorted:
+            top = msg_sorted[:3]
+            lines.append("📜 Messages :" + ", ".join(f"<@{uid}> ({data.get('messages',0)})" for uid, data in top))
+        if vc_sorted:
+            top = vc_sorted[:3]
+            lines.append("🎤 Vocal :" + ", ".join(f"<@{uid}> ({int(data.get('voice',0)//60)}m)" for uid, data in top))
+        if mvp_sorted:
+            top = mvp_sorted[:3]
+            lines.append("👑 MVP :" + ", ".join(f"<@{uid}> ({round(score((uid,data)),2)})" for uid, data in top))
+        await safe_respond(interaction, "\n".join(lines), ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:  # pragma: no cover - integration
+    await bot.add_cog(DailyLeaderboard(bot))

--- a/tests/test_daily_leaderboard.py
+++ b/tests/test_daily_leaderboard.py
@@ -1,0 +1,100 @@
+import asyncio
+from types import SimpleNamespace
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import cogs.xp as xp
+import cogs.daily_leaderboard as dl
+from cogs.daily_leaderboard import DailyLeaderboard
+from config import MVP_ROLE_ID, TOP_MSG_ROLE_ID, TOP_VC_ROLE_ID
+
+
+class DummyRole:
+    def __init__(self, rid: int):
+        self.id = rid
+
+
+class DummyMember:
+    def __init__(self, mid: int, roles=None):
+        self.id = mid
+        self.roles = list(roles) if roles else []
+
+    async def remove_roles(self, *roles, reason=None):
+        for r in roles:
+            if r in self.roles:
+                self.roles.remove(r)
+
+    async def add_roles(self, role, reason=None):
+        if role not in self.roles:
+            self.roles.append(role)
+
+
+class DummyGuild:
+    def __init__(self, members, roles):
+        self.members = members
+        self._roles = roles
+
+    def get_role(self, rid: int):
+        return self._roles.get(rid)
+
+    def get_member(self, uid: int):
+        for m in self.members:
+            if m.id == uid:
+                return m
+        return None
+
+
+@pytest.mark.asyncio
+async def test_calculate_daily_winners(monkeypatch):
+    date = "2024-01-01"
+    xp.DAILY_STATS = {
+        date: {
+            "1": {"messages": 5, "voice": 60},
+            "2": {"messages": 3, "voice": 120},
+        }
+    }
+    dl.DAILY_STATS = xp.DAILY_STATS
+    xp.DAILY_LOCK = asyncio.Lock()
+    dl.DAILY_LOCK = xp.DAILY_LOCK
+
+    async def dummy_save() -> None:
+        return None
+
+    monkeypatch.setattr(xp, "save_daily_stats_to_disk", dummy_save)
+    cog = DailyLeaderboard.__new__(DailyLeaderboard)
+    result = await DailyLeaderboard._calculate_daily_winners(cog, date)
+    assert result["winners"] == {"msg": 1, "vc": 2, "mvp": 1}
+    assert date not in xp.DAILY_STATS
+
+
+@pytest.mark.asyncio
+async def test_update_daily_roles_assigns():
+    mvp = DummyRole(MVP_ROLE_ID)
+    msg = DummyRole(TOP_MSG_ROLE_ID)
+    vc = DummyRole(TOP_VC_ROLE_ID)
+
+    winner_msg = DummyMember(1)
+    winner_vc = DummyMember(2)
+    winner_mvp = DummyMember(3)
+    other = DummyMember(4, roles=[mvp, msg, vc])
+
+    guild = DummyGuild(
+        [winner_msg, winner_vc, winner_mvp, other],
+        {MVP_ROLE_ID: mvp, TOP_MSG_ROLE_ID: msg, TOP_VC_ROLE_ID: vc},
+    )
+
+    cog = DailyLeaderboard.__new__(DailyLeaderboard)
+    await DailyLeaderboard._update_daily_roles(
+        cog,
+        guild,
+        {"msg": 1, "vc": 2, "mvp": 3},
+    )
+
+    assert msg in winner_msg.roles
+    assert vc in winner_vc.roles
+    assert mvp in winner_mvp.roles
+    assert msg not in other.roles and vc not in other.roles and mvp not in other.roles


### PR DESCRIPTION
## Summary
- add `DailyLeaderboard` cog with daily reset, role assignment, and leaderboard command
- ensure bot loads new cog at startup
- tests for computing winners and role assignment

## Testing
- `pytest tests/test_daily_leaderboard.py tests/test_daily_awards.py tests/test_daily_ranking_startup_recovery.py -q`
- `pytest -q` *(failed: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8d7066908324afc0a07cb180a064