### PR TITLE
Update Rap FR stream URL and add FFmpeg header support

### DIFF
--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -7,6 +7,7 @@ from discord.ext import commands
 
 from config import (
     DATA_DIR,
+    RADIO_RAP_FR_STREAM_HEADERS,
     RADIO_RAP_FR_STREAM_URL,
     RADIO_RAP_STREAM_URL,
     RADIO_STREAM_URL,
@@ -60,7 +61,17 @@ class RadioCog(commands.Cog):
                     self._delayed_reconnect()
                 )
             return
-        play_stream(self.voice, self.stream_url, after=self._after_play)
+        play_stream(
+            self.voice,
+            self.stream_url,
+            after=self._after_play,
+            headers=self._stream_headers(self.stream_url),
+        )
+
+    def _stream_headers(self, stream_url: Optional[str]) -> Optional[str]:
+        if stream_url == RADIO_RAP_FR_STREAM_URL:
+            return RADIO_RAP_FR_STREAM_HEADERS or None
+        return None
 
     def _after_play(self, error: Optional[Exception]) -> None:
         if error:

--- a/config.py
+++ b/config.py
@@ -64,7 +64,17 @@ RADIO_STREAM_URL = os.getenv(
     "https://n08.radiojar.com/2b5w4a2kb?rj-ttl=5&rj-tok=AAABmNHaVWAAm4GDT5xyXjsi5A",
 )
 RADIO_RAP_STREAM_URL = "https://stream.laut.fm/24-7-rap"
-RADIO_RAP_FR_STREAM_URL = "http://icecast.radiofrance.fr/mouvrapfr-midfi.mp3"
+RADIO_RAP_FR_STREAM_URL = os.getenv(
+    "RADIO_RAP_FR_STREAM_URL",
+    "https://stream.radiofrance.fr/mouvrapfr/mouvrapfr_midfi.mp3?ID=radiofrance",
+)
+RADIO_RAP_FR_STREAM_HEADERS = os.getenv(
+    "RADIO_RAP_FR_STREAM_HEADERS",
+    (
+        "User-Agent: Mozilla/5.0 (Discord bot; +https://discord.com)\r\n"
+        "Referer: https://www.radiofrance.fr/mouv/rap-fr"
+    ),
+).strip()
 
 ROCK_RADIO_VC_ID = 1408081503707074650
 ROCK_RADIO_STREAM_URL = os.getenv(

--- a/tests/test_play_stream_headers.py
+++ b/tests/test_play_stream_headers.py
@@ -1,0 +1,38 @@
+import shutil
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import utils.voice as voice_mod
+
+
+class DummyVoice:
+    def __init__(self) -> None:
+        self.play_called_with = None
+
+    def is_playing(self) -> bool:
+        return False
+
+    def play(self, source, after=None):  # pragma: no cover - simple setter
+        self.play_called_with = source
+
+
+def test_play_stream_adds_headers(monkeypatch):
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/ffmpeg")
+    captured = {}
+
+    def fake_ffmpeg_audio(url, *, before_options, options):
+        captured["url"] = url
+        captured["before"] = before_options
+        captured["options"] = options
+        return object()
+
+    monkeypatch.setattr(voice_mod.discord, "FFmpegPCMAudio", fake_ffmpeg_audio)
+
+    voice = DummyVoice()
+    voice_mod.play_stream(voice, "http://example.com", headers="X-Test: value")
+
+    assert captured["url"] == "http://example.com"
+    assert "-headers 'X-Test: value'" in captured["before"]
+    assert voice.play_called_with is not None

--- a/tests/test_play_stream_missing_ffmpeg.py
+++ b/tests/test_play_stream_missing_ffmpeg.py
@@ -1,5 +1,9 @@
 import logging
 import shutil
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from utils.voice import play_stream
 

--- a/utils/voice.py
+++ b/utils/voice.py
@@ -1,4 +1,5 @@
 import logging
+import shlex
 import shutil
 from typing import Callable, Optional
 
@@ -75,13 +76,18 @@ def play_stream(
     stream_url: str,
     *,
     after: Optional[Callable[[Optional[Exception]], None]] = None,
+    headers: Optional[str] = None,
 ) -> None:
     """Lance la lecture du flux ``stream_url`` si rien n'est joué."""
     if voice and not voice.is_playing():
         if shutil.which("ffmpeg") is None:
             logger.warning("FFmpeg introuvable: impossible de lire le flux %s", stream_url)
             return
+        before_options = FFMPEG_BEFORE
+        header_value = headers.strip() if headers else ""
+        if header_value:
+            before_options = f"{before_options} -headers {shlex.quote(header_value)}"
         source = discord.FFmpegPCMAudio(
-            stream_url, before_options=FFMPEG_BEFORE, options=FFMPEG_OPTIONS
+            stream_url, before_options=before_options, options=FFMPEG_OPTIONS
         )
         voice.play(source, after=after)


### PR DESCRIPTION
## Summary
- update the Rap FR radio stream URL and expose configurable HTTP headers
- allow FFmpeg sources to inject custom headers and use them for the Rap FR station
- add regression coverage for the new header handling in the voice utilities

## Testing
- PYTHONPATH=. pytest tests/test_play_stream_headers.py tests/test_play_stream_missing_ffmpeg.py tests/test_radio_rapfr.py

------
https://chatgpt.com/codex/tasks/task_e_68d2c03175a483249bb3a0f1174cd25b