### PR TITLE
feat: prioritize afk and chat in temp VC names

### DIFF
--- a/cogs/temp_vc.py
+++ b/cogs/temp_vc.py
@@ -170,7 +170,7 @@ class TempVCCog(commands.Cog):
             return None
         base = self._base_name_from_members(channel.members)
 
-        # Priorité : activité > "Endormie" > "Chat"
+        # NOUVELLE PRIORITÉ : activité > "AFK" (si mute) > "Chat"
         activity_counts: Dict[str, int] = {}
         for m in channel.members:
             act_name = self._get_primary_activity(m)
@@ -178,13 +178,17 @@ class TempVCCog(commands.Cog):
                 activity_counts[act_name] = activity_counts.get(act_name, 0) + 1
 
         if activity_counts:
+            # Il y a une activité détectée - priorité maximale
             activity_name = max(activity_counts, key=activity_counts.get)
             max_status_len = 100 - len(base) - 3
             status = activity_name[:max_status_len]
         elif any(m.voice and m.voice.self_mute for m in channel.members):
-            status = "Endormie"
+            # Quelqu'un est mute - "AFK"
+            status = "AFK"
         else:
+            # Aucune activité détectée et personne mute - "Chat"
             status = "Chat"
+
         name = f"{base} • {status}"
         return name[:100]
 


### PR DESCRIPTION
## Summary
- expand temporary voice channel naming to include AFK and Chat statuses
- remove Endormie status

## Testing
- `python -m pytest tests/test_temp_vc_channel_name_length.py tests/test_temp_vc_game_priority.py tests/test_temp_vc_long_game_trunc.py tests/test_temp_vc_cleanup.py tests/test_temp_vc_lobby_creation.py tests/test_temp_vc_move_failure_cleanup.py tests/test_temp_vc_rename_delay.py --disable-warnings`
- `ruff check cogs/temp_vc.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb9a75cdf8832494197da7f65cb09d