### PR TITLE
fix: honor JSON storage defaults

### DIFF
--- a/tests/test_storage_load_json_default.py
+++ b/tests/test_storage_load_json_default.py
@@ -1,0 +1,53 @@
+import json
+
+from utils.persistence import read_json_safe
+from utils.storage import load_json
+
+
+def test_load_json_returns_list_default_when_file_is_missing(tmp_path):
+    path = tmp_path / "missing.json"
+
+    result = load_json(path, [])
+
+    assert result == []
+    assert isinstance(result, list)
+
+
+def test_load_json_returns_default_when_primary_and_backup_are_corrupt(tmp_path):
+    path = tmp_path / "corrupt.json"
+    path.write_text("{not-json", encoding="utf-8")
+    path.with_suffix(".json.bak").write_text("[also-not-json", encoding="utf-8")
+    default = ["fallback"]
+
+    result = load_json(path, default)
+
+    assert result == ["fallback"]
+
+
+def test_load_json_uses_valid_backup_before_default(tmp_path):
+    path = tmp_path / "recover.json"
+    path.write_text("{not-json", encoding="utf-8")
+    path.with_suffix(".json.bak").write_text(
+        json.dumps(["from-backup"]), encoding="utf-8"
+    )
+
+    result = load_json(path, ["fallback"])
+
+    assert result == ["from-backup"]
+
+
+def test_load_json_preserves_valid_empty_dict_instead_of_default(tmp_path):
+    path = tmp_path / "empty-dict.json"
+    path.write_text("{}", encoding="utf-8")
+
+    result = load_json(path, [])
+
+    assert result == {}
+
+
+def test_read_json_safe_keeps_historical_empty_dict_fallback(tmp_path):
+    path = tmp_path / "missing.json"
+
+    result = read_json_safe(path)
+
+    assert result == {}

--- a/utils/persistence.py
+++ b/utils/persistence.py
@@ -16,6 +16,7 @@ __all__ = [
 
 _write_lock: asyncio.Lock | None = None
 _write_lock_loop: asyncio.AbstractEventLoop | None = None
+_DEFAULT_JSON_FALLBACK = object()
 
 
 def ensure_dir(path: str | os.PathLike[str]) -> None:
@@ -23,12 +24,16 @@ def ensure_dir(path: str | os.PathLike[str]) -> None:
     Path(path).mkdir(parents=True, exist_ok=True)
 
 
-def read_json_safe(path: str | os.PathLike[str]) -> dict:
-    """Read JSON data from ``path``.
+def read_json_safe(
+    path: str | os.PathLike[str], default: Any = _DEFAULT_JSON_FALLBACK
+) -> Any:
+    """Read JSON data from ``path`` with backup fallback.
 
-    If the file is missing or corrupted, attempt to read from ``path`` with
-    ``.bak`` appended. Returns an empty dict on failure.
+    If the primary file is missing or corrupted, ``path.bak`` is attempted.
+    When neither file can be read, return ``default`` when explicitly
+    provided; otherwise preserve the historical empty-dict fallback.
     """
+    fallback = {} if default is _DEFAULT_JSON_FALLBACK else default
     p = Path(path)
     try:
         return json.loads(p.read_text(encoding="utf-8"))
@@ -44,13 +49,13 @@ def read_json_safe(path: str | os.PathLike[str]) -> dict:
         return json.loads(bak.read_text(encoding="utf-8"))
     except FileNotFoundError:
         logging.warning("Backup file %s not found", bak)
-        return {}
+        return fallback
     except json.JSONDecodeError:
         logging.warning("Backup file %s is corrupted", bak)
-        return {}
+        return fallback
     except OSError as e:
         logging.warning("Error reading backup %s: %s", bak, e)
-        return {}
+        return fallback
 
 
 def atomic_write_json(path: str | os.PathLike[str], data: Any) -> None:
@@ -135,4 +140,3 @@ async def schedule_checkpoint(
                 _checkpoint_task = None
 
         _checkpoint_task = asyncio.create_task(_run())
-

--- a/utils/storage.py
+++ b/utils/storage.py
@@ -8,10 +8,9 @@ from utils.persistence import ensure_dir, read_json_safe, atomic_write_json_asyn
 
 
 def load_json(path: Path, default: Any) -> Any:
-    """Load JSON data from ``path`` or return ``default`` if missing."""
+    """Load JSON data from ``path`` or return ``default`` if unreadable."""
     ensure_dir(path.parent)
-    data = read_json_safe(path)
-    return data if data is not None else default
+    return read_json_safe(path, default=default)
 
 
 async def save_json(path: Path, data: Any) -> None:


### PR DESCRIPTION
## Problème
`utils.storage.load_json(path, default)` utilisait `read_json_safe()`, mais ce dernier renvoyait toujours `{}` lorsque le fichier principal et son backup étaient absents ou illisibles. Le test `data is not None` dans `load_json()` était donc toujours vrai.

Conséquence : un appel comme `load_json(path, [])` pouvait renvoyer `{}` au lieu de `[]`, avec un type inattendu pour les appelants.

## Correction
- `read_json_safe()` accepte désormais un fallback optionnel ;
- sans fallback explicite, son comportement historique reste inchangé : `{}` en cas d'échec ;
- `load_json()` transmet son `default` à `read_json_safe()` ;
- un JSON valide `{}` reste bien `{}` et n'est pas remplacé par le fallback ;
- un backup valide continue d'être prioritaire sur le fallback.

## Tests
`tests/test_storage_load_json_default.py` couvre :
- fichier absent avec `default=[]` ;
- fichier principal et backup corrompus ;
- backup valide ;
- dictionnaire vide valide avec un fallback de type liste ;
- compatibilité historique de `read_json_safe()` sans fallback explicite.

## Portée
3 fichiers uniquement : `utils/persistence.py`, `utils/storage.py` et le nouveau test. Aucun format JSON existant ni appelant métier n'est modifié.

## Validation
La branche part du `main` après la PR #489. La suite pytest complète ne peut pas être exécutée dans ce runtime faute de checkout GitHub exécutable ; la PR reste en brouillon jusqu'à validation.