### PR TITLE
Retirer l'attribution de rôles du classement journalier

### DIFF
--- a/tests/test_daily_awards.py
+++ b/tests/test_daily_awards.py
@@ -4,73 +4,6 @@ import pytest
 from unittest.mock import AsyncMock
 
 from cogs.daily_awards import DailyAwards
-from config import MVP_ROLE_ID, WRITER_ROLE_ID, VOICE_ROLE_ID
-
-
-class DummyRole:
-    def __init__(self, rid: int):
-        self.id = rid
-
-
-class DummyMember:
-    def __init__(self, mid: int, roles=None):
-        self.id = mid
-        self.roles = list(roles) if roles else []
-
-    async def remove_roles(self, *roles, reason=None):
-        for r in roles:
-            if r in self.roles:
-                self.roles.remove(r)
-
-    async def add_roles(self, role, reason=None):
-        if role not in self.roles:
-            self.roles.append(role)
-
-
-class DummyGuild:
-    def __init__(self, members, roles):
-        self.members = members
-        self._roles = roles
-
-    def get_role(self, rid: int):
-        return self._roles.get(rid)
-
-    def get_member(self, uid: int):
-        for m in self.members:
-            if m.id == uid:
-                return m
-        return None
-
-
-@pytest.mark.asyncio
-async def test_roles_reassigned():
-    mvp = DummyRole(MVP_ROLE_ID)
-    msg = DummyRole(WRITER_ROLE_ID)
-    vc = DummyRole(VOICE_ROLE_ID)
-
-    winner_mvp = DummyMember(1)
-    winner_msg = DummyMember(2)
-    winner_vc = DummyMember(3)
-    other = DummyMember(4, roles=[mvp, msg, vc])
-
-    guild = DummyGuild(
-        [winner_mvp, winner_msg, winner_vc, other],
-        {MVP_ROLE_ID: mvp, WRITER_ROLE_ID: msg, VOICE_ROLE_ID: vc},
-    )
-
-    cog = DailyAwards.__new__(DailyAwards)
-    cog.bot = SimpleNamespace(get_guild=lambda _id: guild)
-
-    winners = {"mvp": winner_mvp.id, "msg": winner_msg.id, "vc": winner_vc.id}
-    await DailyAwards._reset_and_assign(cog, winners)
-
-    assert mvp in winner_mvp.roles
-    assert msg in winner_msg.roles
-    assert vc in winner_vc.roles
-
-    assert mvp not in other.roles
-    assert msg not in other.roles
-    assert vc not in other.roles
 
 
 @pytest.mark.asyncio
@@ -91,25 +24,21 @@ async def test_build_message_partial():
 
 
 @pytest.mark.asyncio
-async def test_maybe_award_partial_publishes_and_assigns():
+async def test_maybe_award_partial_publishes():
     channel = SimpleNamespace(send=AsyncMock())
-    bot = SimpleNamespace(get_channel=lambda _id: channel)
 
     cog = DailyAwards.__new__(DailyAwards)
-    cog.bot = bot
+    cog.bot = SimpleNamespace()
     cog._read_state = lambda: {}
     cog._write_state = lambda state: None
-    cog._reset_and_assign = AsyncMock()
     cog._build_message = AsyncMock(return_value="msg")
+    cog._get_announce_channel = AsyncMock(return_value=channel)
 
-    data = {
-        "date": "2024-01-01",
-        "winners": {"mvp": 1, "msg": None, "vc": None},
-    }
+    data = {"date": "2024-01-01", "winners": {"mvp": 1, "msg": None, "vc": None}}
 
     await DailyAwards._maybe_award(cog, data)
 
-    cog._reset_and_assign.assert_awaited_once_with(data["winners"])
+    cog._build_message.assert_awaited_once_with(data)
     channel.send.assert_awaited_once_with("msg")
 
 

--- a/tests/test_daily_leaderboard.py
+++ b/tests/test_daily_leaderboard.py
@@ -1,5 +1,4 @@
 import asyncio
-from types import SimpleNamespace
 from pathlib import Path
 import sys
 
@@ -10,42 +9,6 @@ sys.path.append(str(Path(__file__).resolve().parents[1]))
 import cogs.xp as xp
 import cogs.daily_leaderboard as dl
 from cogs.daily_leaderboard import DailyLeaderboard
