### PR TITLE
feat: migrate F1 standings to OpenF1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Pillow>=10.0
 yt-dlp>=2024.7.1
 imageio-ffmpeg>=0.4
 pytest-asyncio>=0.23
+aiohttp>=3.8


### PR DESCRIPTION
## Summary
- switch F1 standings cog from Ergast to OpenF1 API
- cache driver information and update session fetching/parsing
- document aiohttp dependency for OpenF1 requests

## Testing
- `pytest` *(fails: KeyboardInterrupt)*


------
https://chatgpt.com/codex/tasks/task_e_68be2c3e5fec83248d175628e652af9d