### PR TITLE
fix: keep XP leaderboard current before flush

### DIFF
--- a/storage/xp_store.py
+++ b/storage/xp_store.py
@@ -409,16 +409,28 @@ class XPStore:
         return user_data
 
     async def get_top_users(self, limit: int = 10) -> List[Tuple[str, XPUserData]]:
-        """Récupère le top des utilisateurs par XP."""
-        all_data = read_json_safe(self.path)
-        
-        # Trier par XP
+        """Récupère le top des utilisateurs depuis l'état XP le plus récent."""
+        disk_data = await asyncio.to_thread(read_json_safe, self.path)
+        all_data: Dict[str, XPUserData] = {}
+        if isinstance(disk_data, dict):
+            all_data = {
+                str(uid): dict(payload)
+                for uid, payload in disk_data.items()
+                if isinstance(payload, dict)
+            }
+
+        # Les mutations immédiates vivent d'abord dans ``self.data`` et ne sont
+        # persistées qu'après un flush différé. Elles doivent donc écraser le
+        # snapshot disque pour éviter un classement temporairement obsolète.
+        async with self.lock:
+            for uid, payload in self.data.items():
+                all_data[uid] = dict(payload)
+
         sorted_users = sorted(
             all_data.items(),
-            key=lambda x: x[1].get("xp", 0),
-            reverse=True
+            key=lambda x: int(x[1].get("xp", 0)),
+            reverse=True,
         )[:limit]
-        
         return sorted_users
 
     def read_json(self) -> Dict[str, XPUserData]:

--- a/tests/test_xp_top_users_fresh.py
+++ b/tests/test_xp_top_users_fresh.py
@@ -1,0 +1,59 @@
+import pytest
+
+from storage.xp_store import XPStore
+from utils.persistence import atomic_write_json
+
+
+@pytest.mark.asyncio
+async def test_get_top_users_prefers_fresh_memory_over_stale_disk(tmp_path):
+    path = tmp_path / "xp.json"
+    atomic_write_json(
+        path,
+        {
+            "1": {"xp": 100, "level": 1},
+            "2": {"xp": 200, "level": 1},
+        },
+    )
+    store = XPStore(path=str(path))
+    store.data["1"] = {"xp": 300, "level": 1}
+
+    leaderboard = await store.get_top_users(limit=2)
+
+    assert [(uid, payload["xp"]) for uid, payload in leaderboard] == [
+        ("1", 300),
+        ("2", 200),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_top_users_keeps_disk_only_users_when_memory_is_partial(tmp_path):
+    path = tmp_path / "xp.json"
+    atomic_write_json(
+        path,
+        {
+            "10": {"xp": 500, "level": 2},
+            "20": {"xp": 50, "level": 0},
+        },
+    )
+    store = XPStore(path=str(path))
+    store.data["30"] = {"xp": 250, "level": 1}
+
+    leaderboard = await store.get_top_users(limit=3)
+
+    assert [(uid, payload["xp"]) for uid, payload in leaderboard] == [
+        ("10", 500),
+        ("30", 250),
+        ("20", 50),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_top_users_returns_copies_not_mutable_store_entries(tmp_path):
+    path = tmp_path / "xp.json"
+    store = XPStore(path=str(path))
+    store.data["1"] = {"xp": 300, "level": 1}
+
+    leaderboard = await store.get_top_users(limit=1)
+    leaderboard[0][1]["xp"] = 0
+
+    assert store.data["1"]["xp"] == 300


### PR DESCRIPTION
## Problème
`XPStore.get_top_users()` relisait uniquement le fichier JSON sur disque. Or les gains/dépenses XP sont d'abord appliqués à `self.data` puis persistés avec un flush différé. Un classement demandé juste après une mutation pouvait donc afficher pendant plusieurs secondes un score obsolète.

## Correction
- lecture du snapshot disque hors de la boucle asyncio via `asyncio.to_thread()` ;
- fusion avec l'état XP actuellement chargé en mémoire ;
- l'état mémoire a priorité sur la version disque pour les mêmes utilisateurs ;
- les utilisateurs présents uniquement sur disque restent inclus, ce qui conserve le comportement utile avant chargement complet ;
- les payloads du classement sont copiés avant retour afin qu'un appelant ne puisse pas modifier `self.data` par référence.

## Tests
`tests/test_xp_top_users_fresh.py` couvre :
- un solde mémoire plus récent remplace bien un solde disque obsolète avant tout flush ;
- les utilisateurs uniquement présents sur disque restent classés ;
- modifier le résultat retourné ne modifie pas l'état interne du store.

## Portée
2 fichiers uniquement : `storage/xp_store.py` et le nouveau test. Aucun calcul de gain XP, niveau, débit, batch ou mécanisme de flush n'est modifié.

## Note audit
Le point envisagé juste avant sur le verrou global de `schedule_checkpoint()` a été abandonné après inspection : sa section critique ne contient aucun `await`, donc le risque de liaison inter-boucles n'était pas suffisamment concret pour justifier un patch.

## Validation
La branche part du `main` après la PR #495. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation.