### PR TITLE
Improve temp VC rename reliability and monitoring

### DIFF
--- a/storage/temp_vc_store.py
+++ b/storage/temp_vc_store.py
@@ -1,11 +1,13 @@
+import asyncio
 import logging
 from pathlib import Path
-from typing import Iterable, Set
+from typing import Dict, Iterable, Set
 
 from config import DATA_DIR
 from utils.persistence import atomic_write_json, read_json_safe
 
 DATA_FILE = Path(DATA_DIR) / "temp_vc_ids.json"
+LAST_NAMES_FILE = Path(DATA_DIR) / "temp_vc_last_names.json"
 
 
 def load_temp_vc_ids() -> Set[int]:
@@ -22,3 +24,53 @@ def save_temp_vc_ids(ids: Iterable[int]) -> None:
         atomic_write_json(DATA_FILE, sorted(set(int(i) for i in ids)))
     except Exception as e:
         logging.error("[temp_vc_store] Écriture échouée pour %s: %s", DATA_FILE, e)
+
+
+def load_last_names_cache() -> Dict[int, str]:
+    """Charge le cache des derniers noms de salons."""
+    data = read_json_safe(LAST_NAMES_FILE)
+    if isinstance(data, dict):
+        return {int(k): str(v) for k, v in data.items()}
+    return {}
+
+
+async def save_temp_vc_ids_async(
+    ids: Iterable[int], max_retries: int = 3
+) -> None:
+    """Sauvegarde asynchrone avec retries des IDs de salons temporaires."""
+    payload = sorted(set(int(i) for i in ids))
+    for attempt in range(max_retries):
+        try:
+            await asyncio.to_thread(atomic_write_json, DATA_FILE, payload)
+            return
+        except Exception as e:
+            logging.error(
+                "[temp_vc_store] Écriture échouée pour %s: %s (tentative %d/%d)",
+                DATA_FILE,
+                e,
+                attempt + 1,
+                max_retries,
+            )
+            if attempt + 1 < max_retries:
+                await asyncio.sleep(2 ** attempt)
+
+
+async def save_last_names_cache(
+    cache: Dict[int, str], max_retries: int = 3
+) -> None:
+    """Sauvegarde asynchrone avec retries du cache des derniers noms."""
+    payload = {str(k): v for k, v in cache.items()}
+    for attempt in range(max_retries):
+        try:
+            await asyncio.to_thread(atomic_write_json, LAST_NAMES_FILE, payload)
+            return
+        except Exception as e:
+            logging.error(
+                "[temp_vc_store] Écriture échouée pour %s: %s (tentative %d/%d)",
+                LAST_NAMES_FILE,
+                e,
+                attempt + 1,
+                max_retries,
+            )
+            if attempt + 1 < max_retries:
+                await asyncio.sleep(2 ** attempt)

--- a/tests/test_temp_vc_channel_name_length.py
+++ b/tests/test_temp_vc_channel_name_length.py
@@ -13,7 +13,15 @@ async def test_channel_name_truncated(monkeypatch):
     loop = asyncio.get_running_loop()
     bot = SimpleNamespace(get_channel=lambda _id: None, loop=loop)
     monkeypatch.setattr(temp_vc.rename_manager, "start", AsyncMock())
-    monkeypatch.setattr(temp_vc, "save_temp_vc_ids", lambda ids: None)
+
+    async def no_save_ids(ids, max_retries=3):
+        return None
+
+    async def no_save_cache(cache, max_retries=3):
+        return None
+
+    monkeypatch.setattr(temp_vc, "save_temp_vc_ids_async", no_save_ids)
+    monkeypatch.setattr(temp_vc, "save_last_names_cache", no_save_cache)
 
     with patch.object(temp_vc.tasks.Loop, "start", lambda self, *a, **k: None):
         cog = temp_vc.TempVCCog(bot)

--- a/tests/test_temp_vc_lobby_creation.py
+++ b/tests/test_temp_vc_lobby_creation.py
@@ -16,7 +16,15 @@ async def test_temp_channel_created_and_removed(monkeypatch):
 
     # avoid starting real rename manager worker and file I/O
     monkeypatch.setattr(temp_vc.rename_manager, "start", AsyncMock())
-    monkeypatch.setattr(temp_vc, "save_temp_vc_ids", lambda ids: None)
+
+    async def no_save_ids(ids, max_retries=3):
+        return None
+
+    async def no_save_cache(cache, max_retries=3):
+        return None
+
+    monkeypatch.setattr(temp_vc, "save_temp_vc_ids_async", no_save_ids)
+    monkeypatch.setattr(temp_vc, "save_last_names_cache", no_save_cache)
 
     with patch.object(temp_vc.tasks.Loop, "start", lambda self, *a, **k: None):
         cog = temp_vc.TempVCCog(bot)
@@ -26,7 +34,7 @@ async def test_temp_channel_created_and_removed(monkeypatch):
 
     async def fake_create_temp_vc(_member):
         temp_vc.TEMP_VC_IDS.add(channel.id)
-        temp_vc.save_temp_vc_ids(temp_vc.TEMP_VC_IDS)
+        await temp_vc.save_temp_vc_ids_async(temp_vc.TEMP_VC_IDS)
         return channel
 
     monkeypatch.setattr(cog, "_create_temp_vc", fake_create_temp_vc)

--- a/tests/test_temp_vc_long_game_trunc.py
+++ b/tests/test_temp_vc_long_game_trunc.py
@@ -13,7 +13,15 @@ async def test_long_game_name_truncated(monkeypatch):
     loop = asyncio.get_running_loop()
     bot = SimpleNamespace(get_channel=lambda _id: None, loop=loop)
     monkeypatch.setattr(temp_vc.rename_manager, "start", AsyncMock())
-    monkeypatch.setattr(temp_vc, "save_temp_vc_ids", lambda ids: None)
+
+    async def no_save_ids(ids, max_retries=3):
+        return None
+
+    async def no_save_cache(cache, max_retries=3):
+        return None
+
+    monkeypatch.setattr(temp_vc, "save_temp_vc_ids_async", no_save_ids)
+    monkeypatch.setattr(temp_vc, "save_last_names_cache", no_save_cache)
 
     with patch.object(temp_vc.tasks.Loop, "start", lambda self, *a, **k: None):
         cog = temp_vc.TempVCCog(bot)


### PR DESCRIPTION
## Summary
- ensure rename manager worker starts reliably and monitor its health
- persist temporary VC last names with async retrying storage
- broaden activity detection and guard against race conditions in channel renaming

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bb94e05abc8324b9e6f2c946a0b717