### PR TITLE
fix: unify persistent storage under DATA_DIR

### DIFF
--- a/config.py
+++ b/config.py
@@ -235,8 +235,10 @@ XP_DOUBLE_VOICE_ANNOUNCE_CHANNEL_ID: int = int(
 
 
 # ── Jeux organisés ────────────────────────────────────────────
-GAMES_DATA_DIR: str = os.getenv("GAMES_DATA_DIR", "/app/data/games")
-"""Répertoire de persistance des événements de jeu."""
+GAMES_DATA_DIR: str = os.getenv(
+    "GAMES_DATA_DIR", os.path.join(DATA_DIR, "games")
+)
+"""Répertoire de persistance des événements de jeu, sous ``DATA_DIR`` par défaut."""
 
 CHANNEL_EDIT_MIN_INTERVAL_SECONDS: int = int(
     os.getenv("CHANNEL_EDIT_MIN_INTERVAL_SECONDS", "180")

--- a/storage/economy.py
+++ b/storage/economy.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict
 
+from config import DATA_DIR
 from storage.transaction_store import TransactionStore
 from utils.storage import load_json, save_json
 
-# Base directory for economy data files
-ECONOMY_DIR = Path(__file__).resolve().parent.parent / "data" / "economy"
+# All persistent economy files live below the configured persistent root.
+ECONOMY_DIR = Path(DATA_DIR) / "economy"
 
 # Paths for various economy files
 SHOP_FILE = ECONOMY_DIR / "shop.json"

--- a/tests/test_data_dir_paths.py
+++ b/tests/test_data_dir_paths.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+
+import config
+from storage import economy
+
+
+def test_economy_storage_is_rooted_under_data_dir():
+    expected = Path(config.DATA_DIR) / "economy"
+
+    assert economy.ECONOMY_DIR == expected
+    assert economy.SHOP_FILE == expected / "shop.json"
+    assert economy.TRANSACTIONS_FILE == expected / "transactions.json"
+    assert economy.BOOSTS_FILE == expected / "boosts.json"
+    assert economy.TICKETS_FILE == expected / "tickets.json"
+    assert economy.UI_FILE == expected / "ui.json"
+
+
+def test_games_storage_uses_data_dir_by_default_or_explicit_override():
+    explicit = os.getenv("GAMES_DATA_DIR")
+    expected = Path(explicit) if explicit else Path(config.DATA_DIR) / "games"
+
+    assert Path(config.GAMES_DATA_DIR) == expected


### PR DESCRIPTION
## Problème
`DATA_DIR` est documenté comme la racine unique de persistance, mais deux chemins la contournaient :
- l'économie reconstruisait directement `<repo>/data/economy` ;
- les événements de jeu utilisaient `/app/data/games` par défaut, même quand `DATA_DIR` était personnalisé.

Selon l'environnement, XP, économie et événements pouvaient donc écrire dans des racines différentes.

## Correction
- `storage/economy.py` utilise désormais `Path(DATA_DIR) / "economy"` ;
- `GAMES_DATA_DIR` devient par défaut `os.path.join(DATA_DIR, "games")` ;
- un override explicite `GAMES_DATA_DIR` reste prioritaire et compatible.

## Tests ajoutés
`tests/test_data_dir_paths.py` vérifie :
- que tous les fichiers économie sont sous `DATA_DIR/economy` ;
- que les événements sont sous `DATA_DIR/games` par défaut ;
- qu'un `GAMES_DATA_DIR` explicite reste respecté.

## Compatibilité
Avec le montage Railway standard `DATA_DIR=/app/data`, les chemins restent `/app/data/economy` et `/app/data/games`. Le correctif change surtout le comportement des environnements utilisant un `DATA_DIR` personnalisé, pour lesquels la persistance devient enfin cohérente.

## Portée
3 fichiers seulement : `config.py`, `storage/economy.py` et le nouveau test de contrat. Aucun format JSON, calcul XP ou comportement Discord n'est modifié.

## Validation
Le runtime de cette session ne dispose pas d'un checkout exécutable du dépôt ; la suite pytest complète n'a donc pas pu être lancée ici. La PR reste en brouillon jusqu'à validation.