### PR TITLE
fix: make XP spending atomic

### DIFF
--- a/cogs/economy_ui.py
+++ b/cogs/economy_ui.py
@@ -284,12 +284,21 @@ class EconomyUICog(commands.Cog):
                 "Solde insuffisant.", ephemeral=True
             )
             return
-        await xp_adapter.add_xp(
-            user_id,
-            amount=-price,
-            guild_id=interaction.guild_id or 0,
-            source="shop",
-        )
+        try:
+            await xp_adapter.add_xp(
+                user_id,
+                amount=-price,
+                guild_id=interaction.guild_id or 0,
+                source="shop",
+            )
+        except xp_adapter.InsufficientXPError:
+            # Le pré-contrôle de solde est uniquement informatif. Le débit
+            # atomique reste la source de vérité si deux achats/paris arrivent
+            # simultanément pour le même utilisateur.
+            await interaction.response.send_message(
+                "Solde insuffisant.", ephemeral=True
+            )
+            return
 
         if item_key == "ticket_royal":
             tickets = load_tickets()

--- a/cogs/pari_xp.py
+++ b/cogs/pari_xp.py
@@ -22,6 +22,7 @@ from config import (
 )
 from storage.xp_store import xp_store
 from cogs.xp import award_xp
+from utils import xp_adapter
 from utils.timezones import PARIS_TZ
 from utils.persistence import atomic_write_json_async, read_json_safe
 from utils.interactions import safe_respond
@@ -277,12 +278,17 @@ class PariXPCog(commands.Cog):
                 await safe_respond(interaction, "❌ XP insuffisant.", ephemeral=True)
                 return
             try:
-                await award_xp(
+                await xp_adapter.add_xp(
                     interaction.user.id,
-                    -amount,
-                    guild_id=interaction.guild_id,
+                    amount=-amount,
+                    guild_id=interaction.guild_id or 0,
                     source="pari_xp",
                 )
+            except xp_adapter.InsufficientXPError:
+                # Une autre opération a pu consommer le solde après le
+                # pré-contrôle. Le débit atomique refuse alors proprement le pari.
+                await safe_respond(interaction, "❌ XP insuffisant.", ephemeral=True)
+                return
             except Exception as e:  # pragma: no cover - defensive
                 logger.exception("[PariXP] debit failed: %s", e)
                 await safe_respond(interaction, "❌ Erreur interne.", ephemeral=True)

--- a/storage/xp_store.py
+++ b/storage/xp_store.py
@@ -303,6 +303,82 @@ class XPStore:
         
         return old_level, new_level, old_xp, new_xp
 
+    async def try_spend_xp(
+        self,
+        user_id: int,
+        amount: int,
+        *,
+        guild_id: Optional[int] = None,
+        source: str = "spend",
+    ) -> bool:
+        """Débite ``amount`` XP seulement si le solde est suffisant.
+
+        La vérification du solde et le débit sont effectués sous le même verrou
+        que les autres mises à jour immédiates du store. Deux dépenses
+        concurrentes ne peuvent donc pas consommer le même solde.
+
+        Contrairement à :meth:`add_xp` avec un montant négatif, cette méthode ne
+        rabat jamais silencieusement le solde à zéro : si l'utilisateur ne peut
+        pas payer l'intégralité du montant, aucune XP n'est retirée et ``False``
+        est retourné.
+        """
+        if amount < 0:
+            raise ValueError("amount must be non-negative")
+        if amount == 0:
+            return True
+        if amount > 10000:
+            raise ValueError("amount exceeds maximum XP transaction")
+
+        uid = str(user_id)
+        old_level = 0
+        new_level = 0
+        old_xp = 0
+        new_xp = 0
+
+        async with self.lock:
+            if uid not in self.data:
+                self.stats["cache_misses"] += 1
+                all_data = read_json_safe(self.path)
+                if uid in all_data:
+                    self.data[uid] = all_data[uid]
+                else:
+                    self.data[uid] = {"xp": 0, "level": 0}
+            else:
+                self.stats["cache_hits"] += 1
+
+            user = self.data[uid]
+            old_xp = int(user.get("xp", 0))
+            old_level = int(user.get("level", self._calc_level(old_xp)))
+
+            if old_xp < amount:
+                user["last_accessed"] = datetime.utcnow().isoformat()
+                return False
+
+            new_xp = old_xp - amount
+            new_level = self._calc_level(new_xp)
+            user["xp"] = new_xp
+            user["level"] = new_level
+            user["last_accessed"] = datetime.utcnow().isoformat()
+            self.stats["total_updates"] += 1
+
+        self._schedule_flush()
+
+        if new_level != old_level and guild_id is not None:
+            from utils.level_feed import LevelChange, emit
+            emit(
+                LevelChange(
+                    user_id=user_id,
+                    guild_id=guild_id,
+                    old_level=old_level,
+                    new_level=new_level,
+                    old_xp=old_xp,
+                    new_xp=new_xp,
+                    source=source,
+                )
+            )
+
+        return True
+
     async def get_user_data(self, user_id: int) -> XPUserData:
         """Récupère les données d'un utilisateur."""
         uid = str(user_id)

--- a/tests/test_xp_atomic_spending.py
+++ b/tests/test_xp_atomic_spending.py
@@ -1,0 +1,97 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cogs.economy_ui as economy_ui
+import cogs.pari_xp as pari_xp
+from storage.xp_store import XPStore
+from utils import xp_adapter
+
+
+@pytest.mark.asyncio
+async def test_try_spend_xp_prevents_double_spend(tmp_path):
+    store = XPStore(path=str(tmp_path / "xp.json"), cache_size=10)
+    store.data["1"] = {"xp": 100, "level": 1}
+
+    results = await asyncio.gather(
+        store.try_spend_xp(1, 100),
+        store.try_spend_xp(1, 100),
+    )
+
+    assert sorted(results) == [False, True]
+    assert store.data["1"]["xp"] == 0
+    await store.aclose()
+
+
+@pytest.mark.asyncio
+async def test_xp_adapter_rejects_unfunded_negative_debit(tmp_path, monkeypatch):
+    store = XPStore(path=str(tmp_path / "xp.json"), cache_size=10)
+    store.data["7"] = {"xp": 50, "level": 0}
+    monkeypatch.setattr(xp_adapter, "xp_store", store)
+
+    with pytest.raises(xp_adapter.InsufficientXPError):
+        await xp_adapter.add_xp(7, -100, guild_id=123, source="test")
+
+    assert store.data["7"]["xp"] == 50
+    await store.aclose()
+
+
+@pytest.mark.asyncio
+async def test_shop_does_not_grant_item_when_atomic_debit_fails(monkeypatch):
+    monkeypatch.setattr(
+        economy_ui,
+        "_load_shop",
+        lambda: {"ticket_royal": {"name": "Ticket Royal", "price": 100}},
+    )
+    monkeypatch.setattr(economy_ui, "load_tickets", lambda: {})
+    monkeypatch.setattr(economy_ui.xp_adapter, "get_balance", lambda _uid: 100)
+    debit = AsyncMock(side_effect=xp_adapter.InsufficientXPError("insufficient"))
+    monkeypatch.setattr(economy_ui.xp_adapter, "add_xp", debit)
+    save_tickets = AsyncMock()
+    monkeypatch.setattr(economy_ui, "save_tickets", save_tickets)
+
+    cog = economy_ui.EconomyUICog(object())
+    send = AsyncMock()
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        guild_id=123,
+        response=SimpleNamespace(send_message=send),
+    )
+
+    await cog._handle_shop_purchase(interaction, "ticket_royal")
+
+    debit.assert_awaited_once()
+    save_tickets.assert_not_awaited()
+    assert "insuffisant" in send.call_args.args[0].lower()
+
+
+@pytest.mark.asyncio
+async def test_roulette_rejects_bet_when_atomic_debit_fails(monkeypatch):
+    cog = object.__new__(pari_xp.PariXPCog)
+    cog.is_open = True
+
+    monkeypatch.setattr(
+        pari_xp.xp_store,
+        "get_user_data",
+        AsyncMock(return_value={"xp": 100, "level": 1}),
+    )
+    monkeypatch.setattr(
+        pari_xp.xp_adapter,
+        "add_xp",
+        AsyncMock(side_effect=xp_adapter.InsufficientXPError("insufficient")),
+    )
+    respond = AsyncMock()
+    monkeypatch.setattr(pari_xp, "safe_respond", respond)
+
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        guild_id=123,
+        guild=None,
+    )
+
+    await pari_xp.PariXPCog._handle_bet(cog, interaction, "red", 100)
+
+    respond.assert_awaited_once()
+    assert "insuffisant" in respond.call_args.args[1].lower()

