### PR TITLE
Fix F1 times display and add tests

### DIFF
--- a/cogs/f1_standings.py
+++ b/cogs/f1_standings.py
@@ -231,13 +231,12 @@ class F1Standings(commands.Cog):
         for p in sorted(positions, key=lambda r: r.get("position", 0))[:20]:
             driver_num = p.get("driver_number")
             info = await self._get_driver_info(driver_num)
-            time_str = (
-                p.get("time")
-                or p.get("gap_to_leader")
-                or p.get("interval")
-                or p.get("best_lap_time")
-                or "No Time"
-            )
+            time_str = "No Time"
+            for key in ("time", "gap_to_leader", "interval", "best_lap_time"):
+                val = p.get(key)
+                if val is not None and val != "":
+                    time_str = str(val)
+                    break
             parsed.append(
                 {
                     "driver": info.get("name", f"#{driver_num}"),

--- a/tests/test_f1_times.py
+++ b/tests/test_f1_times.py
@@ -1,0 +1,20 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cogs.f1_standings import F1Standings
+
+
+@pytest.mark.asyncio
+async def test_parse_openf1_positions_returns_times(monkeypatch):
+    monkeypatch.setattr(asyncio, "create_task", lambda *args, **kwargs: MagicMock())
+    cog = F1Standings(MagicMock())
+    cog._get_driver_info = AsyncMock(return_value={"name": "Driver", "team": "Team"})
+    positions = [
+        {"position": 1, "driver_number": 1, "time": 0},
+        {"position": 2, "driver_number": 2, "best_lap_time": 83.123},
+    ]
+    results = await cog._parse_openf1_positions(positions)
+    assert results[0]["time"] == "0"
+    assert results[1]["time"] == "83.123"


### PR DESCRIPTION
## Summary
- handle zero and numeric values when extracting F1 session times
- add regression test for F1 standings time parsing

## Testing
- `ruff check cogs/f1_standings.py tests/test_f1_times.py`
- `PYTHONPATH=. pytest tests/test_f1_times.py -q`
- `pytest -q` *(interrupted: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68be31241f388324a6340d519b6e25c8