### PR TITLE
Remove random double voice XP scheduling

### DIFF
--- a/config.py
+++ b/config.py
@@ -146,10 +146,7 @@ DATA_DIR: str = _resolve_data_dir()
 """Répertoire de stockage persistant."""
 
 # ── Double XP vocal ───────────────────────────────────────────
-XP_DOUBLE_VOICE_SESSIONS_PER_DAY: int = int(
-    os.getenv("XP_DOUBLE_VOICE_SESSIONS_PER_DAY", "2")
-)
-"""Nombre maximum de sessions Double XP vocal par jour."""
+"""Les sessions Double XP vocal ne sont plus générées automatiquement."""
 
 XP_DOUBLE_VOICE_DURATION_MINUTES: int = int(
     os.getenv("XP_DOUBLE_VOICE_DURATION_MINUTES", "60")


### PR DESCRIPTION
## Summary
- remove the automatic random scheduling from the double voice XP cog so sessions stay empty until configured manually
- update the configuration comments to reflect the end of automatic planning
- refresh the test suite to cover the manual-only scheduling behaviour

## Testing
- pytest tests/test_voice_double_xp.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dec53fdac483249879815a8dedc56b