### PR TITLE
fix: rank casino performance instead of global XP

### DIFF
--- a/cogs/pari_xp.py
+++ b/cogs/pari_xp.py
@@ -136,6 +136,7 @@ class PariXPCog(commands.Cog):
         self.state.setdefault("is_open", False)
         self.state.setdefault("total_bets", 0)
         self.state.setdefault("total_winnings", 0)
+        self.state.setdefault("players", {})
         self.is_open: bool = bool(self.state.get("is_open"))
         self._message_id: Optional[int] = self.state.get("message_id")
         self._last_announced_state: Optional[bool] = None
@@ -253,6 +254,22 @@ class PariXPCog(commands.Cog):
             self.state["message_id"] = sent.id
             await self._save_state()
 
+    def _record_player_result(self, user_id: int, bet_amount: int, payout: int) -> None:
+        players = self.state.setdefault("players", {})
+        if not isinstance(players, dict):
+            players = {}
+            self.state["players"] = players
+
+        user_key = str(user_id)
+        stats = players.get(user_key)
+        if not isinstance(stats, dict):
+            stats = {}
+            players[user_key] = stats
+
+        stats["bets"] = int(stats.get("bets", 0)) + 1
+        stats["wagered"] = int(stats.get("wagered", 0)) + bet_amount
+        stats["winnings"] = int(stats.get("winnings", 0)) + payout
+
     # ── Betting logic ──
     async def _handle_bet(
         self,
@@ -307,11 +324,13 @@ class PariXPCog(commands.Cog):
             else:
                 win = roll < 0.03 + 0.45
                 multiplier = 2
+
+            payout = amount * multiplier if win else 0
             if win:
                 try:
                     await award_xp(
                         interaction.user.id,
-                        amount * multiplier,
+                        payout,
                         guild_id=interaction.guild_id,
                         source="pari_xp",
                     )
@@ -319,11 +338,11 @@ class PariXPCog(commands.Cog):
                     logger.exception("[PariXP] credit failed: %s", e)
                     await safe_respond(interaction, "❌ Erreur interne.", ephemeral=True)
                     return
-                msg = f"🎉 Gagné ! Tu remportes {amount * multiplier} XP."
-                self.state["total_winnings"] = self.state.get("total_winnings", 0) + amount * multiplier
+                msg = f"🎉 Gagné ! Tu remportes {payout} XP."
+                self.state["total_winnings"] = self.state.get("total_winnings", 0) + payout
                 self.state["last_winner"] = {
                     "user_id": interaction.user.id,
-                    "amount": amount * multiplier,
+                    "amount": payout,
                     "timestamp": datetime.now(self.tz).isoformat(),
                 }
                 if PARI_XP_ROLE_ID and interaction.guild:
@@ -341,6 +360,7 @@ class PariXPCog(commands.Cog):
             else:
                 outcome_line = "🎯 Pas de zéro vert cette fois."
             self.state["total_bets"] = self.state.get("total_bets", 0) + amount
+            self._record_player_result(interaction.user.id, amount, payout)
             await self._save_state()
             result_embed = discord.Embed(
                 title="🎰 Résultat",
@@ -355,40 +375,77 @@ class PariXPCog(commands.Cog):
 
     @app_commands.command(
         name="top_casino",
-        description="Afficher le top 10 des joueurs XP du casino",
+        description="Afficher le top 10 des performances au casino",
     )
     async def top_casino(self, interaction: discord.Interaction) -> None:
-        data = xp_store.read_json()
-        if not data:
+        players = self.state.get("players", {})
+        if not isinstance(players, dict):
+            players = {}
+
+        leaderboard = []
+        for user_id, payload in players.items():
+            if not isinstance(payload, dict):
+                continue
+            try:
+                bets = int(payload.get("bets", 0))
+                wagered = int(payload.get("wagered", 0))
+                winnings = int(payload.get("winnings", 0))
+            except (TypeError, ValueError):
+                continue
+            if bets <= 0:
+                continue
+            net = winnings - wagered
+            leaderboard.append((str(user_id), net, winnings, wagered, bets))
+
+        if not leaderboard:
             embed = discord.Embed(
                 title="🏆 Top Casino",
-                description="Aucune donnée XP disponible pour le moment.",
+                description="Aucune activité casino enregistrée pour le moment.",
             )
             await interaction.response.send_message(embed=embed, ephemeral=True)
             return
-        leaderboard = sorted(
-            data.items(),
-            key=lambda item: item[1].get("xp", 0) if isinstance(item[1], dict) else item[1],
+
+        leaderboard.sort(
+            key=lambda item: (item[1], item[2], -item[3]),
             reverse=True,
-        )[:10]
+        )
         lines = []
-        for idx, (user_id, payload) in enumerate(leaderboard, start=1):
-            xp_amount = payload.get("xp", 0) if isinstance(payload, dict) else payload
+        for idx, (user_id, net, winnings, wagered, bets) in enumerate(
+            leaderboard[:10],
+            start=1,
+        ):
             member = None
-            if interaction.guild:
-                member = interaction.guild.get_member(int(user_id))
+            numeric_user_id: Optional[int] = None
+            try:
+                numeric_user_id = int(user_id)
+            except (TypeError, ValueError):
+                pass
+
+            if interaction.guild and numeric_user_id is not None:
+                member = interaction.guild.get_member(numeric_user_id)
             if member:
                 display_name = member.display_name
-            else:
+            elif numeric_user_id is not None:
                 try:
-                    user = await self.bot.fetch_user(int(user_id))
+                    user = await self.bot.fetch_user(numeric_user_id)
                     display_name = user.display_name
                 except discord.HTTPException:
                     display_name = f"Utilisateur {user_id}"
-            lines.append(f"**#{idx}** {display_name} — {xp_amount} XP")
+            else:
+                display_name = f"Utilisateur {user_id}"
+
+            bet_label = "pari" if bets == 1 else "paris"
+            lines.append(
+                f"**#{idx}** {display_name} — **{net:+d} XP net** · "
+                f"{bets} {bet_label} · {wagered} misés · {winnings} gagnés"
+            )
+
         embed = discord.Embed(
             title="🏆 Top Casino",
-            description="\n".join(lines),
+            description=(
+                "Classement par résultat net (gains - mises).\n\n"
+                + "\n".join(lines)
+            ),
         )
         await interaction.response.send_message(embed=embed)
 

--- a/tests/test_pari_xp_leaderboard.py
+++ b/tests/test_pari_xp_leaderboard.py
@@ -1,0 +1,143 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import cogs.pari_xp as pari_xp
+
+
+def _make_cog(state: dict):
+    cog = object.__new__(pari_xp.PariXPCog)
+    cog.bot = SimpleNamespace(fetch_user=AsyncMock())
+    cog.tz = pari_xp.PARIS_TZ
+    cog.state = state
+    cog.is_open = True
+    cog._message_id = None
+    cog._last_announced_state = None
+    return cog
+
+
+@pytest.mark.asyncio
+async def test_completed_bets_update_per_player_casino_stats(monkeypatch):
+    cog = _make_cog({"is_open": True, "total_bets": 0, "total_winnings": 0})
+    cog._save_state = AsyncMock()
+
+    monkeypatch.setattr(
+        pari_xp.xp_store,
+        "get_user_data",
+        AsyncMock(return_value={"xp": 100, "level": 1}),
+    )
+    monkeypatch.setattr(pari_xp.xp_adapter, "add_xp", AsyncMock())
+    monkeypatch.setattr(
+        pari_xp,
+        "award_xp",
+        AsyncMock(return_value=(1, 1, 80, 120)),
+    )
+    monkeypatch.setattr(pari_xp.random, "random", lambda: 0.10)
+    monkeypatch.setattr(pari_xp.asyncio, "sleep", AsyncMock())
+
+    result_message = SimpleNamespace(edit=AsyncMock())
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        guild_id=123,
+        guild=None,
+        response=SimpleNamespace(send_message=AsyncMock()),
+        original_response=AsyncMock(return_value=result_message),
+    )
+
+    await pari_xp.PariXPCog._handle_bet(cog, interaction, "red", 20)
+
+    assert cog.state["players"]["42"] == {
+        "bets": 1,
+        "wagered": 20,
+        "winnings": 40,
+    }
+
+
+@pytest.mark.asyncio
+async def test_losing_bet_records_stake_without_winnings(monkeypatch):
+    cog = _make_cog({"is_open": True, "total_bets": 0, "total_winnings": 0})
+    cog._save_state = AsyncMock()
+
+    monkeypatch.setattr(
+        pari_xp.xp_store,
+        "get_user_data",
+        AsyncMock(return_value={"xp": 100, "level": 1}),
+    )
+    monkeypatch.setattr(pari_xp.xp_adapter, "add_xp", AsyncMock())
+    monkeypatch.setattr(pari_xp, "award_xp", AsyncMock())
+    monkeypatch.setattr(pari_xp.random, "random", lambda: 0.90)
+    monkeypatch.setattr(pari_xp.asyncio, "sleep", AsyncMock())
+
+    result_message = SimpleNamespace(edit=AsyncMock())
+    interaction = SimpleNamespace(
+        user=SimpleNamespace(id=42),
+        guild_id=123,
+        guild=None,
+        response=SimpleNamespace(send_message=AsyncMock()),
+        original_response=AsyncMock(return_value=result_message),
+    )
+
+    await pari_xp.PariXPCog._handle_bet(cog, interaction, "black", 20)
+
+    assert cog.state["players"]["42"] == {
+        "bets": 1,
+        "wagered": 20,
+        "winnings": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_top_casino_ranks_net_casino_result_not_global_xp(monkeypatch):
+    cog = _make_cog(
+        {
+            "players": {
+                "1": {"bets": 2, "wagered": 100, "winnings": 120},
+                "2": {"bets": 1, "wagered": 10, "winnings": 100},
+                "3": {"bets": 4, "wagered": 500, "winnings": 550},
+            }
+        }
+    )
+    monkeypatch.setattr(
+        pari_xp.xp_store,
+        "read_json",
+        Mock(side_effect=AssertionError("global XP must not drive top_casino")),
+    )
+
+    names = {1: "Alice", 2: "Bob", 3: "Charlie"}
+    guild = SimpleNamespace(
+        get_member=lambda uid: SimpleNamespace(display_name=names[uid]),
+    )
+    interaction = SimpleNamespace(
+        guild=guild,
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await pari_xp.PariXPCog.top_casino.callback(cog, interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    description = embed.description or ""
+    assert description.index("Bob") < description.index("Charlie") < description.index("Alice")
+    assert "**+90 XP net**" in description
+    assert "Classement par résultat net" in description
+
+
+@pytest.mark.asyncio
+async def test_top_casino_does_not_fallback_to_global_xp(monkeypatch):
+    cog = _make_cog({"players": {}})
+    monkeypatch.setattr(
+        pari_xp.xp_store,
+        "read_json",
+        Mock(side_effect=AssertionError("global XP must not be read")),
+    )
+    interaction = SimpleNamespace(
+        guild=None,
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+    await pari_xp.PariXPCog.top_casino.callback(cog, interaction)
+
+    embed = interaction.response.send_message.await_args.kwargs["embed"]
+    assert embed.title == "🏆 Top Casino"
+    assert embed.description == "Aucune activité casino enregistrée pour le moment."
+    assert interaction.response.send_message.await_args.kwargs["ephemeral"] is True


### PR DESCRIPTION
## Problème
`/top_casino` lisait `xp_store.read_json()` puis triait les joueurs par solde XP global. Le classement pouvait donc être dominé par des membres n'ayant presque pas joué au casino, simplement parce qu'ils avaient beaucoup d'XP ailleurs dans le bot.

## Correction
- ajout d'un suivi par joueur dans `pari_xp_state.json` : nombre de paris, XP misés et gains bruts ;
- chaque pari terminé met à jour ces statistiques en même temps que les totaux casino existants ;
- `/top_casino` ne lit plus le solde XP global ;
- classement sur le résultat net réel du casino : `gains - mises` ;
- affichage du net, du nombre de paris, des mises et des gains ;
- si aucune statistique joueur n'existe encore, la commande indique qu'aucune activité casino n'est enregistrée.

## Compatibilité / historique
Aucune migration artificielle n'est faite depuis les soldes XP globaux : les anciennes données ne permettent pas de reconstruire honnêtement les performances casino par joueur. Le classement commence donc avec les paris enregistrés après ce correctif, tandis que les totaux globaux déjà présents dans `pari_xp_state.json` restent conservés.

## Tests
`tests/test_pari_xp_leaderboard.py` couvre :
- enregistrement d'un pari gagnant ;
- enregistrement d'un pari perdant ;
- classement par résultat net ;
- preuve que `/top_casino` ne lit plus `xp_store.read_json()` ;
- état vide sans fallback vers le classement XP global.

## Portée
2 fichiers uniquement : `cogs/pari_xp.py` et le nouveau test. Les probabilités, multiplicateurs, limites de mise, débit atomique XP et horaires du casino ne changent pas.

## Validation
La branche part du `main` après la PR #491. La suite pytest complète ne peut pas être exécutée dans ce runtime faute de checkout GitHub exécutable ; la PR reste en brouillon jusqu'à validation.