### PR TITLE
Ajout des commandes F1 via OpenF1

### DIFF
--- a/cogs/f1_openf1_commands.py
+++ b/cogs/f1_openf1_commands.py
@@ -62,7 +62,7 @@ class F1OpenF1Auto(commands.Cog):
                 )
             except Exception:
                 pass
-            await asyncio.sleep(6 * 3600)  # mise à jour toutes les 6h
+            await asyncio.sleep(3600)  # mise à jour toutes les heures
 
     async def _post_or_edit(self, key: str, embed: discord.Embed) -> None:
         channel = self.bot.get_channel(F1_CHANNEL_ID)


### PR DESCRIPTION
## Résumé
- Ajout d'une nouvelle cog `F1OpenF1Commands` utilisant l'API OpenF1.
- Commande `/f1 next` pour connaître le prochain Grand Prix avec date et lieu.
- Commande `/f1 last` affichant le top 10 du dernier GP.
- Commande `/f1 standings` calculant le classement pilotes et constructeurs.

## Tests
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf54b31ab883249e003c9080704faa