### PR TITLE
fix: serialize temporary voice persistence writes

### DIFF
--- a/storage/temp_vc_store.py
+++ b/storage/temp_vc_store.py
@@ -57,11 +57,11 @@ def load_streamer_temp_vcs() -> Dict[int, int]:
 async def save_temp_vc_ids_async(
     ids: Iterable[int], max_retries: int = 3
 ) -> None:
-    """Sauvegarde asynchrone avec retries des IDs de salons temporaires."""
+    """Sauvegarde asynchrone sérialisée avec retries des IDs temporaires."""
     payload = sorted(set(int(i) for i in ids))
     for attempt in range(max_retries):
         try:
-            await asyncio.to_thread(atomic_write_json, DATA_FILE, payload)
+            await atomic_write_json_async(DATA_FILE, payload)
             return
         except Exception as e:
             logging.error(
@@ -78,11 +78,11 @@ async def save_temp_vc_ids_async(
 async def save_last_names_cache(
     cache: Dict[int, str], max_retries: int = 3
 ) -> None:
-    """Sauvegarde asynchrone avec retries du cache des derniers noms."""
+    """Sauvegarde asynchrone sérialisée avec retries du cache des noms."""
     payload = {str(k): v for k, v in cache.items()}
     for attempt in range(max_retries):
         try:
-            await asyncio.to_thread(atomic_write_json, LAST_NAMES_FILE, payload)
+            await atomic_write_json_async(LAST_NAMES_FILE, payload)
             return
         except Exception as e:
             logging.error(

--- a/tests/test_temp_vc_store_concurrency.py
+++ b/tests/test_temp_vc_store_concurrency.py
@@ -1,0 +1,73 @@
+import asyncio
+import json
+import threading
+import time
+
+import pytest
+
+import storage.temp_vc_store as temp_vc_store
+import utils.persistence as persistence
+
+
+def _reset_async_write_lock(monkeypatch) -> None:
+    monkeypatch.setattr(persistence, "_write_lock", None)
+    monkeypatch.setattr(persistence, "_write_lock_loop", None)
+
+
+@pytest.mark.asyncio
+async def test_temp_vc_ids_newer_snapshot_wins(monkeypatch, tmp_path):
+    _reset_async_write_lock(monkeypatch)
+    path = tmp_path / "temp_vc_ids.json"
+    monkeypatch.setattr(temp_vc_store, "DATA_FILE", path)
+
+    original_write = persistence.atomic_write_json
+    first_started = threading.Event()
+
+    def controlled_write(dest, data):
+        if data == [1]:
+            first_started.set()
+            time.sleep(0.05)
+        original_write(dest, data)
+
+    monkeypatch.setattr(persistence, "atomic_write_json", controlled_write)
+
+    older = asyncio.create_task(temp_vc_store.save_temp_vc_ids_async({1}))
+    assert await asyncio.to_thread(first_started.wait, 1.0)
+    newer = asyncio.create_task(temp_vc_store.save_temp_vc_ids_async({1, 2}))
+
+    await asyncio.gather(older, newer)
+
+    assert json.loads(path.read_text(encoding="utf-8")) == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_temp_vc_names_newer_snapshot_wins(monkeypatch, tmp_path):
+    _reset_async_write_lock(monkeypatch)
+    path = tmp_path / "temp_vc_last_names.json"
+    monkeypatch.setattr(temp_vc_store, "LAST_NAMES_FILE", path)
+
+    original_write = persistence.atomic_write_json
+    first_started = threading.Event()
+
+    def controlled_write(dest, data):
+        if data == {"1": "ancien"}:
+            first_started.set()
+            time.sleep(0.05)
+        original_write(dest, data)
+
+    monkeypatch.setattr(persistence, "atomic_write_json", controlled_write)
+
+    older = asyncio.create_task(
+        temp_vc_store.save_last_names_cache({1: "ancien"})
+    )
+    assert await asyncio.to_thread(first_started.wait, 1.0)
+    newer = asyncio.create_task(
+        temp_vc_store.save_last_names_cache({1: "nouveau", 2: "actif"})
+    )
+
+    await asyncio.gather(older, newer)
+
+    assert json.loads(path.read_text(encoding="utf-8")) == {
+        "1": "nouveau",
+        "2": "actif",
+    }


### PR DESCRIPTION
## Problème
`save_temp_vc_ids_async()` et `save_last_names_cache()` lançaient directement leurs écritures via `asyncio.to_thread(atomic_write_json, ...)`. Deux snapshots concurrents pouvaient donc s'écrire en parallèle et terminer dans l'ordre inverse : un ancien état lent pouvait finir après un état plus récent et l'écraser.

Le mapping streamer ajouté dans la PR #488 utilisait déjà `atomic_write_json_async()` et n'était pas concerné.

## Correction
- `save_temp_vc_ids_async()` passe désormais par `atomic_write_json_async()` ;
- `save_last_names_cache()` passe désormais par la même primitive ;
- les retries et backoffs existants sont conservés ;
- aucune logique de création, renommage ou suppression des salons n'est modifiée.

## Tests de régression
`tests/test_temp_vc_store_concurrency.py` force volontairement une ancienne sauvegarde à être lente puis démarre un snapshot plus récent. Il vérifie pour les deux fichiers que le snapshot final reste le plus récent :
- `temp_vc_ids.json` ;
- `temp_vc_last_names.json`.

Ces scénarios auraient permis à l'ancien snapshot de terminer en dernier avec les `to_thread()` indépendants.

## Portée
2 fichiers seulement. Dans `storage/temp_vc_store.py`, seulement 4 lignes fonctionnelles sont remplacées pour utiliser la primitive sérialisée déjà existante dans `utils.persistence`.

## Validation
La branche part du `main` après la PR #488. La suite pytest complète ne peut pas être exécutée dans ce runtime faute de checkout GitHub exécutable ; la PR reste en brouillon jusqu'à validation.