### PR TITLE
fix: stop background helpers cleanly

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -146,6 +146,8 @@ class RefugeBot(commands.Bot):
 
     async def close(self) -> None:  # type: ignore[override]
         """Ensure background helpers are stopped before shutting down."""
+        await limiter.aclose()
+        await api_meter.aclose()
         await rename_manager.aclose()
         await channel_edit_manager.aclose()
         await xp_store.aclose()

--- a/tests/test_bot_close_stops_rename_manager.py
+++ b/tests/test_bot_close_stops_rename_manager.py
@@ -13,9 +13,15 @@ import bot
 
 
 @pytest.mark.asyncio
-async def test_bot_close_stops_rename_manager(monkeypatch):
+async def test_bot_close_stops_background_helpers(monkeypatch):
     intents = discord.Intents.none()
     test_bot = bot.RefugeBot(command_prefix="!", intents=intents)
+
+    limiter_aclose_mock = AsyncMock()
+    monkeypatch.setattr(bot.limiter, "aclose", limiter_aclose_mock)
+
+    meter_aclose_mock = AsyncMock()
+    monkeypatch.setattr(bot.api_meter, "aclose", meter_aclose_mock)
 
     rm_aclose_mock = AsyncMock()
     monkeypatch.setattr(bot.rename_manager, "aclose", rm_aclose_mock)
@@ -33,6 +39,8 @@ async def test_bot_close_stops_rename_manager(monkeypatch):
 
     await test_bot.close()
 
+    limiter_aclose_mock.assert_awaited_once()
+    meter_aclose_mock.assert_awaited_once()
     rm_aclose_mock.assert_awaited_once()
     cem_aclose_mock.assert_awaited_once()
     store_aclose_mock.assert_awaited_once()

--- a/tests/test_rate_limiter_lifecycle.py
+++ b/tests/test_rate_limiter_lifecycle.py
@@ -1,0 +1,33 @@
+import pytest
+
+from utils.rate_limit import GlobalRateLimiter
+
+
+@pytest.mark.asyncio
+async def test_rate_limiter_shutdown_is_idempotent_and_restartable():
+    limiter = GlobalRateLimiter()
+    limiter.strict = True
+
+    limiter.start()
+    first_task = limiter._task
+    assert first_task is not None
+    assert not first_task.done()
+
+    await limiter.aclose()
+
+    assert limiter._task is None
+    assert first_task.cancelled()
+
+    # Closing an already stopped limiter must remain harmless.
+    await limiter.aclose()
+
+    limiter.start()
+    second_task = limiter._task
+    assert second_task is not None
+    assert second_task is not first_task
+    assert not second_task.done()
+
+    await limiter.aclose()
+
+    assert limiter._task is None
+    assert second_task.cancelled()

--- a/utils/rate_limit.py
+++ b/utils/rate_limit.py
@@ -1,4 +1,5 @@
 import asyncio  # required for asynchronous rate limiting
+import contextlib
 import logging
 import os
 import time
@@ -83,9 +84,20 @@ class GlobalRateLimiter:
             self.logger.debug("Rate limiter waited %.3fs for bucket %s", elapsed, bucket)
 
     def start(self) -> None:
-        if self.strict and self._task is None:
+        if self.strict and (self._task is None or self._task.done()):
             loop = asyncio.get_running_loop()
             self._task = loop.create_task(self._log_loop())
+
+    async def aclose(self) -> None:
+        """Stop the background logging task, if one is running."""
+        task = self._task
+        self._task = None
+        if task is None:
+            return
+        if not task.done():
+            task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
 
     async def _log_loop(self) -> None:
         while True:


### PR DESCRIPTION
## Problème
`RefugeBot.setup_hook()` démarre `api_meter` et le `GlobalRateLimiter`, mais `RefugeBot.close()` ne les arrêtait pas. Le rate limiter gardait donc sa boucle de log infinie active pendant l'extinction, et l'API meter n'était pas explicitement flush/fermé par le cycle de vie principal du bot.

## Correction
- ajout de `GlobalRateLimiter.aclose()` pour annuler et attendre proprement la tâche de log ;
- `GlobalRateLimiter.start()` recrée une tâche si le limiter a déjà été fermé ;
- `RefugeBot.close()` appelle désormais `limiter.aclose()` puis `api_meter.aclose()` avant de fermer les autres services et Discord.

## Tests
- le test de fermeture du bot exige désormais la fermeture de `limiter`, `api_meter`, `rename_manager`, `channel_edit_manager` et `xp_store` ;
- un nouveau test vérifie que la fermeture du limiter est idempotente, annule réellement la tâche et autorise un redémarrage ultérieur.

## Portée
4 fichiers. Aucun changement de capacité, refill rate, bucket, délai ou logique de limitation des requêtes.

## Validation
La branche part du `main` après la PR #485. La suite pytest complète ne peut pas être exécutée dans ce runtime faute de checkout GitHub exécutable ; la PR reste en brouillon jusqu'à validation.