### PR TITLE
Casino: central schedule, roulette green-zero, spin GIF, and /top_casino leaderboard

### DIFF
--- a/config.py
+++ b/config.py
@@ -46,6 +46,11 @@ except AttributeError:
     # ``tzset`` n'existe pas sur toutes les plateformes (ex: Windows)
     pass
 
+# ── Horaires du casino ────────────────────────────────────────
+CASINO_OPEN_HOUR: int = int(os.getenv("CASINO_OPEN_HOUR", "10"))
+CASINO_CLOSE_HOUR: int = int(os.getenv("CASINO_CLOSE_HOUR", "2"))
+CASINO_SCHEDULE_LABEL = f"{CASINO_OPEN_HOUR:02d}h00 - {CASINO_CLOSE_HOUR:02d}h00"
+
 
 # ── Salons statistiques ───────────────────────────────────────
 STATS_MEMBERS_CHANNEL_ID = 1406435185813098537

--- a/storage/xp_store.py
+++ b/storage/xp_store.py
@@ -357,6 +357,10 @@ class XPStore:
         
         return sorted_users
 
+    def read_json(self) -> Dict[str, XPUserData]:
+        """Lit le fichier JSON brut des XP."""
+        return read_json_safe(self.path)
+
     async def get_stats(self) -> Dict[str, any]:
         """Retourne les statistiques du store."""
         async with self.lock:


### PR DESCRIPTION
### Motivation
- Centraliser les horaires d'ouverture du casino pour éviter la duplication et permettre un réglage unique (`config.py`).
- Introduire l'avantage de la maison sur la roulette avec un résultat « Zéro Vert » et améliorer l'expérience utilisateur visuelle lors du tirage.
- Fournir un classement accessible via slash command pour afficher le top des joueurs par XP.

### Description
- Ajout des variables de planning centralisées `CASINO_OPEN_HOUR`, `CASINO_CLOSE_HOUR` et `CASINO_SCHEDULE_LABEL` dans `config.py` et usage de ces valeurs dans la roulette et la machine à sous (`cogs/pari_xp.py`, `cogs/machine_a_sous/machine_a_sous.py`).
- Roulette (`cogs/pari_xp.py`): ajout d'une issue « Zéro Vert » avec probabilité ~3% (impacte les probabilités pour laisser la somme = 1.0), logique qui perd automatiquement les paris `red`/`black`/numéros, et mise à jour des messages d'ouverture/fermeture pour utiliser le planning centralisé.
- Roulette: ajout d'un flux visuel de suspense avant le résultat en envoyant un embed avec le GIF `SPINNING_GIF_URL`, `await asyncio.sleep(2.5)`, puis `message.edit` pour afficher l'embed final du résultat.
- Ajout de la commande slash `top_casino` (`@app_commands.command`) dans `cogs/pari_xp.py` qui lit les données brutes via `xp_store.read_json()` et renvoie un embed du top 10 trié par `xp` (gère l'absence de données).
- Machine à sous (`cogs/machine_a_sous/machine_a_sous.py`): remplacement des appels locaux d'heure par une fonction `_is_casino_open` utilisant les variables de `config.py`, et harmonisation des messages/embeds pour afficher `CASINO_SCHEDULE_LABEL` et le message fermé `🌙 Le Casino est fermé. Horaires : 10h00 - 02h00.`.
- Stockage XP (`storage/xp_store.py`): ajout de la méthode `read_json()` pour exposer la lecture brute du fichier JSON et alimenter la commande `top_casino`.

### Testing
- Aucun test automatisé n'a été exécuté sur ces changements (aucune suite CI/pytest lancée durant la modification).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff48bcd908324854f0f197f14eabb)