### PR TITLE
fix: prevent XP data loss during cache cleanup

### DIFF
--- a/storage/xp_store.py
+++ b/storage/xp_store.py
@@ -70,7 +70,9 @@ class XPStore:
         ensure_dir(DATA_DIR)
         self.data = read_json_safe(self.path)
         
-        # Nettoyer le cache au démarrage
+        # ``self.data`` est la source de vérité persistée, pas un cache jetable.
+        # La maintenance peut donc observer sa taille mais ne doit jamais évincer
+        # des utilisateurs tant qu'un cache séparé n'existe pas.
         await self._cleanup_cache()
         
         self._periodic_task = asyncio.create_task(self._periodic_maintenance())
@@ -94,41 +96,26 @@ class XPStore:
         logger.info("XP Store fermé (stats: %s)", self.stats)
 
     async def _cleanup_cache(self) -> None:
-        """Supprime les entrées les moins récemment utilisées."""
+        """Préserve toutes les entrées XP tant que ``data`` est la source de vérité.
+
+        Historiquement, cette méthode supprimait les utilisateurs les moins
+        récemment consultés lorsque ``len(self.data)`` dépassait ``cache_size``.
+        Or :meth:`flush` persiste directement ``self.data``. L'éviction d'une
+        entrée revenait donc à supprimer définitivement cet utilisateur du
+        fichier XP au prochain flush.
+
+        ``cache_size`` reste conservé comme paramètre de compatibilité et pourra
+        être réutilisé lorsqu'un véritable cache, distinct des données complètes,
+        sera introduit. En attendant, cette opération est volontairement un
+        no-op afin de garantir l'intégrité des données.
+        """
         async with self.lock:
-            if len(self.data) <= self.cache_size:
-                return
-            
-            # Trier par dernière utilisation
-            items = [
-                (uid, data) 
-                for uid, data in self.data.items()
-            ]
-            
-            # Parser les dates d'accès
-            def get_last_accessed(item):
-                _, data = item
-                last = data.get("last_accessed")
-                if not last:
-                    return datetime.min
-                try:
-                    return datetime.fromisoformat(last)
-                except:
-                    return datetime.min
-            
-            items.sort(key=get_last_accessed)
-            
-            # Garder seulement les N plus récents
-            to_remove = len(items) - self.cache_size
-            if to_remove > 0:
-                removed_users = [uid for uid, _ in items[:to_remove]]
-                
-                # Supprimer du cache sans déclencher de sauvegarde immédiate
-                for uid in removed_users:
-                    del self.data[uid]
-                    
-                logger.info("Cache nettoyé: %d entrées supprimées", to_remove)
-                self.stats["cache_misses"] += to_remove
+            if len(self.data) > self.cache_size:
+                logger.debug(
+                    "XP cache limit exceeded (%d > %d); preserving all users because self.data is persistent state",
+                    len(self.data),
+                    self.cache_size,
+                )
 
     async def _periodic_maintenance(self) -> None:
         """Maintenance périodique: flush batch et nettoyage cache."""
@@ -139,7 +126,7 @@ class XPStore:
                 # Traiter les mises à jour en lot
                 await self._process_batch_updates()
                 
-                # Nettoyer le cache toutes les 10 minutes
+                # Vérifier périodiquement la taille sans évincer de données.
                 now = datetime.utcnow()
                 if (now - self._last_cleanup).seconds > 600:
                     await self._cleanup_cache()
@@ -338,7 +325,8 @@ class XPStore:
             self.data[uid] = user_data
             user_data["last_accessed"] = datetime.utcnow().isoformat()
             
-            # Vérifier la taille du cache
+            # Vérifier la taille du cache. La méthode ne supprime aucune donnée
+            # tant que ``self.data`` reste la source de vérité persistée.
             if len(self.data) > self.cache_size * 1.2:  # 20% de marge
                 asyncio.create_task(self._cleanup_cache())
         

--- a/tests/test_xp_store_data_integrity.py
+++ b/tests/test_xp_store_data_integrity.py
@@ -1,0 +1,26 @@
+import json
+
+import pytest
+
+from storage.xp_store import XPStore
+
+
+@pytest.mark.asyncio
+async def test_cleanup_does_not_delete_persistent_users(tmp_path):
+    path = tmp_path / "data.json"
+    store = XPStore(path=str(path), cache_size=2)
+    store.data = {
+        "1": {"xp": 100, "level": 1, "last_accessed": "2026-01-01T00:00:00"},
+        "2": {"xp": 200, "level": 1, "last_accessed": "2026-01-02T00:00:00"},
+        "3": {"xp": 300, "level": 1, "last_accessed": "2026-01-03T00:00:00"},
+    }
+
+    await store._cleanup_cache()
+    await store.flush()
+
+    assert set(store.data) == {"1", "2", "3"}
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert set(persisted) == {"1", "2", "3"}
+    assert persisted["1"]["xp"] == 100
+    assert persisted["2"]["xp"] == 200
+    assert persisted["3"]["xp"] == 300


### PR DESCRIPTION
## Problème
`XPStore._cleanup_cache()` supprimait des utilisateurs de `self.data` lorsque le nombre d'entrées dépassait `cache_size`. Or `self.data` est également la source persistée par `flush()`. Une éviction de cache pouvait donc supprimer définitivement des comptes XP du fichier JSON.

## Correction
- rendre `_cleanup_cache()` non destructif tant qu'un cache séparé n'existe pas ;
- conserver `cache_size` pour compatibilité et future refonte ;
- documenter explicitement que `self.data` est actuellement la source de vérité ;
- ajouter un test de non-régression qui dépasse volontairement la limite du cache, exécute le cleanup puis un flush et vérifie que tous les utilisateurs restent présents.

## Portée
Aucun calcul d'XP, bonus, niveau, batch ou logique Discord n'est modifié.

## Validation
Le diff est limité à `storage/xp_store.py` et au nouveau test `tests/test_xp_store_data_integrity.py`. La suite pytest n'a pas pu être exécutée localement depuis cet environnement car le checkout GitHub n'est pas disponible au runtime ; la PR reste donc en brouillon jusqu'à validation/CI.