### PR TITLE
fix: persist streamer temporary voice channels

### DIFF
--- a/cogs/streamer_temp_vc.py
+++ b/cogs/streamer_temp_vc.py
@@ -13,9 +13,15 @@ from config import (
     TEMP_VOICE_CATEGORY_ID,
     TRIGGER_CHANNEL_ID,
 )
+from storage.temp_vc_store import (
+    load_streamer_temp_vcs,
+    save_streamer_temp_vcs_async,
+)
 from view import StreamerTempVoiceView
 
 logger = logging.getLogger(__name__)
+
+STREAMER_TEMP_CHANNEL_PREFIX = "🔊・"
 
 
 class StreamerTempVCCog(commands.Cog):
@@ -23,16 +29,82 @@ class StreamerTempVCCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
-        self._owner_to_channel: Dict[int, int] = {}
-        self._channel_to_owner: Dict[int, int] = {}
+        persisted = load_streamer_temp_vcs()
+        self._channel_to_owner: Dict[int, int] = dict(persisted)
+        self._owner_to_channel: Dict[int, int] = {
+            owner_id: channel_id for channel_id, owner_id in persisted.items()
+        }
         self._delete_tasks: Dict[int, asyncio.Task] = {}
+
+    def cog_unload(self) -> None:
+        for task in self._delete_tasks.values():
+            task.cancel()
+        self._delete_tasks.clear()
+
+    async def _persist_channels(self) -> None:
+        await save_streamer_temp_vcs_async(self._channel_to_owner.copy())
+
+    def _track_channel(self, owner_id: int, channel_id: int) -> None:
+        previous_channel = self._owner_to_channel.get(owner_id)
+        if previous_channel and previous_channel != channel_id:
+            self._channel_to_owner.pop(previous_channel, None)
+        self._owner_to_channel[owner_id] = channel_id
+        self._channel_to_owner[channel_id] = owner_id
+
+    def _forget_channel(self, channel_id: int) -> bool:
+        owner_id = self._channel_to_owner.pop(channel_id, None)
+        if owner_id is None:
+            return False
+        if self._owner_to_channel.get(owner_id) == channel_id:
+            self._owner_to_channel.pop(owner_id, None)
+        return True
+
+    async def _untrack_channel(self, channel_id: int) -> None:
+        if self._forget_channel(channel_id):
+            await self._persist_channels()
 
     def _safe_name(self, member: discord.Member) -> str:
         base = (member.display_name or member.name).lower()
         safe = re.sub(r"[^a-z0-9]+", "-", base).strip("-")
         return safe or "streamer"
 
