### PR TITLE
fix: schedule critical log alerts safely

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,13 +22,49 @@ class DiscordCriticalHandler(logging.Handler):
         self.bot = bot
         self.channel_id = channel_id
 
+    def _get_running_loop(self) -> asyncio.AbstractEventLoop | None:
+        loop = getattr(self.bot, "loop", None)
+        if not isinstance(loop, asyncio.AbstractEventLoop):
+            return None
+        if loop.is_closed() or not loop.is_running():
+            return None
+        return loop
+
     async def _send(self, message: str) -> None:
         channel = self.bot.get_channel(self.channel_id)
         if channel:
             await channel.send(f"```{message}```")
 
+    @staticmethod
+    def _consume_send_result(task: asyncio.Task[None]) -> None:
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            # A logging handler must never surface delivery failures back into
+            # the application or create "Task exception was never retrieved".
+            pass
+
+    def _schedule_send(self, message: str) -> None:
+        loop = self._get_running_loop()
+        if loop is None:
+            return
+        task = loop.create_task(self._send(message))
+        task.add_done_callback(self._consume_send_result)
+
     def emit(self, record: logging.LogRecord) -> None:
-        asyncio.create_task(self._send(self.format(record)))
+        try:
+            loop = self._get_running_loop()
+            if loop is None:
+                return
+            message = self.format(record)
+            loop.call_soon_threadsafe(self._schedule_send, message)
+        except RuntimeError:
+            # The Discord loop can stop between the state check and scheduling.
+            return
+        except Exception:
+            self.handleError(record)
 
 
 def main() -> None:

--- a/tests/test_critical_log_handler.py
+++ b/tests/test_critical_log_handler.py
@@ -1,0 +1,79 @@
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from main import DiscordCriticalHandler
+
+
+def _record(message: str = "boom") -> logging.LogRecord:
+    return logging.LogRecord(
+        name="test.critical",
+        level=logging.CRITICAL,
+        pathname=__file__,
+        lineno=1,
+        msg=message,
+        args=(),
+        exc_info=None,
+    )
+
+
+def test_emit_without_running_bot_loop_is_safe():
+    bot = SimpleNamespace(loop=None, get_channel=lambda _channel_id: None)
+    handler = DiscordCriticalHandler(bot, 123)
+
+    handler.emit(_record())
+
+
+@pytest.mark.asyncio
+async def test_emit_from_worker_thread_schedules_on_bot_loop():
+    loop = asyncio.get_running_loop()
+    sent = asyncio.Event()
+    messages: list[str] = []
+
+    class Channel:
+        async def send(self, message: str) -> None:
+            messages.append(message)
+            sent.set()
+
+    channel = Channel()
+    bot = SimpleNamespace(
+        loop=loop,
+        get_channel=lambda channel_id: channel if channel_id == 123 else None,
+    )
+    handler = DiscordCriticalHandler(bot, 123)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    await asyncio.to_thread(handler.emit, _record("critical from thread"))
+    await asyncio.wait_for(sent.wait(), timeout=1)
+
+    assert messages == ["```critical from thread```"]
+
+
+@pytest.mark.asyncio
+async def test_send_failure_is_consumed_without_loop_error():
+    loop = asyncio.get_running_loop()
+    attempted = asyncio.Event()
+    loop_errors: list[dict] = []
+    previous_handler = loop.get_exception_handler()
+
+    class FailingChannel:
+        async def send(self, _message: str) -> None:
+            attempted.set()
+            raise RuntimeError("discord unavailable")
+
+    channel = FailingChannel()
+    bot = SimpleNamespace(loop=loop, get_channel=lambda _channel_id: channel)
+    handler = DiscordCriticalHandler(bot, 123)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    loop.set_exception_handler(lambda _loop, context: loop_errors.append(context))
+    try:
+        await asyncio.to_thread(handler.emit, _record("delivery failure"))
+        await asyncio.wait_for(attempted.wait(), timeout=1)
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(previous_handler)
+
+    assert loop_errors == []


### PR DESCRIPTION
## Problème
`DiscordCriticalHandler.emit()` appelait directement `asyncio.create_task()`. Un `logging.Handler` peut pourtant être invoqué avant le démarrage complet du bot ou depuis un autre thread. Dans ces cas, il n'existe pas forcément de boucle asyncio active dans le thread courant, ce qui peut lever `RuntimeError: no running event loop` au moment même où le bot essaie de journaliser une erreur critique.

## Correction
- détection explicite de la boucle Discord réellement active ;
- aucun scheduling tant que la boucle n'est pas disponible, n'est pas démarrée ou est déjà fermée ;
- passage depuis le thread de logging vers la boucle Discord via `loop.call_soon_threadsafe()` ;
- création de la tâche d'envoi uniquement sur cette boucle ;
- récupération du résultat de la tâche afin d'éviter les messages `Task exception was never retrieved` si Discord refuse l'envoi ;
- la fermeture de la boucle entre le contrôle et le scheduling est traitée sans propager d'exception au logging.

## Tests
`tests/test_critical_log_handler.py` couvre :
- émission sans boucle Discord active : aucun crash ;
- émission depuis un thread de travail : l'envoi est correctement replanifié sur la boucle du bot ;
- échec de l'envoi Discord : aucune erreur asyncio non récupérée.

## Portée
2 fichiers uniquement : `main.py` et le nouveau test. Le token, les intents, la construction de `RefugeBot`, la configuration du canal critique et `bot.run()` ne changent pas.

## Validation
La branche part du `main` après la PR #490. La suite pytest complète ne peut pas être exécutée dans ce runtime faute de checkout GitHub exécutable ; la PR reste en brouillon jusqu'à validation.