### PR TITLE
Add monthly leaderboard for Pari XP

### DIFF
--- a/main/cogs/pari_xp.py
+++ b/main/cogs/pari_xp.py
@@ -37,6 +37,71 @@ TX_PATH = PARI_XP_DATA_DIR / "transactions.json"
 
 DEFAULT_CHANNEL_ID = 1408834276228730900
 
+WINNERS_COLOR = 0x00FF9F
+LOSERS_COLOR = 0xFF4757
+
+
+class MonthlyLeaderboardView(discord.ui.View):
+    """Vue persistante pour le classement mensuel."""
+
+    def __init__(self, cog: "RouletteRefugeCog") -> None:
+        super().__init__(timeout=None)
+        self.cog = cog
+
+    @discord.ui.button(
+        label="Top Gagnants",
+        style=discord.ButtonStyle.success,
+        custom_id="monthly_winners",
+    )
+    async def winners(  # type: ignore[override]
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        try:
+            self.cog.state["monthly_leaderboard_view"] = "winners"
+            await storage.save_json(STATE_PATH, self.cog.state)
+            embed = await self.cog._build_monthly_leaderboard_embed("winners")
+            await interaction.response.edit_message(embed=embed, view=self)
+        except Exception:
+            await interaction.response.send_message(
+                "Une erreur est survenue.", ephemeral=True
+            )
+
+    @discord.ui.button(
+        label="Top Perdants",
+        style=discord.ButtonStyle.danger,
+        custom_id="monthly_losers",
+    )
+    async def losers(  # type: ignore[override]
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        try:
+            self.cog.state["monthly_leaderboard_view"] = "losers"
+            await storage.save_json(STATE_PATH, self.cog.state)
+            embed = await self.cog._build_monthly_leaderboard_embed("losers")
+            await interaction.response.edit_message(embed=embed, view=self)
+        except Exception:
+            await interaction.response.send_message(
+                "Une erreur est survenue.", ephemeral=True
+            )
+
+    @discord.ui.button(
+        label="Actualiser",
+        style=discord.ButtonStyle.secondary,
+        custom_id="refresh_monthly",
+    )
+    async def refresh(  # type: ignore[override]
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        try:
+            self.cog._monthly_stats_month = None
+            self.cog._monthly_stats_cache = {}
+            await self.cog._update_monthly_leaderboard()
+            await interaction.response.defer()
+        except Exception:
+            await interaction.response.send_message(
+                "Une erreur est survenue.", ephemeral=True
+            )
+
 
 class RouletteRefugeCog(commands.Cog):
     def __init__(self, bot: commands.Bot) -> None:
@@ -52,6 +117,9 @@ class RouletteRefugeCog(commands.Cog):
         self._autoheal_presence_task.start()
         self.roulette_store = RouletteStore(data_dir=DATA_DIR)
         self._loss_streak: dict[int, int] = {}
+        self._monthly_stats_cache: dict[int, dict[str, Any]] = {}
+        self._monthly_stats_month: str | None = None
+        self._monthly_stats_mtime: float | None = None
 
     def _now(self) -> datetime:
         return datetime.now(timezones.TZ_PARIS)
@@ -175,8 +243,10 @@ class RouletteRefugeCog(commands.Cog):
         channel = await self._get_channel()
         if channel:
             await self._ensure_hub_message(channel)
+            await self._ensure_monthly_leaderboard_message(channel)
         try:
             self.bot.add_view(self._build_hub_view())
+            self.bot.add_view(MonthlyLeaderboardView(self))
         except Exception:
             pass
         try:
@@ -236,6 +306,123 @@ class RouletteRefugeCog(commands.Cog):
             "total_payout": total_payout,
             "net": net,
         }
+
+    def _get_monthly_stats(self) -> dict[int, dict[str, Any]]:
+        now = self._now()
+        month_key = now.strftime("%Y-%m")
+        mtime = None
+        try:
+            mtime = TX_PATH.stat().st_mtime
+        except OSError:
+            pass
+        if (
+            self._monthly_stats_month == month_key
+            and self._monthly_stats_cache
+            and mtime == self._monthly_stats_mtime
+        ):
+            return self._monthly_stats_cache
+        transactions = storage.load_json(TX_PATH, [])
+        if not isinstance(transactions, list):
+            transactions = []
+        stats: dict[int, dict[str, Any]] = {}
+        for tx in transactions:
+            ts = tx.get("ts")
+            uid = tx.get("user_id")
+            if not ts or uid is None:
+                continue
+            try:
+                dt = datetime.fromisoformat(ts).astimezone(TZ_PARIS)
+            except Exception:
+                continue
+            if dt.year != now.year or dt.month != now.month:
+                continue
+            username = tx.get("username", str(uid))
+            bet = int(tx.get("bet", 0))
+            payout = int(tx.get("payout", 0))
+            delta = int(tx.get("delta", 0))
+            user_stat = stats.setdefault(
+                int(uid),
+                {
+                    "username": username,
+                    "total_bet": 0,
+                    "total_payout": 0,
+                    "net_gain": 0,
+                    "games_played": 0,
+                },
+            )
+            user_stat["username"] = username
+            user_stat["total_bet"] += bet
+            user_stat["total_payout"] += payout
+            user_stat["net_gain"] += delta
+            user_stat["games_played"] += 1
+        self._monthly_stats_cache = stats
+        self._monthly_stats_month = month_key
+        self._monthly_stats_mtime = mtime
+        return stats
+
+    async def _build_monthly_leaderboard_embed(self, view_type: str) -> discord.Embed:
+        stats = self._get_monthly_stats()
+        now = self._now()
+        month_name = now.strftime("%B %Y")
+        total_games = sum(int(v["games_played"]) for v in stats.values())
+        if view_type == "losers":
+            title = f"💸 Top 10 Perdants - {month_name}"
+            color = LOSERS_COLOR
+            sorted_stats = sorted(
+                stats.values(), key=lambda x: int(x["net_gain"])
+            )[:10]
+        else:
+            title = f"🏆 Top 10 Gagnants - {month_name}"
+            color = WINNERS_COLOR
+            sorted_stats = sorted(
+                stats.values(), key=lambda x: int(x["net_gain"]), reverse=True
+            )[:10]
+        lines = []
+        medals = {0: "🥇", 1: "🥈", 2: "🥉"}
+        for idx, s in enumerate(sorted_stats):
+            medal = medals.get(idx, f"{idx + 1}.")
+            net = int(s["net_gain"])
+            lines.append(
+                f"{medal} **{s['username']}** • {net:+} XP ({int(s['games_played'])} parties)"
+            )
+        if not lines:
+            lines = ["Aucune donnée disponible."]
+        embed = discord.Embed(
+            title=title,
+            description="\n".join(lines),
+            color=color,
+            timestamp=now,
+        )
+        embed.set_footer(
+            text=f"📊 Basé sur {total_games} parties ce mois • 🔄 Mis à jour en temps réel"
+        )
+        return embed
+
+    async def _ensure_monthly_leaderboard_message(
+        self, channel: discord.TextChannel
+    ) -> None:
+        msg_id = self.state.get("monthly_leaderboard_msg_id")
+        view_type = self.state.get("monthly_leaderboard_view", "winners")
+        embed = await self._build_monthly_leaderboard_embed(view_type)
+        view = MonthlyLeaderboardView(self)
+        message = None
+        if msg_id:
+            try:
+                message = await channel.fetch_message(int(msg_id))
+            except Exception:
+                message = None
+        if message:
+            await safe_message_edit(message, embed=embed, view=view)
+        else:
+            message = await channel.send(embed=embed, view=view)
+            self.state["monthly_leaderboard_msg_id"] = message.id
+            await storage.save_json(STATE_PATH, self.state)
+
+    async def _update_monthly_leaderboard(self) -> None:
+        channel = await self._get_channel()
+        if not channel:
+            return
+        await self._ensure_monthly_leaderboard_message(channel)
 
     async def _announce_close(self, channel: discord.TextChannel) -> None:
         stats = self._daily_stats()
@@ -335,12 +522,18 @@ class RouletteRefugeCog(commands.Cog):
             self.state["daily_cap_counter"] = 0
             await storage.save_json(STATE_PATH, self.state)
 
+        if now.day == 1 and now.hour == 0 and now.minute == 0:
+            await storage.save_json(TX_PATH, [])
+            self._monthly_stats_cache = {}
+            self._monthly_stats_month = None
+            self._monthly_stats_mtime = None
+            await self._update_monthly_leaderboard()
+
         channel = await self._get_channel()
         if not channel:
             return
 
-        if now.day == 1 and now.hour == 0 and now.minute == 0:
-            await storage.save_json(TX_PATH, [])
+        await self._ensure_monthly_leaderboard_message(channel)
 
         # --- Gestion ouverture/fermeture + "dernier appel" ---
         is_open_now = self._is_open_hours(now)


### PR DESCRIPTION
## Summary
- add persistent MonthlyLeaderboardView with navigation and refresh buttons
- compute monthly stats and show winners/losers embeds
- update scheduler to reset and refresh leaderboard each month

## Testing
- `PYTHONPATH=. pytest tests/test_pari_xp_daily_stats.py tests/test_pari_xp_error.py tests/test_pari_xp_free_ticket.py tests/test_pari_xp_open_hours.py tests/test_pari_xp_store_ticket_usage.py tests/test_pari_xp_ticket.py`

------
https://chatgpt.com/codex/tasks/task_e_68bc158ad5488324aef59470a856b2be