--- a/utils/xp_adapter.py
+++ b/utils/xp_adapter.py
@@ -5,6 +5,10 @@ from storage.xp_store import xp_store
 from utils.persistence import read_json_safe
 
 
+class InsufficientXPError(ValueError):
+    """Raised when an atomic XP debit cannot be fully funded."""
+
+
 def get_balance(user_id: int) -> int:
     """Return current XP balance for ``user_id``.
 
@@ -31,5 +35,27 @@ def get_balance(user_id: int) -> int:
 
 
 async def add_xp(user_id: int, amount: int, guild_id: int, source: str) -> None:
-    """Add (or remove) XP for ``user_id`` with event metadata."""
+    """Add or spend XP for ``user_id`` with event metadata.
+
+    Positive amounts keep the historical :meth:`XPStore.add_xp` behaviour.
+    Negative amounts are treated as purchases/spends and therefore use the
+    atomic :meth:`XPStore.try_spend_xp` operation: an insufficient balance
+    raises :class:`InsufficientXPError` instead of silently clamping to zero.
+    """
+    if amount < 0:
+        spent = await xp_store.try_spend_xp(
+            user_id,
+            -amount,
+            guild_id=guild_id,
+            source=source,
+        )
+        if not spent:
+            raise InsufficientXPError(
+                f"user {user_id} cannot spend {-amount} XP"
+            )
+        return
+
     await xp_store.add_xp(user_id, amount, guild_id=guild_id, source=source)
+
+
+__all__ = ["InsufficientXPError", "get_balance", "add_xp"]


### PR DESCRIPTION
## Problème
La boutique et la roulette faisaient un pré-contrôle du solde puis un débit séparé. Deux actions simultanées pouvaient donc toutes les deux voir un solde suffisant et consommer la même réserve XP.

## Correction
- ajout de `XPStore.try_spend_xp()` : vérification du solde et débit sous le même verrou que les mises à jour XP immédiates ;
- une dépense insuffisamment financée ne modifie pas le solde et retourne `False` ;
- conservation du comportement historique de `add_xp()` pour les retraits administratifs qui peuvent rabattre le solde à zéro ;
- `utils.xp_adapter.add_xp()` route désormais les montants négatifs par l'opération atomique et lève `InsufficientXPError` si le débit est refusé ;
- la boutique et la roulette gèrent proprement cette erreur sans délivrer l'article ni accepter le pari.

## Tests ajoutés
`tests/test_xp_atomic_spending.py` couvre :
- deux dépenses concurrentes sur un seul solde : une seule réussit ;
- un débit négatif via l'adapter avec solde insuffisant ;
- la boutique ne délivre pas de ticket si le débit atomique échoue ;
- la roulette refuse le pari si le débit atomique échoue.

## Portée
Aucune modification des gains XP positifs, du calcul de niveau, des probabilités casino ou des limites de boutique.

## Validation
Le diff est limité à `storage/xp_store.py`, `utils/xp_adapter.py`, `cogs/economy_ui.py`, `cogs/pari_xp.py` et au nouveau test. Le runtime disponible ici ne contient pas `discord.py` et ne permet pas de cloner le dépôt depuis GitHub, donc `pytest` complet n'a pas pu être exécuté localement. La PR reste en brouillon jusqu'à validation.