### PR TITLE
fix: avoid redundant XP maintenance flushes

### DIFF
--- a/storage/xp_store.py
+++ b/storage/xp_store.py
@@ -53,6 +53,7 @@ class XPStore:
         self._periodic_task: Optional[asyncio.Task] = None
         self._batch_updates = BatchUpdate()
         self._last_cleanup = datetime.utcnow()
+        self._last_flushed_update_count = 0
         
         # Statistiques pour monitoring
         self.stats = {
@@ -117,6 +118,10 @@ class XPStore:
                     self.cache_size,
                 )
 
+    def _has_unflushed_updates(self) -> bool:
+        """Indique si des mutations XP sont postérieures au dernier flush réussi."""
+        return self.stats["total_updates"] > self._last_flushed_update_count
+
     async def _periodic_maintenance(self) -> None:
         """Maintenance périodique: flush batch et nettoyage cache."""
         try:
@@ -132,8 +137,9 @@ class XPStore:
                     await self._cleanup_cache()
                     self._last_cleanup = now
                 
-                # Flush périodique sur disque toutes les 5 minutes
-                if self.stats["total_updates"] % 100 == 0:
+                # Filet de sécurité : n'écrire que si des mises à jour n'ont pas
+                # encore été incluses dans un flush réussi.
+                if self._has_unflushed_updates():
                     await self.flush()
                     
         except asyncio.CancelledError:
@@ -179,10 +185,16 @@ class XPStore:
     async def flush(self) -> None:
         """Écrit les données sur disque."""
         async with self.lock:
-            # Créer une copie pour l'écriture
+            # Créer une copie pour l'écriture et mémoriser le compteur exact
+            # inclus dans ce snapshot.
             data_copy = dict(self.data)
+            update_count = self.stats["total_updates"]
             
         await atomic_write_json_async(self.path, data_copy)
+        self._last_flushed_update_count = max(
+            self._last_flushed_update_count,
+            update_count,
+        )
         logger.info("XP flush: %d utilisateurs, %d updates totales", 
                    len(data_copy), self.stats["total_updates"])
 

--- a/tests/test_xp_periodic_flush.py
+++ b/tests/test_xp_periodic_flush.py
@@ -1,0 +1,81 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+import storage.xp_store as xp_store_module
+from storage.xp_store import XPStore
+
+
+def test_new_store_has_no_unflushed_updates(tmp_path):
+    store = XPStore(path=str(tmp_path / "xp.json"))
+
+    assert store.stats["total_updates"] == 0
+    assert store._last_flushed_update_count == 0
+    assert store._has_unflushed_updates() is False
+
+
+@pytest.mark.asyncio
+async def test_successful_flush_marks_only_current_snapshot_clean(monkeypatch, tmp_path):
+    store = XPStore(path=str(tmp_path / "xp.json"))
+    store.data = {"1": {"xp": 100, "level": 1}}
+    store.stats["total_updates"] = 100
+
+    write = AsyncMock()
+    monkeypatch.setattr(xp_store_module, "atomic_write_json_async", write)
+
+    assert store._has_unflushed_updates() is True
+
+    await store.flush()
+
+    write.assert_awaited_once()
+    assert store._last_flushed_update_count == 100
+    assert store._has_unflushed_updates() is False
+
+    # La maintenance ne doit plus considérer le même palier comme sale.
+    assert store._has_unflushed_updates() is False
+
+    # Une nouvelle mutation rend à nouveau l'état sale.
+    store.stats["total_updates"] = 101
+    assert store._has_unflushed_updates() is True
+
+
+@pytest.mark.asyncio
+async def test_failed_flush_keeps_updates_dirty(monkeypatch, tmp_path):
+    store = XPStore(path=str(tmp_path / "xp.json"))
+    store.data = {"1": {"xp": 100, "level": 1}}
+    store.stats["total_updates"] = 100
+
+    write = AsyncMock(side_effect=OSError("disk unavailable"))
+    monkeypatch.setattr(xp_store_module, "atomic_write_json_async", write)
+
+    with pytest.raises(OSError, match="disk unavailable"):
+        await store.flush()
+
+    assert store._last_flushed_update_count == 0
+    assert store._has_unflushed_updates() is True
+
+
+@pytest.mark.asyncio
+async def test_older_flush_cannot_move_persisted_counter_backwards(monkeypatch, tmp_path):
+    store = XPStore(path=str(tmp_path / "xp.json"))
+    store.data = {"1": {"xp": 100, "level": 1}}
+    store.stats["total_updates"] = 100
+
+    write_started = pytest.importorskip("asyncio").Event()
+    release_write = pytest.importorskip("asyncio").Event()
+
+    async def slow_write(path, data):
+        write_started.set()
+        await release_write.wait()
+
+    monkeypatch.setattr(xp_store_module, "atomic_write_json_async", slow_write)
+
+    first_flush = pytest.importorskip("asyncio").create_task(store.flush())
+    await write_started.wait()
+
+    # Simule qu'un flush plus récent a déjà persisté davantage d'updates.
+    store._last_flushed_update_count = 101
+    release_write.set()
+    await first_flush
+
+    assert store._last_flushed_update_count == 101

--- a/tests/test_xp_periodic_flush.py
+++ b/tests/test_xp_periodic_flush.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
@@ -31,9 +32,6 @@ async def test_successful_flush_marks_only_current_snapshot_clean(monkeypatch, t
     assert store._last_flushed_update_count == 100
     assert store._has_unflushed_updates() is False
 
-    # La maintenance ne doit plus considérer le même palier comme sale.
-    assert store._has_unflushed_updates() is False
-
     # Une nouvelle mutation rend à nouveau l'état sale.
     store.stats["total_updates"] = 101
     assert store._has_unflushed_updates() is True
@@ -61,8 +59,8 @@ async def test_older_flush_cannot_move_persisted_counter_backwards(monkeypatch, 
     store.data = {"1": {"xp": 100, "level": 1}}
     store.stats["total_updates"] = 100
 
-    write_started = pytest.importorskip("asyncio").Event()
-    release_write = pytest.importorskip("asyncio").Event()
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
 
     async def slow_write(path, data):
         write_started.set()
@@ -70,7 +68,7 @@ async def test_older_flush_cannot_move_persisted_counter_backwards(monkeypatch, 
 
     monkeypatch.setattr(xp_store_module, "atomic_write_json_async", slow_write)
 
-    first_flush = pytest.importorskip("asyncio").create_task(store.flush())
+    first_flush = asyncio.create_task(store.flush())
     await write_started.wait()
 
     # Simule qu'un flush plus récent a déjà persisté davantage d'updates.


### PR DESCRIPTION
## Problème
`XPStore._periodic_maintenance()` déclenchait un flush dès que `total_updates % 100 == 0`. Cette condition est vraie à `0`, puis reste vraie à `100`, `200`, etc. tant que le compteur ne change pas. Le store pouvait donc réécrire le même état sur disque à chaque passage de maintenance alors qu'aucune donnée XP nouvelle n'avait été produite.

## Correction
- ajout d'un compteur `_last_flushed_update_count` représentant le nombre exact de mises à jour incluses dans le dernier flush réussi ;
- la maintenance n'appelle désormais `flush()` que si `total_updates` est strictement supérieur à ce compteur ;
- `flush()` capture le compteur correspondant à son snapshot sous le verrou, puis ne marque ce compteur comme persisté qu'après une écriture réussie ;
- `max(...)` empêche un flush ancien qui termine plus tard de faire reculer le compteur de persistance ;
- un échec d'écriture laisse l'état marqué comme sale afin qu'un prochain flush puisse réessayer.

## Effet
Le flush différé de 5 secondes reste inchangé et persiste normalement les mutations. Si ce flush a déjà réussi, la maintenance d'une minute n'effectue plus d'écriture redondante. À `0`, `100`, `200`, etc., aucune boucle de réécriture n'est possible sans nouvelles mutations.

## Tests
`tests/test_xp_periodic_flush.py` couvre :
- un store neuf sans mise à jour n'est pas considéré comme sale ;
- un flush réussi marque uniquement le snapshot courant comme persisté ;
- une nouvelle mutation rend de nouveau l'état sale ;
- un flush échoué ne marque pas les updates comme persistées ;
- un flush plus ancien ne peut pas faire reculer le compteur de persistance.

## Portée
2 fichiers uniquement : `storage/xp_store.py` et le nouveau test. Aucun calcul de gain, débit, niveau, batch, classement ou règle métier XP n'est modifié.

## Validation
La branche part du `main` après la PR #497. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation.