### PR TITLE
Use daily winners archive for award announcements

### DIFF
--- a/tests/test_daily_ranking_startup_recovery.py
+++ b/tests/test_daily_ranking_startup_recovery.py
@@ -16,6 +16,8 @@ async def test_startup_recovers_and_awards(tmp_path):
     rank_file = tmp_path / "daily_ranking.json"
     daily_ranking.DAILY_RANK_FILE = str(rank_file)
     daily_awards.DAILY_RANK_FILE = str(rank_file)
+    winners_file = tmp_path / "daily_winners.json"
+    daily_awards.DAILY_WINNERS_FILE = str(winners_file)
 
     xp.DAILY_STATS.clear()
     yesterday = (datetime.now(PARIS_TZ) - timedelta(days=1)).date().isoformat()


### PR DESCRIPTION
## Summary
- read the archived `daily_winners.json` data (with a legacy fallback) and normalise the payload passed to embeds
- update the award scheduler/startup flow to rely on the new loader so announcements follow the latest winners
- expand the award tests to cover the new loader behaviour and keep the startup recovery scenario working

## Testing
- pytest tests/test_daily_awards.py tests/test_daily_ranking_startup_recovery.py tests/awards_verif -q


------
https://chatgpt.com/codex/tasks/task_e_68caf077b06c832481dc023edbc17b07