-    def _get_existing_channel(
+    def _configured_category(
+        self, guild: discord.Guild
+    ) -> Optional[discord.CategoryChannel]:
+        if TEMP_VOICE_CATEGORY_ID:
+            category = guild.get_channel(TEMP_VOICE_CATEGORY_ID)
+            if isinstance(category, discord.CategoryChannel):
+                return category
+
+        trigger = guild.get_channel(TRIGGER_CHANNEL_ID) if TRIGGER_CHANNEL_ID else None
+        category = getattr(trigger, "category", None)
+        if isinstance(category, discord.CategoryChannel):
+            return category
+        return None
+
+    def _get_category(
+        self, guild: discord.Guild, trigger_channel: discord.abc.GuildChannel
+    ) -> Optional[discord.CategoryChannel]:
+        category = self._configured_category(guild)
+        if category is not None:
+            return category
+        fallback = getattr(trigger_channel, "category", None)
+        return fallback if isinstance(fallback, discord.CategoryChannel) else None
+
+    def _looks_like_streamer_temp(self, channel: object) -> bool:
+        return str(getattr(channel, "name", "")).startswith(STREAMER_TEMP_CHANNEL_PREFIX)
+
+    def _is_in_managed_category(
+        self, guild: discord.Guild, channel: object
+    ) -> bool:
+        category = self._configured_category(guild)
+        if category is None:
+            return False
+        if getattr(channel, "category", None) is category:
+            return True
+        return getattr(channel, "category_id", None) == getattr(category, "id", None)
+
+    async def _get_existing_channel(
         self, guild: discord.Guild, owner_id: int
     ) -> Optional[discord.VoiceChannel]:
         channel_id = self._owner_to_channel.get(owner_id)
@@ -40,19 +112,34 @@ class StreamerTempVCCog(commands.Cog):
             return None
         channel = guild.get_channel(channel_id)
         if not isinstance(channel, discord.VoiceChannel):
-            self._owner_to_channel.pop(owner_id, None)
-            self._channel_to_owner.pop(channel_id, None)
+            if self._forget_channel(channel_id):
+                await self._persist_channels()
             return None
         return channel
 
-    def _get_category(
-        self, guild: discord.Guild, trigger_channel: discord.abc.GuildChannel
-    ) -> Optional[discord.CategoryChannel]:
-        if TEMP_VOICE_CATEGORY_ID:
-            category = guild.get_channel(TEMP_VOICE_CATEGORY_ID)
-            if isinstance(category, discord.CategoryChannel):
-                return category
-        return trigger_channel.category
+    async def _adopt_existing_channel(
+        self,
+        member: discord.Member,
+        trigger_channel: discord.abc.GuildChannel,
+    ) -> Optional[discord.VoiceChannel]:
+        """Récupère un ancien vocal non persisté si son propriétaire y est encore."""
+        category = self._get_category(member.guild, trigger_channel)
+        if category is None:
+            return None
+
+        expected_name = f"{STREAMER_TEMP_CHANNEL_PREFIX}{self._safe_name(member)}"
+        matches = [
+            channel
+            for channel in category.voice_channels
+            if channel.name == expected_name and member in channel.members
+        ]
+        if len(matches) != 1:
+            return None
+
+        channel = matches[0]
+        self._track_channel(member.id, channel.id)
+        await self._persist_channels()
+        return channel
 
     async def _create_channel(
         self, member: discord.Member, trigger_channel: discord.abc.GuildChannel
@@ -88,34 +175,51 @@ class StreamerTempVCCog(commands.Cog):
             )
 
         category = self._get_category(guild, trigger_channel)
-        name = f"🔊・{self._safe_name(member)}"
+        name = f"{STREAMER_TEMP_CHANNEL_PREFIX}{self._safe_name(member)}"
         channel = await guild.create_voice_channel(
             name=name,
             category=category,
             overwrites=overwrites,
         )
-        self._owner_to_channel[member.id] = channel.id
-        self._channel_to_owner[channel.id] = member.id
+        self._track_channel(member.id, channel.id)
+        try:
+            await self._persist_channels()
+        except Exception:
+            self._forget_channel(channel.id)
+            try:
+                await channel.delete(reason="Échec de persistance du vocal temporaire")
+            except Exception:
+                logger.exception(
+                    "[streamer_temp_vc] nettoyage après échec de persistance impossible"
+                )
+            raise
         return channel
 
     async def _delete_after_delay(self, channel_id: int) -> None:
+        remove_mapping = False
         try:
             await asyncio.sleep(DELETE_DELAY_SECONDS)
             channel = self.bot.get_channel(channel_id)
             if not isinstance(channel, discord.VoiceChannel):
+                remove_mapping = True
                 return
             if channel.members:
                 return
             await channel.delete(reason="Salon temporaire vide")
+            remove_mapping = True
         except asyncio.CancelledError:
             return
         except Exception:
             logger.exception("[streamer_temp_vc] suppression du salon échouée")
         finally:
-            owner_id = self._channel_to_owner.pop(channel_id, None)
-            if owner_id:
-                self._owner_to_channel.pop(owner_id, None)
             self._delete_tasks.pop(channel_id, None)
+            if remove_mapping:
+                try:
+                    await self._untrack_channel(channel_id)
+                except Exception:
+                    logger.exception(
+                        "[streamer_temp_vc] persistance après suppression échouée"
+                    )
 
     def _schedule_delete(self, channel_id: int) -> None:
         task = self._delete_tasks.pop(channel_id, None)
@@ -129,6 +233,42 @@ class StreamerTempVCCog(commands.Cog):
         task = self._delete_tasks.pop(channel_id, None)
         if task:
             task.cancel()
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        """Réconcilie les vocaux persistés et nettoie les orphelins vides."""
+        try:
+            changed = False
+            for channel_id in list(self._channel_to_owner):
+                channel = self.bot.get_channel(channel_id)
+                if not isinstance(channel, discord.VoiceChannel):
+                    changed = self._forget_channel(channel_id) or changed
+                    continue
+                if not channel.members:
+                    self._schedule_delete(channel_id)
+
+            if changed:
+                await self._persist_channels()
+
+            for guild in getattr(self.bot, "guilds", []):
+                category = self._configured_category(guild)
+                if category is None:
+                    continue
+                for channel in list(category.voice_channels):
+                    if channel.id in self._channel_to_owner:
+                        continue
+                    if not self._looks_like_streamer_temp(channel):
+                        continue
+                    if channel.members:
+                        continue
+                    try:
+                        await channel.delete(reason="Salon streamer temporaire orphelin")
+                    except discord.HTTPException:
+                        logger.exception(
+                            "[streamer_temp_vc] suppression d'un vocal orphelin échouée"
+                        )
+        except Exception:
+            logger.exception("[streamer_temp_vc] réconciliation au démarrage échouée")
 
     async def handle_create_request(
         self, interaction: discord.Interaction
@@ -175,7 +315,9 @@ class StreamerTempVCCog(commands.Cog):
             )
             return
 
-        existing = self._get_existing_channel(guild, member.id)
+        existing = await self._get_existing_channel(guild, member.id)
+        if existing is None:
+            existing = await self._adopt_existing_channel(member, trigger_channel)
         if existing is not None:
             await interaction.response.send_message(
                 f"Ton vocal existe déjà : {existing.mention}",
@@ -215,20 +357,28 @@ class StreamerTempVCCog(commands.Cog):
         if after.channel and after.channel.id in self._channel_to_owner:
             self._cancel_delete(after.channel.id)
 
-        if before.channel and before.channel.id in self._channel_to_owner:
-            if not before.channel.members:
+        if before.channel and not before.channel.members:
+            tracked = before.channel.id in self._channel_to_owner
+            orphan = (
+                self._looks_like_streamer_temp(before.channel)
+                and self._is_in_managed_category(member.guild, before.channel)
+            )
+            if tracked or orphan:
                 self._schedule_delete(before.channel.id)
 
     @commands.Cog.listener()
     async def on_guild_channel_delete(
         self, channel: discord.abc.GuildChannel
     ) -> None:
+        self._cancel_delete(channel.id)
         if channel.id not in self._channel_to_owner:
             return
-        owner_id = self._channel_to_owner.pop(channel.id, None)
-        if owner_id:
-            self._owner_to_channel.pop(owner_id, None)
-        self._cancel_delete(channel.id)
+        try:
+            await self._untrack_channel(channel.id)
+        except Exception:
+            logger.exception(
+                "[streamer_temp_vc] persistance après suppression externe échouée"
+            )
 
     @app_commands.command(
         name="streamer_vocal_message",

--- a/storage/temp_vc_store.py
+++ b/storage/temp_vc_store.py
@@ -1,13 +1,14 @@
 import asyncio
 import logging
 from pathlib import Path
-from typing import Dict, Iterable, Set
+from typing import Dict, Iterable, Mapping, Set
 
 from config import DATA_DIR
-from utils.persistence import atomic_write_json, read_json_safe
+from utils.persistence import atomic_write_json, atomic_write_json_async, read_json_safe
 
 DATA_FILE = Path(DATA_DIR) / "temp_vc_ids.json"
 LAST_NAMES_FILE = Path(DATA_DIR) / "temp_vc_last_names.json"
+STREAMER_TEMP_VC_FILE = Path(DATA_DIR) / "streamer_temp_vc.json"
 
 
 def load_temp_vc_ids() -> Set[int]:
@@ -32,6 +33,25 @@ def load_last_names_cache() -> Dict[int, str]:
     if isinstance(data, dict):
         return {int(k): str(v) for k, v in data.items()}
     return {}
+
+
+def load_streamer_temp_vcs() -> Dict[int, int]:
+    """Charge le mapping ``channel_id -> owner_id`` des vocaux streamer."""
+    data = read_json_safe(STREAMER_TEMP_VC_FILE)
+    if not isinstance(data, dict):
+        return {}
+
+    mapping: Dict[int, int] = {}
+    for channel_id, owner_id in data.items():
+        try:
+            mapping[int(channel_id)] = int(owner_id)
+        except (TypeError, ValueError):
+            logging.warning(
+                "[temp_vc_store] Entrée streamer invalide ignorée: %r -> %r",
+                channel_id,
+                owner_id,
+            )
+    return mapping
 
 
 async def save_temp_vc_ids_async(
@@ -74,3 +94,9 @@ async def save_last_names_cache(
             )
             if attempt + 1 < max_retries:
                 await asyncio.sleep(2 ** attempt)
+
+
+async def save_streamer_temp_vcs_async(mapping: Mapping[int, int]) -> None:
+    """Persiste atomiquement les propriétaires des vocaux streamer temporaires."""
+    payload = {str(int(channel_id)): int(owner_id) for channel_id, owner_id in mapping.items()}
+    await atomic_write_json_async(STREAMER_TEMP_VC_FILE, payload)

--- a/tests/test_streamer_temp_vc_persistence.py
+++ b/tests/test_streamer_temp_vc_persistence.py
@@ -1,0 +1,175 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import cogs.streamer_temp_vc as streamer_temp_vc
+
+
+class DummyVoiceChannel:
+    def __init__(
+        self,
+        channel_id: int,
+        *,
+        name: str = "🔊・kevin",
+        members=None,
+        category=None,
+    ) -> None:
+        self.id = channel_id
+        self.name = name
+        self.members = list(members or [])
+        self.category = category
+        self.category_id = getattr(category, "id", None)
+        self.mention = f"<#{channel_id}>"
+        self.delete = AsyncMock()
+
+
+class DummyCategory:
+    def __init__(self, category_id: int, voice_channels=None) -> None:
+        self.id = category_id
+        self.voice_channels = list(voice_channels or [])
+
+
+@pytest.fixture
+def discord_channel_types(monkeypatch):
+    monkeypatch.setattr(streamer_temp_vc.discord, "VoiceChannel", DummyVoiceChannel)
+    monkeypatch.setattr(streamer_temp_vc.discord, "CategoryChannel", DummyCategory)
+
+
+@pytest.mark.asyncio
+async def test_ready_removes_missing_persisted_channel(
+    monkeypatch, discord_channel_types
+):
+    monkeypatch.setattr(
+        streamer_temp_vc,
+        "load_streamer_temp_vcs",
+        lambda: {42: 7},
+    )
+    save_mock = AsyncMock()
+    monkeypatch.setattr(streamer_temp_vc, "save_streamer_temp_vcs_async", save_mock)
+
+    bot = SimpleNamespace(get_channel=lambda _cid: None, guilds=[])
+    cog = streamer_temp_vc.StreamerTempVCCog(bot)
+
+    await cog.on_ready()
+
+    assert cog._channel_to_owner == {}
+    assert cog._owner_to_channel == {}
+    save_mock.assert_awaited_once_with({})
+
+
+@pytest.mark.asyncio
+async def test_ready_deletes_empty_untracked_streamer_channel(
+    monkeypatch, discord_channel_types
+):
+    monkeypatch.setattr(streamer_temp_vc, "load_streamer_temp_vcs", lambda: {})
+    monkeypatch.setattr(
+        streamer_temp_vc,
+        "save_streamer_temp_vcs_async",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(streamer_temp_vc, "TEMP_VOICE_CATEGORY_ID", 123)
+
+    category = DummyCategory(123)
+    orphan = DummyVoiceChannel(55, category=category, members=[])
+    category.voice_channels.append(orphan)
+    guild = SimpleNamespace(
+        get_channel=lambda cid: category if cid == category.id else None,
+    )
+    bot = SimpleNamespace(get_channel=lambda _cid: None, guilds=[guild])
+    cog = streamer_temp_vc.StreamerTempVCCog(bot)
+
+    await cog.on_ready()
+
+    orphan.delete.assert_awaited_once_with(
+        reason="Salon streamer temporaire orphelin"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_channel_persists_owner_mapping(
+    monkeypatch, discord_channel_types
+):
+    monkeypatch.setattr(streamer_temp_vc, "load_streamer_temp_vcs", lambda: {})
+    save_mock = AsyncMock()
+    monkeypatch.setattr(streamer_temp_vc, "save_streamer_temp_vcs_async", save_mock)
+    monkeypatch.setattr(streamer_temp_vc, "TEMP_VOICE_CATEGORY_ID", 0)
+
+    category = DummyCategory(321)
+    trigger = SimpleNamespace(category=category)
+    role = SimpleNamespace(id=streamer_temp_vc.ALLOWED_ROLE_ID)
+    default_role = SimpleNamespace(id=1)
+    created = DummyVoiceChannel(99, category=category)
+
+    guild = SimpleNamespace(
+        default_role=default_role,
+        get_role=lambda rid: role if rid == streamer_temp_vc.ALLOWED_ROLE_ID else None,
+        get_member=lambda _mid: None,
+        get_channel=lambda _cid: None,
+        create_voice_channel=AsyncMock(return_value=created),
+    )
+    member = SimpleNamespace(
+        id=7,
+        display_name="Kevin",
+        name="Kevin",
+        guild=guild,
+    )
+    bot = SimpleNamespace(user=None)
+    cog = streamer_temp_vc.StreamerTempVCCog(bot)
+
+    channel = await cog._create_channel(member, trigger)
+
+    assert channel is created
+    assert cog._channel_to_owner == {99: 7}
+    assert cog._owner_to_channel == {7: 99}
+    save_mock.assert_awaited_once_with({99: 7})
+
+
+@pytest.mark.asyncio
+async def test_delete_removes_mapping_only_after_success(
+    monkeypatch, discord_channel_types
+):
+    monkeypatch.setattr(
+        streamer_temp_vc,
+        "load_streamer_temp_vcs",
+        lambda: {99: 7},
+    )
+    save_mock = AsyncMock()
+    monkeypatch.setattr(streamer_temp_vc, "save_streamer_temp_vcs_async", save_mock)
+    monkeypatch.setattr(streamer_temp_vc, "DELETE_DELAY_SECONDS", 0)
+
+    channel = DummyVoiceChannel(99, members=[])
+    bot = SimpleNamespace(get_channel=lambda cid: channel if cid == 99 else None)
+    cog = streamer_temp_vc.StreamerTempVCCog(bot)
+
+    await cog._delete_after_delay(99)
+
+    channel.delete.assert_awaited_once_with(reason="Salon temporaire vide")
+    assert cog._channel_to_owner == {}
+    assert cog._owner_to_channel == {}
+    save_mock.assert_awaited_once_with({})
+
+
+@pytest.mark.asyncio
+async def test_delete_keeps_mapping_when_channel_reoccupied(
+    monkeypatch, discord_channel_types
+):
+    monkeypatch.setattr(
+        streamer_temp_vc,
+        "load_streamer_temp_vcs",
+        lambda: {99: 7},
+    )
+    save_mock = AsyncMock()
+    monkeypatch.setattr(streamer_temp_vc, "save_streamer_temp_vcs_async", save_mock)
+    monkeypatch.setattr(streamer_temp_vc, "DELETE_DELAY_SECONDS", 0)
+
+    channel = DummyVoiceChannel(99, members=[object()])
+    bot = SimpleNamespace(get_channel=lambda cid: channel if cid == 99 else None)
+    cog = streamer_temp_vc.StreamerTempVCCog(bot)
+
+    await cog._delete_after_delay(99)
+
+    channel.delete.assert_not_awaited()
+    assert cog._channel_to_owner == {99: 7}
+    assert cog._owner_to_channel == {7: 99}
+    save_mock.assert_not_awaited()

--- a/tests/test_streamer_temp_vc_persistence.py
+++ b/tests/test_streamer_temp_vc_persistence.py
@@ -1,9 +1,14 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 import pytest
 
 import cogs.streamer_temp_vc as streamer_temp_vc
+
+
+class DummySnowflake:
+    def __init__(self, snowflake_id: int) -> None:
+        self.id = snowflake_id
 
 
 class DummyVoiceChannel:
@@ -94,11 +99,12 @@ async def test_create_channel_persists_owner_mapping(
     save_mock = AsyncMock()
     monkeypatch.setattr(streamer_temp_vc, "save_streamer_temp_vcs_async", save_mock)
     monkeypatch.setattr(streamer_temp_vc, "TEMP_VOICE_CATEGORY_ID", 0)
+    monkeypatch.setattr(streamer_temp_vc, "TRIGGER_CHANNEL_ID", 0)
 
     category = DummyCategory(321)
     trigger = SimpleNamespace(category=category)
-    role = SimpleNamespace(id=streamer_temp_vc.ALLOWED_ROLE_ID)
-    default_role = SimpleNamespace(id=1)
+    role = DummySnowflake(streamer_temp_vc.ALLOWED_ROLE_ID)
+    default_role = DummySnowflake(1)
     created = DummyVoiceChannel(99, category=category)
 
     guild = SimpleNamespace(


### PR DESCRIPTION
## Problème
Le bot possède deux portes d'entrée pour les salons vocaux temporaires streamer :
- `cogs/temp_vc.py`, via le lobby vocal, déjà persisté ;
- `cogs/streamer_temp_vc.py`, via le bouton, dont les mappings propriétaire ↔ salon n'existaient qu'en mémoire.

Après un redémarrage, les salons créés par le bouton pouvaient donc rester orphelins, ne plus être reconnus par le cog et permettre la création d'un doublon.

## Correction
- ajout d'un mapping persistant `channel_id -> owner_id` dans `storage/temp_vc_store.py` ;
- restauration de ce mapping au démarrage de `StreamerTempVCCog` ;
- réconciliation au `on_ready` : entrées disparues supprimées du stockage et salons `🔊・...` vides/non suivis nettoyés dans la catégorie streamer ;
- persistance à chaque création et suppression ;
- adoption best-effort d'un ancien salon non persisté lorsque son propriétaire y est encore connecté ;
- le mapping n'est plus supprimé si la suppression différée est annulée parce que le salon s'est repeuplé, ni si la suppression Discord échoue ;
- les tâches de suppression sont annulées lors du déchargement du cog.

## Portée
Le système principal `cogs/temp_vc.py` n'est pas modifié. Les deux modes de création restent disponibles ; seul le mode bouton gagne une persistance et une réconciliation compatibles avec les redémarrages.

## Tests ajoutés
`tests/test_streamer_temp_vc_persistence.py` couvre :
- nettoyage d'un mapping persistant dont le salon a disparu ;
- suppression d'un salon streamer vide orphelin au démarrage ;
- persistance du mapping à la création ;
- retrait/persistance du mapping après suppression réussie ;
- conservation du mapping si le salon s'est repeuplé avant la suppression différée.

## Validation
La branche part du `main` après la PR #487. La suite pytest complète ne peut pas être exécutée dans ce runtime faute de checkout GitHub exécutable ; la PR reste en brouillon jusqu'à validation.