### PR TITLE
fix: protect XP user data from external mutation

### DIFF
--- a/storage/xp_store.py
+++ b/storage/xp_store.py
@@ -419,17 +419,19 @@ class XPStore:
                 if isinstance(payload, dict)
             }
 
-        # ``self.data`` contient les mutations appliquées immédiatement mais pas
-        # forcément encore flushées. Il doit donc gagner face au snapshot disque.
+        # Les mutations immédiates vivent d'abord dans ``self.data`` et ne sont
+        # persistées qu'après un flush différé. Elles doivent donc écraser le
+        # snapshot disque pour éviter un classement temporairement obsolète.
         async with self.lock:
             for uid, payload in self.data.items():
                 all_data[uid] = dict(payload)
 
-        return sorted(
+        sorted_users = sorted(
             all_data.items(),
-            key=lambda item: item[1].get("xp", 0),
+            key=lambda x: int(x[1].get("xp", 0)),
             reverse=True,
         )[:limit]
+        return sorted_users
 
     def read_json(self) -> Dict[str, XPUserData]:
         """Lit le fichier JSON brut des XP."""

--- a/storage/xp_store.py
+++ b/storage/xp_store.py
@@ -380,7 +380,7 @@ class XPStore:
         return True
 
     async def get_user_data(self, user_id: int) -> XPUserData:
-        """Récupère les données d'un utilisateur."""
+        """Récupère une copie des données d'un utilisateur."""
         uid = str(user_id)
         
         async with self.lock:
@@ -388,7 +388,7 @@ class XPStore:
                 self.stats["cache_hits"] += 1
                 user = self.data[uid]
                 user["last_accessed"] = datetime.utcnow().isoformat()
-                return user
+                return dict(user)
             
             self.stats["cache_misses"] += 1
             
@@ -406,7 +406,7 @@ class XPStore:
             if len(self.data) > self.cache_size * 1.2:  # 20% de marge
                 asyncio.create_task(self._cleanup_cache())
         
-        return user_data
+        return dict(user_data)
 
     async def get_top_users(self, limit: int = 10) -> List[Tuple[str, XPUserData]]:
         """Récupère le top des utilisateurs depuis l'état XP le plus récent."""
@@ -419,19 +419,17 @@ class XPStore:
                 if isinstance(payload, dict)
             }
 
-        # Les mutations immédiates vivent d'abord dans ``self.data`` et ne sont
-        # persistées qu'après un flush différé. Elles doivent donc écraser le
-        # snapshot disque pour éviter un classement temporairement obsolète.
+        # ``self.data`` contient les mutations appliquées immédiatement mais pas
+        # forcément encore flushées. Il doit donc gagner face au snapshot disque.
         async with self.lock:
             for uid, payload in self.data.items():
                 all_data[uid] = dict(payload)
 
-        sorted_users = sorted(
+        return sorted(
             all_data.items(),
-            key=lambda x: int(x[1].get("xp", 0)),
+            key=lambda item: item[1].get("xp", 0),
             reverse=True,
         )[:limit]
-        return sorted_users
 
     def read_json(self) -> Dict[str, XPUserData]:
         """Lit le fichier JSON brut des XP."""

--- a/tests/test_xp_user_data_copy.py
+++ b/tests/test_xp_user_data_copy.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from storage.xp_store import XPStore
+
+
+@pytest.mark.asyncio
+async def test_get_user_data_returns_copy_for_cached_user(tmp_path: Path):
+    store = XPStore(path=str(tmp_path / "xp.json"))
+    store.data["42"] = {"xp": 125, "level": 1}
+
+    payload = await store.get_user_data(42)
+    payload["xp"] = 9999
+    payload["level"] = 99
+
+    assert store.data["42"]["xp"] == 125
+    assert store.data["42"]["level"] == 1
+
+    fresh_payload = await store.get_user_data(42)
+    assert fresh_payload["xp"] == 125
+    assert fresh_payload["level"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_user_data_returns_copy_after_disk_load(tmp_path: Path):
+    path = tmp_path / "xp.json"
+    path.write_text(
+        json.dumps({"7": {"xp": 350, "level": 1}}),
+        encoding="utf-8",
+    )
+    store = XPStore(path=str(path))
+
+    payload = await store.get_user_data(7)
+    payload["xp"] = 0
+
+    assert store.data["7"]["xp"] == 350
+    assert (await store.get_user_data(7))["xp"] == 350


### PR DESCRIPTION
## Problème
`XPStore.get_user_data()` renvoyait directement le dictionnaire stocké dans `self.data`. Un appelant pouvait donc modifier le solde XP, le niveau ou d'autres champs en mémoire sans passer par les verrous, validations, événements de niveau ni mécanismes de flush du store.

L'usage actif identifié dans `cogs/pari_xp.py` ne fait que lire le solde, donc il n'a pas besoin d'une référence mutable vers l'état interne.

## Correction
- `get_user_data()` retourne désormais une copie du payload utilisateur lors d'un cache hit ;
- le chemin de chargement depuis le disque retourne lui aussi une copie après avoir placé l'objet canonique dans `self.data` ;
- la mise à jour interne de `last_accessed` est conservée ;
- aucune API publique ni logique de calcul XP n'est modifiée.

## Tests
`tests/test_xp_user_data_copy.py` couvre :
- mutation du dictionnaire retourné pour un utilisateur déjà en mémoire sans altération de `self.data` ;
- même protection après chargement depuis le disque ;
- un second `get_user_data()` restitue toujours le solde canonique.

## Portée
2 fichiers uniquement. Dans `storage/xp_store.py`, le diff fonctionnel est limité à la docstring et aux deux retours de `get_user_data()`. Aucun changement dans les gains, débits, niveaux, batchs, classements ou flushs.

## Validation
La branche part du `main` après la PR #496. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation.