### PR TITLE
fix: serialize Ticket Royal stock mutations

### DIFF
--- a/cogs/economy_ui.py
+++ b/cogs/economy_ui.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from storage.economy import (
     ECONOMY_DIR,
     SHOP_FILE,
+    get_ticket_lock,
     load_boosts,
     load_tickets,
     load_ui,
@@ -234,7 +235,11 @@ class EconomyUICog(commands.Cog):
         await self._handle_shop_purchase(interaction, item_key)
 
     async def _handle_shop_purchase(
-        self, interaction: discord.Interaction, item_key: str
+        self,
+        interaction: discord.Interaction,
+        item_key: str,
+        *,
+        _ticket_locked: bool = False,
     ) -> None:
         shop = _load_shop()
         if not shop:
@@ -247,6 +252,14 @@ class EconomyUICog(commands.Cog):
             item.get("name", "")
         ).lower():
             await interaction.response.send_message("Article inconnu.", ephemeral=True)
+            return
+        if item_key == "ticket_royal" and not _ticket_locked:
+            async with get_ticket_lock():
+                await self._handle_shop_purchase(
+                    interaction,
+                    item_key,
+                    _ticket_locked=True,
+                )
             return
         user_id = interaction.user.id
         limit = PURCHASE_LIMITS.get(item_key)

--- a/storage/economy.py
+++ b/storage/economy.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+import weakref
 from pathlib import Path
 from typing import Any, Dict
 
@@ -19,6 +21,24 @@ UI_FILE = ECONOMY_DIR / "ui.json"
 
 # Append-only transaction ledger
 transactions = TransactionStore(TRANSACTIONS_FILE)
+
+
+# Ticket stock uses read/check/mutate/write transactions from multiple modules.
+# Keep one shared lock per live event loop so purchases and consumptions cannot
+# overwrite each other while tests that create separate loops stay isolated.
+_ticket_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def get_ticket_lock() -> asyncio.Lock:
+    """Return the shared ticket transaction lock for the running event loop."""
+    loop = asyncio.get_running_loop()
+    lock = _ticket_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _ticket_locks[loop] = lock
+    return lock
 
 
 def load_boosts() -> Dict[str, Any]:

--- a/tests/test_economy_ticket_purchase_concurrency.py
+++ b/tests/test_economy_ticket_purchase_concurrency.py
@@ -1,0 +1,146 @@
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cogs.economy_ui as economy_ui
+from cogs.economy_ui import EconomyUICog
+from storage import economy
+from storage.transaction_store import TransactionStore
+import utils.economy_tickets as economy_tickets
+from utils.persistence import atomic_write_json_async
+from utils.storage import load_json
+
+
+def _setup_paths(tmp_path, monkeypatch):
+    shop_file = tmp_path / "shop.json"
+    tickets_file = tmp_path / "tickets.json"
+    transactions_file = tmp_path / "transactions.json"
+
+    shop_file.write_text(
+        json.dumps({"ticket_royal": {"name": "Ticket Royal", "price": 100}}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(economy, "SHOP_FILE", shop_file)
+    monkeypatch.setattr(economy_ui, "SHOP_FILE", shop_file)
+    monkeypatch.setattr(economy, "TICKETS_FILE", tickets_file)
+    monkeypatch.setattr(economy_tickets, "TICKETS_FILE", tickets_file)
+
+    transaction_store = TransactionStore(transactions_file)
+    monkeypatch.setattr(economy, "transactions", transaction_store)
+    monkeypatch.setattr(economy_ui, "transactions", transaction_store)
+    monkeypatch.setattr(economy_tickets, "transactions", transaction_store)
+
+    return tickets_file, transaction_store
+
+
+def _interaction(user_id: int = 1):
+    return SimpleNamespace(
+        data={"custom_id": "shop_buy:ticket_royal"},
+        user=SimpleNamespace(id=user_id, add_roles=AsyncMock()),
+        guild=None,
+        guild_id=123,
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_concurrent_ticket_purchases_share_limit_and_debit_boundary(
+    tmp_path, monkeypatch
+):
+    tickets_file, transaction_store = _setup_paths(tmp_path, monkeypatch)
+    await economy.save_tickets({"1": 2})
+
+    monkeypatch.setattr(economy_ui.xp_adapter, "get_balance", lambda _uid: 1000)
+
+    first_debit_started = asyncio.Event()
+    release_first_debit = asyncio.Event()
+    debit_calls = []
+
+    async def blocked_debit(user_id, *, amount, guild_id, source):
+        debit_calls.append((user_id, amount, guild_id, source))
+        first_debit_started.set()
+        await release_first_debit.wait()
+
+    monkeypatch.setattr(economy_ui.xp_adapter, "add_xp", blocked_debit)
+
+    cog = EconomyUICog(object())
+    first = _interaction()
+    second = _interaction()
+
+    first_task = asyncio.create_task(cog.on_interaction(first))
+    await first_debit_started.wait()
+
+    second_task = asyncio.create_task(cog.on_interaction(second))
+    await asyncio.sleep(0)
+
+    # The second purchase must still be waiting on the shared ticket lock. If it
+    # reached the debit concurrently, both purchases could charge XP at stock 2.
+    assert len(debit_calls) == 1
+
+    release_first_debit.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert load_json(tickets_file, {}) == {"1": 3}
+    assert len(debit_calls) == 1
+
+    responses = [
+        first.response.send_message.await_args.args[0],
+        second.response.send_message.await_args.args[0],
+    ]
+    assert sum("effectu" in response.lower() for response in responses) == 1
+    assert sum("stock" in response.lower() for response in responses) == 1
+
+    entries = await transaction_store.all()
+    purchases = [entry for entry in entries if entry.get("type") == "buy"]
+    assert len(purchases) == 1
+    assert purchases[0]["item"] == "ticket_royal"
+
+
+@pytest.mark.asyncio
+async def test_ticket_purchase_waits_for_concurrent_consumption(tmp_path, monkeypatch):
+    tickets_file, transaction_store = _setup_paths(tmp_path, monkeypatch)
+    await economy.save_tickets({"1": 1})
+
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+
+    async def blocked_ticket_write(path, data):
+        write_started.set()
+        await release_write.wait()
+        await atomic_write_json_async(path, data)
+
+    monkeypatch.setattr(
+        economy_tickets,
+        "atomic_write_json_async",
+        blocked_ticket_write,
+    )
+
+    monkeypatch.setattr(economy_ui.xp_adapter, "get_balance", lambda _uid: 1000)
+    debit = AsyncMock()
+    monkeypatch.setattr(economy_ui.xp_adapter, "add_xp", debit)
+
+    consume_task = asyncio.create_task(economy_tickets.consume_free_ticket(1))
+    await write_started.wait()
+
+    cog = EconomyUICog(object())
+    interaction = _interaction()
+    purchase_task = asyncio.create_task(cog.on_interaction(interaction))
+    await asyncio.sleep(0)
+
+    # Consumption still owns the same shared lock, so purchase cannot debit XP
+    # until the decrement has been durably written.
+    debit.assert_not_awaited()
+
+    release_write.set()
+    consumed, _ = await asyncio.gather(consume_task, purchase_task)
+
+    assert consumed is True
+    debit.assert_awaited_once_with(1, amount=-100, guild_id=123, source="shop")
+    assert load_json(tickets_file, {}) == {"1": 1}
+
+    entries = await transaction_store.all()
+    assert sorted(entry["type"] for entry in entries) == ["buy", "ticket_usage"]

--- a/utils/economy_tickets.py
+++ b/utils/economy_tickets.py
@@ -1,42 +1,23 @@
 from __future__ import annotations
 
-import asyncio
-import weakref
 from datetime import datetime, timezone
 from typing import Awaitable, Callable, Dict
 
-from storage.economy import TICKETS_FILE, transactions
+from storage.economy import TICKETS_FILE, get_ticket_lock, transactions
 from storage.roulette_store import RouletteStore
 from utils.storage import load_json
 from utils.persistence import atomic_write_json_async
 
 
-# ``asyncio.Lock`` instances are bound to the event loop that contends on
-# them. Keep one lock per live loop so production has a single transaction
-# boundary while tests that use separate event loops remain isolated.
-_ticket_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
-    weakref.WeakKeyDictionary()
-)
-
-
-def _get_ticket_lock() -> asyncio.Lock:
-    loop = asyncio.get_running_loop()
-    lock = _ticket_locks.get(loop)
-    if lock is None:
-        lock = asyncio.Lock()
-        _ticket_locks[loop] = lock
-    return lock
-
-
 async def consume_free_ticket(user_id: int) -> bool:
     """Consume one free ticket for ``user_id`` if available.
 
-    The read/check/decrement/write sequence is serialized so two concurrent
-    consumers cannot both spend the same ticket. Returns ``True`` only when a
-    ticket was actually consumed, then records that successful usage in the
-    transaction ledger.
+    The read/check/decrement/write sequence is serialized with purchases so two
+    concurrent operations cannot overwrite each other's ticket stock. Returns
+    ``True`` only when a ticket was actually consumed, then records that
+    successful usage in the transaction ledger.
     """
-    async with _get_ticket_lock():
+    async with get_ticket_lock():
         tickets: Dict[str, int] = load_json(TICKETS_FILE, {})
         key = str(user_id)
         count = int(tickets.get(key, 0))


### PR DESCRIPTION
## Problème
La consommation d'un Ticket Royal était déjà protégée par un verrou asyncio, mais l'achat boutique ne partageait pas ce verrou. Deux opérations concurrentes pouvaient donc lire le même stock puis écraser mutuellement leurs sauvegardes.

Cas critique confirmé : avec 2 tickets en stock et une limite de 3, deux achats simultanés pouvaient tous deux passer le contrôle, débiter chacun les XP, puis sauvegarder chacun un stock final de 3. Le joueur payait alors deux achats mais ne recevait qu'un ticket supplémentaire. Une consommation concurrente avec un achat pouvait produire le même type de lost update.

## Correction
- déplacement du verrou ticket loop-aware dans `storage/economy.py` afin qu'il soit partagé par tous les chemins ;
- `consume_free_ticket()` réutilise ce verrou commun ;
- le chemin `ticket_royal` de la boutique acquiert le même verrou avant le contrôle de limite ;
- le verrou couvre le contrôle de stock, le débit XP, l'incrément, la persistance et l'écriture de transaction ;
- les autres articles de boutique ne sont pas sérialisés par ce verrou.

## Tests
`tests/test_economy_ticket_purchase_concurrency.py` couvre :
- deux achats simultanés avec 2 tickets en stock : un seul peut atteindre le débit XP, le stock termine à 3 et une seule transaction d'achat est enregistrée ;
- une consommation bloquée pendant son écriture empêche un achat concurrent d'atteindre le débit XP ; après les deux opérations, le stock et les transactions restent cohérents.

Les tests de consommation existants continuent d'utiliser un verrou par boucle asyncio via `WeakKeyDictionary`.

## Portée
4 fichiers uniquement : `cogs/economy_ui.py`, `storage/economy.py`, `utils/economy_tickets.py` et le nouveau test de concurrence. Aucun prix, limite, calcul XP, boost Double XP ou autre jeu n'est modifié.

## Validation
La branche part du `main` après la PR #499. La suite pytest complète ne peut pas être exécutée dans ce runtime car l'environnement local disponible ici ne fournit pas `discord.py`; la PR reste en brouillon jusqu'à validation.