### PR TITLE
Fix shop view callbacks and ticket persistence

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -304,7 +304,7 @@ class MachineASousView(discord.ui.View):
         # Utilise d'abord un ticket disponible, même si l'utilisateur n'a pas
         # encore effectué son tirage quotidien. Cela permet d'utiliser un
         # ticket « en réserve » sans consommer l'essai journalier.
-        if consume_any_ticket(int(uid), cog.store, consume_free_ticket):
+        if await consume_any_ticket(int(uid), cog.store, consume_free_ticket):
             await interaction.response.defer(ephemeral=True)
             await self._single_spin(interaction, cog, free=True)
             return

--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -632,7 +632,7 @@ class RouletteRefugeCog(commands.Cog):
                 result = self._compute_result(amount, segment)
 
             payout = int(cast(int, result["payout"]))
-            ticket_used = consume_any_ticket(
+            ticket_used = await consume_any_ticket(
                 user_id, self.roulette_store, consume_free_ticket
             )
             delta = payout if ticket_used else int(cast(int, result["delta"]))

--- a/tests/test_economy_consume_free_ticket.py
+++ b/tests/test_economy_consume_free_ticket.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from utils.economy_tickets import consume_free_ticket
 import utils.economy_tickets as et
 from storage.transaction_store import TransactionStore
@@ -15,10 +13,8 @@ async def test_consume_free_ticket(tmp_path):
     et.TICKETS_FILE = ticket_path
     et.transactions = TransactionStore(tx_path)
 
-    assert consume_free_ticket(123) is True
-    assert consume_free_ticket(123) is False
-    # Allow async logging task to complete
-    await asyncio.sleep(0)
+    assert await consume_free_ticket(123) is True
+    assert await consume_free_ticket(123) is False
     assert load_json(ticket_path, {}) == {}
     txs = await et.transactions.all()
     assert txs and txs[0]["type"] == "ticket_usage"

--- a/tests/test_machine_a_sous_free_ticket_priority.py
+++ b/tests/test_machine_a_sous_free_ticket_priority.py
@@ -1,6 +1,6 @@
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -22,7 +22,7 @@ async def test_free_ticket_prioritized_over_store(tmp_path, monkeypatch):
     atomic_write_json(ticket_path, {"123": 1})
     et.TICKETS_FILE = ticket_path
     et.transactions = TransactionStore(tx_path)
-    consume_mock = MagicMock(side_effect=et.consume_free_ticket)
+    consume_mock = AsyncMock(side_effect=et.consume_free_ticket)
     monkeypatch.setattr("cogs.machine_a_sous.machine_a_sous.consume_free_ticket", consume_mock)
 
     view = MachineASousView()

--- a/tests/test_pari_xp_free_ticket.py
+++ b/tests/test_pari_xp_free_ticket.py
@@ -1,7 +1,7 @@
 import asyncio
 import importlib
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from utils.storage import load_json
@@ -13,7 +13,7 @@ async def test_pari_xp_uses_free_ticket(tmp_path, monkeypatch):
     sys.path.append(str(Path(__file__).resolve().parent.parent))
     pari_xp = importlib.import_module("main.cogs.pari_xp")
     economy_tickets = importlib.import_module("utils.economy_tickets")
-    consume_mock = MagicMock(side_effect=pari_xp.consume_free_ticket)
+    consume_mock = AsyncMock(side_effect=pari_xp.consume_free_ticket)
     monkeypatch.setattr(pari_xp, "consume_free_ticket", consume_mock)
 
     ticket_path = tmp_path / "tickets.json"

--- a/tests/test_pari_xp_store_ticket_usage.py
+++ b/tests/test_pari_xp_store_ticket_usage.py
@@ -1,7 +1,7 @@
 import asyncio
 import importlib
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -12,7 +12,7 @@ async def test_pari_xp_consumes_store_ticket(tmp_path, monkeypatch):
     sys.path.append(str(Path(__file__).resolve().parent.parent))
     pari_xp = importlib.import_module("main.cogs.pari_xp")
 
-    consume_mock = MagicMock(return_value=False)
+    consume_mock = AsyncMock(return_value=False)
     monkeypatch.setattr(pari_xp, "consume_free_ticket", consume_mock)
 
     balance = {123: 100}


### PR DESCRIPTION
## Summary
- use persistent button callbacks in shop view and safer interaction handling
- fix ticket persistence: async free ticket consumption and import
- adapt roulette and pari XP to await ticket utilities

## Testing
- `PYTHONPATH=. pytest tests/test_economy_consume_free_ticket.py tests/test_machine_a_sous_free_ticket_priority.py tests/test_pari_xp_free_ticket.py tests/test_pari_xp_store_ticket_usage.py tests/test_shop_buy.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68bb92d997408324b026885d99fe0068