-from config import MVP_ROLE_ID, TOP_MSG_ROLE_ID, TOP_VC_ROLE_ID
-
-
-class DummyRole:
-    def __init__(self, rid: int):
-        self.id = rid
-
-
-class DummyMember:
-    def __init__(self, mid: int, roles=None):
-        self.id = mid
-        self.roles = list(roles) if roles else []
-
-    async def remove_roles(self, *roles, reason=None):
-        for r in roles:
-            if r in self.roles:
-                self.roles.remove(r)
-
-    async def add_roles(self, role, reason=None):
-        if role not in self.roles:
-            self.roles.append(role)
-
-
-class DummyGuild:
-    def __init__(self, members, roles):
-        self.members = members
-        self._roles = roles
-
-    def get_role(self, rid: int):
-        return self._roles.get(rid)
-
-    def get_member(self, uid: int):
-        for m in self.members:
-            if m.id == uid:
-                return m
-        return None
 
 
 @pytest.mark.asyncio
@@ -69,32 +32,3 @@ async def test_calculate_daily_winners(monkeypatch):
     result = await DailyLeaderboard._calculate_daily_winners(cog, date)
     assert result["winners"] == {"msg": 1, "vc": 2, "mvp": 1}
     assert date not in xp.DAILY_STATS
-
-
-@pytest.mark.asyncio
-async def test_update_daily_roles_assigns():
-    mvp = DummyRole(MVP_ROLE_ID)
-    msg = DummyRole(TOP_MSG_ROLE_ID)
-    vc = DummyRole(TOP_VC_ROLE_ID)
-
-    winner_msg = DummyMember(1)
-    winner_vc = DummyMember(2)
-    winner_mvp = DummyMember(3)
-    other = DummyMember(4, roles=[mvp, msg, vc])
-
-    guild = DummyGuild(
-        [winner_msg, winner_vc, winner_mvp, other],
-        {MVP_ROLE_ID: mvp, TOP_MSG_ROLE_ID: msg, TOP_VC_ROLE_ID: vc},
-    )
-
-    cog = DailyLeaderboard.__new__(DailyLeaderboard)
-    await DailyLeaderboard._update_daily_roles(
-        cog,
-        guild,
-        {"msg": 1, "vc": 2, "mvp": 3},
-    )
-
-    assert msg in winner_msg.roles
-    assert vc in winner_vc.roles
-    assert mvp in winner_mvp.roles
-    assert msg not in other.roles and vc not in other.roles and mvp not in other.roles

--- a/tests/test_daily_ranking_startup_recovery.py
+++ b/tests/test_daily_ranking_startup_recovery.py
@@ -27,7 +27,6 @@ async def test_startup_recovers_and_awards(tmp_path):
         await DailyRankingAndRoles._startup_check(cog)
 
     data = daily_ranking.read_json_safe(str(rank_file))
-    winners = data["winners"]
     assert data["date"] == yesterday
 
     channel = SimpleNamespace(send=AsyncMock())
@@ -37,8 +36,7 @@ async def test_startup_recovers_and_awards(tmp_path):
     award_cog._read_state = lambda: {}
     award_cog._write_state = lambda data: None
     award_cog._build_message = AsyncMock(return_value="msg")
-    with patch.object(daily_awards.DailyAwards, "_reset_and_assign", new=AsyncMock()) as reset:
-        await daily_awards.DailyAwards._startup_check(award_cog)
-        reset.assert_awaited_once_with(winners)
+    award_cog._get_announce_channel = AsyncMock(return_value=channel)
+    await daily_awards.DailyAwards._startup_check(award_cog)
     channel.send.assert_awaited_once_with("msg")
 


### PR DESCRIPTION
## Summary
- supprimer la logique d'attribution de rôles dans le classement quotidien
- adapter l'annonce des gagnants pour ne plus mentionner de rôles
- mettre à jour les tests en conséquence

## Testing
- `ruff check cogs/daily_awards.py cogs/daily_leaderboard.py`
- `ruff check tests/test_daily_awards.py`
- `ruff check tests/test_daily_leaderboard.py tests/test_daily_ranking_startup_recovery.py`
- `pytest` *(warning: ruff check . présente des erreurs existantes)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6ca1c43483248cb116090c632ac2