### PR TITLE
fix: make economy ticket consumption atomic

### DIFF
--- a/tests/test_economy_ticket_concurrency.py
+++ b/tests/test_economy_ticket_concurrency.py
@@ -1,0 +1,33 @@
+import asyncio
+
+import pytest
+
+from storage.transaction_store import TransactionStore
+from utils.persist import atomic_write_json
+from utils.storage import load_json
+import utils.economy_tickets as economy_tickets
+
+
+@pytest.mark.asyncio
+async def test_consume_free_ticket_is_atomic(tmp_path, monkeypatch):
+    tickets_path = tmp_path / "tickets.json"
+    transactions_path = tmp_path / "transactions.json"
+
+    atomic_write_json(tickets_path, {"123": 1})
+    transaction_store = TransactionStore(transactions_path)
+
+    monkeypatch.setattr(economy_tickets, "TICKETS_FILE", tickets_path)
+    monkeypatch.setattr(economy_tickets, "transactions", transaction_store)
+
+    results = await asyncio.gather(
+        economy_tickets.consume_free_ticket(123),
+        economy_tickets.consume_free_ticket(123),
+    )
+
+    assert sorted(results) == [False, True]
+    assert load_json(tickets_path, {}) == {}
+
+    entries = await transaction_store.all()
+    assert len(entries) == 1
+    assert entries[0]["type"] == "ticket_usage"
+    assert entries[0]["user_id"] == 123

--- a/utils/economy_tickets.py
+++ b/utils/economy_tickets.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import weakref
 from datetime import datetime, timezone
 from typing import Awaitable, Callable, Dict
 
@@ -9,34 +11,53 @@ from utils.storage import load_json
 from utils.persistence import atomic_write_json_async
 
 
+# ``asyncio.Lock`` instances are bound to the event loop that contends on
+# them. Keep one lock per live loop so production has a single transaction
+# boundary while tests that use separate event loops remain isolated.
+_ticket_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def _get_ticket_lock() -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    lock = _ticket_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _ticket_locks[loop] = lock
+    return lock
+
+
 async def consume_free_ticket(user_id: int) -> bool:
     """Consume one free ticket for ``user_id`` if available.
 
-    Returns ``True`` if a ticket was consumed.
-    Updates ``data/economy/tickets.json`` and logs the usage in
-    ``transactions.json``.
+    The read/check/decrement/write sequence is serialized so two concurrent
+    consumers cannot both spend the same ticket. Returns ``True`` only when a
+    ticket was actually consumed, then records that successful usage in the
+    transaction ledger.
     """
-    tickets: Dict[str, int] = load_json(TICKETS_FILE, {})
-    key = str(user_id)
-    count = int(tickets.get(key, 0))
-    if count <= 0:
-        return False
+    async with _get_ticket_lock():
+        tickets: Dict[str, int] = load_json(TICKETS_FILE, {})
+        key = str(user_id)
+        count = int(tickets.get(key, 0))
+        if count <= 0:
+            return False
 
-    count -= 1
-    if count:
-        tickets[key] = count
-    else:
-        tickets.pop(key, None)
-    await atomic_write_json_async(TICKETS_FILE, tickets)
+        count -= 1
+        if count:
+            tickets[key] = count
+        else:
+            tickets.pop(key, None)
+        await atomic_write_json_async(TICKETS_FILE, tickets)
 
-    await transactions.add(
-        {
-            "type": "ticket_usage",
-            "user_id": user_id,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
-        }
-    )
-    return True
+        await transactions.add(
+            {
+                "type": "ticket_usage",
+                "user_id": user_id,
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            }
+        )
+        return True
 
 
 async def consume_any_ticket(


### PR DESCRIPTION
## Problème
`consume_free_ticket()` faisait une lecture du stock, vérifiait le nombre de tickets, décrémentait puis écrivait le JSON sans verrou transactionnel. Deux appels concurrents pouvaient donc tous les deux lire un stock de `1` et retourner `True`, ce qui permettait de consommer deux fois le même ticket virtuel.

## Correction
- ajout d'un verrou dédié à la transaction de consommation des tickets économie ;
- le verrou couvre lecture, vérification, décrément, écriture et journalisation ;
- le verrou est isolé par event loop afin de rester compatible avec les tests asyncio utilisant plusieurs boucles ;
- `consume_any_ticket()` et les autres comportements restent inchangés.

## Test ajouté
`tests/test_economy_ticket_concurrency.py` lance deux consommations simultanées avec un seul ticket disponible et vérifie :
- exactement une réussite ;
- stock final vide ;
- exactement une transaction `ticket_usage` enregistrée.

## Portée
2 fichiers seulement : `utils/economy_tickets.py` et le nouveau test de concurrence. Aucun changement sur les prix, les gains XP, la boutique ou les probabilités des jeux Discord utilisant des XP virtuels.

## Validation
La branche part du `main` après la PR #484. La suite pytest complète n'a pas pu être exécutée dans ce runtime car le terminal n'a pas accès au checkout GitHub ; la PR reste en brouillon jusqu'à validation.