### PR TITLE
fix: count all API routes in usage summaries

### DIFF
--- a/tests/test_api_meter_window_totals.py
+++ b/tests/test_api_meter_window_totals.py
@@ -1,0 +1,45 @@
+import os
+import sys
+import time
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("DISCORD_TOKEN", "dummy")
+
+from utils.api_meter import APIMeter
+
+
+def _event(route: str, *, status: int = 200, duration_ms: int = 100) -> dict:
+    return {
+        "method": "GET",
+        "route": route,
+        "status": status,
+        "duration_ms": duration_ms,
+        "caller": "test",
+        "cog": None,
+        "command": None,
+    }
+
+
+def test_window_totals_include_routes_outside_top_five():
+    meter = APIMeter()
+    now = time.time()
+
+    # Five dominant routes: 10 calls each.
+    for route_index in range(5):
+        for _ in range(10):
+            meter.events.append((now, _event(f"/route-{route_index}")))
+
+    # Sixth route would be excluded by get_top_routes(..., 5), but its call,
+    # error, 429 and duration must still count toward budget/alert thresholds.
+    meter.events.append(
+        (now, _event("/route-outside-top-five", status=429, duration_ms=1100))
+    )
+
+    assert sum(item["calls"] for item in meter.get_top_routes(10, 5)) == 50
+
+    totals = meter.get_window_totals(10)
+    assert totals["calls"] == 51
+    assert totals["errors"] == 1
+    assert totals["429"] == 1
+    assert totals["avg_ms"] == 6100 / 51

--- a/utils/api_meter.py
+++ b/utils/api_meter.py
@@ -210,6 +210,21 @@ class APIMeter:
             ss["dur_ms"] += ev["duration_ms"]
         return route_stats, source_stats
 
+    def get_window_totals(self, window_min: int = 10) -> Dict[str, float | int]:
+        """Return totals for every route observed inside the time window."""
+        route_stats, _ = self._calc_stats(window_min)
+        calls = sum(stats["calls"] for stats in route_stats.values())
+        errors = sum(stats["errors"] for stats in route_stats.values())
+        too_many = sum(stats["429"] for stats in route_stats.values())
+        duration_ms = sum(stats["dur_ms"] for stats in route_stats.values())
+        avg_ms = duration_ms / calls if calls else 0.0
+        return {
+            "calls": int(calls),
+            "errors": int(errors),
+            "429": int(too_many),
+            "avg_ms": avg_ms,
+        }
+
     def get_top_routes(self, window_min: int = 10, top: int = 10) -> List[Dict[str, Any]]:
         route_stats, _ = self._calc_stats(window_min)
         out: List[Dict[str, Any]] = []
@@ -261,13 +276,11 @@ class APIMeter:
             if self.current_month and month != self.current_month:
                 await self._save_aggregates_async()
                 self._load_aggregates(now)
-            routes = self.get_top_routes(10, 5)
-            total = sum(r["calls"] for r in routes)
-            errors = sum(r["errors"] for r in routes)
-            too_many = sum(r["429"] for r in routes)
-            avg = (
-                sum(r["avg_ms"] * r["calls"] for r in routes) / total if total else 0.0
-            )
+            totals = self.get_window_totals(10)
+            total = int(totals["calls"])
+            errors = int(totals["errors"])
+            too_many = int(totals["429"])
+            avg = float(totals["avg_ms"])
             usage_pct = (total / config.API_BUDGET_PER_10MIN) * 100 if config.API_BUDGET_PER_10MIN else 0
             self.logger.info(
                 "api_summary window=10min calls=%d errors=%d 429=%d avg_ms=%.1f usage=%.1f%%",


### PR DESCRIPTION
## Problème
`APIMeter._summary_loop()` calculait le nombre d'appels, les erreurs, les réponses 429 et la durée moyenne à partir de `get_top_routes(10, 5)`. Les routes situées en dehors du top 5 disparaissaient donc du budget API et des seuils d'alerte.

Exemple : 50 appels sur les 5 routes principales + un 429 sur une 6e route étaient résumés comme 50 appels et 0 erreur.

## Correction
- ajout de `get_window_totals()` qui agrège toutes les routes de la fenêtre demandée ;
- `_summary_loop()` utilise désormais ces totaux complets pour `calls`, `errors`, `429`, `avg_ms` et `usage_pct` ;
- `get_top_routes()` reste inchangé et continue de servir au classement des routes, mais ne détermine plus les seuils.

## Test de régression
`tests/test_api_meter_window_totals.py` crée 50 appels répartis sur cinq routes dominantes puis un 429 sur une sixième route. Il vérifie que :
- le top 5 contient toujours 50 appels ;
- les totaux de fenêtre contiennent 51 appels ;
- l'erreur et le 429 de la sixième route sont comptabilisés ;
- la durée moyenne est calculée sur les 51 appels.

## Portée
2 fichiers seulement : `utils/api_meter.py` et le nouveau test. Aucun changement des valeurs `API_BUDGET_PER_10MIN`, `API_SOFT_LIMIT_PCT` ou `API_HARD_LIMIT_PCT`.

## Validation
La branche part du `main` après la PR #486. La suite pytest complète ne peut pas être exécutée dans ce runtime faute de checkout GitHub exécutable ; la PR reste en brouillon jusqu'à validation.