### PR TITLE
fix: connect shop Double XP to XP awards

### DIFF
--- a/cogs/economy_ui.py
+++ b/cogs/economy_ui.py
@@ -7,7 +7,7 @@ import typing
 import discord
 from discord.ext import commands, tasks
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 from storage.economy import (
     ECONOMY_DIR,
@@ -21,7 +21,6 @@ from storage.economy import (
     transactions,
 )
 from utils import xp_adapter
-from cogs import xp as xp_cog
 import config
 
 CHANNEL_ID = 1409633293791400108
@@ -43,11 +42,17 @@ PURCHASE_LIMITS: dict[str, int] = {
 def _activate_personal_double_xp(user_id: int, duration_minutes: int) -> datetime:
     """Active ou prolonge le vrai bonus Double XP utilisé par ``award_xp``.
 
+    Le module XP est résolu au moment de l'achat, et non lors du chargement de
+    ``economy_ui``. Cela évite de conserver une référence vers une ancienne
+    instance du module si Discord charge ensuite ``cogs.xp`` comme extension.
+
     ``cogs.xp.add_xp_boost`` remplace normalement l'expiration existante. Pour
     les achats boutique, on conserve le temps restant puis on ajoute la nouvelle
     durée afin que deux achats d'une heure donnent bien deux heures de bonus au
     total au lieu de faire payer deux fois pour une seule heure.
     """
+    from cogs import xp as xp_cog
+
     now = datetime.now(timezone.utc)
     current_expiry = xp_cog.XP_BOOSTS.get(str(user_id))
     remaining_minutes = 0.0

--- a/cogs/economy_ui.py
+++ b/cogs/economy_ui.py
@@ -21,6 +21,7 @@ from storage.economy import (
     transactions,
 )
 from utils import xp_adapter
+from cogs import xp as xp_cog
 import config
 
 CHANNEL_ID = 1409633293791400108
@@ -37,6 +38,24 @@ PURCHASE_LIMITS: dict[str, int] = {
     "ticket_royal": 3,
     "double_xp_1h": 2,
 }
+
+
+def _activate_personal_double_xp(user_id: int, duration_minutes: int) -> datetime:
+    """Active ou prolonge le vrai bonus Double XP utilisé par ``award_xp``.
+
+    ``cogs.xp.add_xp_boost`` remplace normalement l'expiration existante. Pour
+    les achats boutique, on conserve le temps restant puis on ajoute la nouvelle
+    durée afin que deux achats d'une heure donnent bien deux heures de bonus au
+    total au lieu de faire payer deux fois pour une seule heure.
+    """
+    now = datetime.now(timezone.utc)
+    current_expiry = xp_cog.XP_BOOSTS.get(str(user_id))
+    remaining_minutes = 0.0
+    if current_expiry and current_expiry > now:
+        remaining_minutes = (current_expiry - now).total_seconds() / 60.0
+
+    xp_cog.add_xp_boost(user_id, duration_minutes + remaining_minutes)
+    return xp_cog.XP_BOOSTS[str(user_id)]
 
 
 def _load_shop() -> typing.Optional[dict[str, typing.Any]]:
@@ -309,8 +328,8 @@ class EconomyUICog(commands.Cog):
             boosts = load_boosts()
             key = str(user_id)
             boost_list = boosts.setdefault(key, [])
-            until = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
-            boost_list.append({"type": "double_xp", "until": until})
+            expiry = _activate_personal_double_xp(user_id, 60)
+            boost_list.append({"type": "double_xp", "until": expiry.isoformat()})
             await save_boosts(boosts)
 
         await transactions.add(
@@ -377,4 +396,3 @@ class EconomyUICog(commands.Cog):
 
 async def setup(bot: commands.Bot) -> None:  # pragma: no cover - requires discord
     await bot.add_cog(EconomyUICog(bot))
-

--- a/tests/test_shop_double_xp_integration.py
+++ b/tests/test_shop_double_xp_integration.py
@@ -1,0 +1,72 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cogs.economy_ui as economy_ui
+import cogs.xp as xp
+
+
+@pytest.mark.asyncio
+async def test_shop_double_xp_activates_real_award_path(monkeypatch):
+    xp.XP_BOOSTS.clear()
+    monkeypatch.setattr(xp, "save_xp_boosts_to_disk", AsyncMock())
+
+    monkeypatch.setattr(
+        economy_ui,
+        "_load_shop",
+        lambda: {"double_xp_1h": {"name": "Double XP 1h", "price": 300}},
+    )
+    monkeypatch.setattr(economy_ui, "load_boosts", lambda: {})
+    save_boosts = AsyncMock()
+    monkeypatch.setattr(economy_ui, "save_boosts", save_boosts)
+    monkeypatch.setattr(economy_ui.xp_adapter, "get_balance", lambda _uid: 1000)
+    monkeypatch.setattr(economy_ui.xp_adapter, "add_xp", AsyncMock())
+    monkeypatch.setattr(
+        economy_ui,
+        "transactions",
+        SimpleNamespace(add=AsyncMock()),
+    )
+
+    store_add = AsyncMock(return_value=(0, 0, 0, 20))
+    monkeypatch.setattr(xp.xp_store, "add_xp", store_add)
+
+    cog = economy_ui.EconomyUICog(object())
+    send = AsyncMock()
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        guild_id=123,
+        response=SimpleNamespace(send_message=send),
+    )
+
+    await cog._handle_shop_purchase(interaction, "double_xp_1h")
+    await asyncio.sleep(0)
+
+    assert "42" in xp.XP_BOOSTS
+    persisted = save_boosts.call_args.args[0]
+    assert datetime.fromisoformat(persisted["42"][0]["until"]) == xp.XP_BOOSTS["42"]
+
+    await xp.award_xp(42, 10, guild_id=123, source="integration_test")
+    store_add.assert_awaited_once_with(
+        42,
+        20,
+        guild_id=123,
+        source="integration_test",
+    )
+
+
+@pytest.mark.asyncio
+async def test_shop_double_xp_second_activation_extends_duration(monkeypatch):
+    xp.XP_BOOSTS.clear()
+    monkeypatch.setattr(xp, "save_xp_boosts_to_disk", AsyncMock())
+
+    before = datetime.now(timezone.utc)
+    first_expiry = economy_ui._activate_personal_double_xp(7, 60)
+    second_expiry = economy_ui._activate_personal_double_xp(7, 60)
+    await asyncio.sleep(0)
+
+    extension = second_expiry - first_expiry
+    assert timedelta(minutes=59, seconds=59) < extension < timedelta(hours=1, seconds=1)
+    assert second_expiry > before + timedelta(minutes=119)


### PR DESCRIPTION
## Problème
L'article `double_xp_1h` de la boutique débitait bien les XP et écrivait une entrée dans `data/economy/boosts.json`, mais le calcul réel des gains via `cogs.xp.award_xp()` consulte `XP_BOOSTS`. Le joueur pouvait donc payer un Double XP sans que ses gains soient doublés.

## Correction
- la boutique active désormais le même `XP_BOOSTS` que celui utilisé par `award_xp()` ;
- le module `cogs.xp` est résolu paresseusement au moment de l'achat afin d'éviter une référence obsolète si Discord charge ensuite l'extension XP ;
- un deuxième achat d'une heure prolonge le temps restant d'une heure au lieu de réinitialiser le bonus à une seule heure ;
- `data/economy/boosts.json` reste conservé pour le suivi et la limite existante de deux boosts boutique, mais son expiration est maintenant alignée sur l'expiration réelle du bonus XP.

## Tests ajoutés
`tests/test_shop_double_xp_integration.py` vérifie :
- qu'un achat boutique active réellement le chemin utilisé par `award_xp()` et transforme un gain de 10 XP en 20 XP ;
- qu'une seconde activation ajoute environ 60 minutes supplémentaires.

## Portée
Aucune modification des probabilités du casino, des récompenses de la machine à sous, du calcul des niveaux ou du débit atomique ajouté par la PR #481.

## Validation
Le diff est limité à `cogs/economy_ui.py` et au nouveau test d'intégration. Le runtime de cette session ne peut pas résoudre `github.com` depuis le terminal et ne permet donc pas d'exécuter la suite pytest locale ; la PR reste en brouillon jusqu'à validation.