### PR TITLE
Fix daily awards announcement

### DIFF
--- a/tests/test_daily_awards.py
+++ b/tests/test_daily_awards.py
@@ -1,44 +1,88 @@
 from types import SimpleNamespace
 
 import pytest
+from unittest import mock
 from unittest.mock import AsyncMock
 
-from cogs.daily_awards import DailyAwards
+import discord
+
+from cogs.daily_awards import DailyAwards, today_str_eu_paris
 
 
 @pytest.mark.asyncio
-async def test_build_message_partial():
+async def test_build_embed_partial():
     cog = DailyAwards.__new__(DailyAwards)
-    cog.bot = SimpleNamespace()
-    cog._mention_or_name = AsyncMock(side_effect=lambda uid: f"u{uid}")
     data = {
-        "top3": {
-            "mvp": [{"id": 1, "score": 10, "messages": 5, "voice": 30}]
-        }
+        "top3": {"mvp": [{"id": 1, "score": 10, "messages": 5, "voice": 30}]}
     }
 
-    message = await DailyAwards._build_message(cog, data)
-    assert "MVP du Refuge" in message
-    assert "Écrivain du Refuge" in message and "Aucun gagnant" in message
-    assert "Voix du Refuge" in message and message.count("Aucun gagnant") >= 2
+    embed = await DailyAwards._build_embed(cog, data)
+    assert embed.title.startswith("📢 Annonce")
+    assert embed.fields[0].name == "MVP"
+    assert "Aucun gagnant" in embed.fields[1].value
+    assert "Aucun gagnant" in embed.fields[2].value
 
 
 @pytest.mark.asyncio
 async def test_maybe_award_partial_publishes():
-    channel = SimpleNamespace(send=AsyncMock())
+    channel = SimpleNamespace(send=AsyncMock(), fetch_message=AsyncMock())
 
     cog = DailyAwards.__new__(DailyAwards)
     cog.bot = SimpleNamespace()
     cog._read_state = lambda: {}
     cog._write_state = lambda state: None
-    cog._build_message = AsyncMock(return_value="msg")
+    cog._build_embed = AsyncMock(return_value=discord.Embed())
     cog._get_announce_channel = AsyncMock(return_value=channel)
 
     data = {"date": "2024-01-01", "winners": {"mvp": 1, "msg": None, "vc": None}}
 
     await DailyAwards._maybe_award(cog, data)
 
-    cog._build_message.assert_awaited_once_with(data)
-    channel.send.assert_awaited_once_with("msg")
+    cog._build_embed.assert_awaited_once_with(data)
+    channel.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_maybe_award_edits_existing():
+    today = today_str_eu_paris()
+    msg = SimpleNamespace(embeds=[], edit=AsyncMock())
+    channel = SimpleNamespace(send=AsyncMock(), fetch_message=AsyncMock(return_value=msg))
+
+    cog = DailyAwards.__new__(DailyAwards)
+    cog.bot = SimpleNamespace()
+    cog._read_state = lambda: {"last_posted_date": today, "last_message_id": 123}
+    cog._write_state = lambda state: None
+    cog._build_embed = AsyncMock(return_value=discord.Embed())
+    cog._get_announce_channel = AsyncMock(return_value=channel)
+
+    await DailyAwards._maybe_award(cog, {"top3": {}})
+
+    channel.fetch_message.assert_awaited_once_with(123)
+    msg.edit.assert_awaited_once()
+    channel.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_maybe_award_reposts_when_missing():
+    today = today_str_eu_paris()
+    state = {"last_posted_date": today, "last_message_id": 123}
+    channel = SimpleNamespace(
+        send=AsyncMock(return_value=SimpleNamespace(id=456)),
+        fetch_message=AsyncMock(
+            side_effect=discord.NotFound(mock.Mock(status=404), "Not Found")
+        ),
+    )
+
+    cog = DailyAwards.__new__(DailyAwards)
+    cog.bot = SimpleNamespace()
+    cog._read_state = lambda: state
+    cog._write_state = lambda data: state.update(data)
+    cog._build_embed = AsyncMock(return_value=discord.Embed())
+    cog._get_announce_channel = AsyncMock(return_value=channel)
+
+    await DailyAwards._maybe_award(cog, {"top3": {}})
+
+    channel.send.assert_awaited_once()
+    assert state["last_message_id"] == 456
 
 

--- a/tests/test_daily_ranking_startup_recovery.py
+++ b/tests/test_daily_ranking_startup_recovery.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
+import discord
 import cogs.daily_ranking as daily_ranking
 import cogs.daily_awards as daily_awards
 import cogs.xp as xp
@@ -29,14 +30,14 @@ async def test_startup_recovers_and_awards(tmp_path):
     data = daily_ranking.read_json_safe(str(rank_file))
     assert data["date"] == yesterday
 
-    channel = SimpleNamespace(send=AsyncMock())
+    channel = SimpleNamespace(send=AsyncMock(), fetch_message=AsyncMock())
     award_bot = SimpleNamespace(get_channel=lambda _cid: channel, wait_until_ready=AsyncMock())
     award_cog = daily_awards.DailyAwards.__new__(daily_awards.DailyAwards)
     award_cog.bot = award_bot
     award_cog._read_state = lambda: {}
     award_cog._write_state = lambda data: None
-    award_cog._build_message = AsyncMock(return_value="msg")
+    award_cog._build_embed = AsyncMock(return_value=discord.Embed())
     award_cog._get_announce_channel = AsyncMock(return_value=channel)
     await daily_awards.DailyAwards._startup_check(award_cog)
-    channel.send.assert_awaited_once_with("msg")
+    channel.send.assert_awaited_once()
 


### PR DESCRIPTION
## Summary
- send daily awards as embed with proper mentions, date and @everyone
- track last announcement to avoid duplicates and allow updates
- update channel ID for announcements

## Testing
- `PYTHONPATH=. pytest tests/test_daily_awards.py -q`
- `PYTHONPATH=. pytest -q` *(killed: process terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68c34bf7d2808324b3da5efa40773b9c