### PR TITLE
chore: separate test dependencies from runtime

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,6 @@
+-r requirements.txt
+
+# Test dependencies
 pytest
 pytest-asyncio
 freezegun
-discord.py>=2,<3

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ python-dotenv>=1.0
 Pillow>=10.0
 yt-dlp>=2024.7.1
 imageio-ffmpeg>=0.4
-pytest-asyncio>=0.23
 aiohttp>=3.8

--- a/tests/test_dependency_requirements.py
+++ b/tests/test_dependency_requirements.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _requirements(path: str) -> list[str]:
+    return [
+        line.strip()
+        for line in (ROOT / path).read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def test_runtime_requirements_exclude_test_only_dependencies():
+    runtime = _requirements("requirements.txt")
+
+    assert not any(line.lower().startswith("pytest") for line in runtime)
+    assert not any(line.lower().startswith("freezegun") for line in runtime)
+
+
+def test_dev_requirements_extend_runtime_and_include_test_tools():
+    dev = _requirements("requirements-dev.txt")
+
+    assert "-r requirements.txt" in dev
+    assert "pytest" in dev
+    assert "pytest-asyncio" in dev
+    assert "freezegun" in dev


### PR DESCRIPTION
## Problème
`requirements.txt` est installé directement dans l'image Docker de production et contenait `pytest-asyncio`, une dépendance utilisée uniquement par les tests. Le dépôt possède déjà un `requirements-dev.txt`, mais celui-ci ne reprenait pas toutes les dépendances runtime et dupliquait `discord.py`.

## Correction
- suppression de `pytest-asyncio` de `requirements.txt` ;
- `requirements-dev.txt` hérite désormais de `requirements.txt` via `-r requirements.txt` ;
- les outils de test restent dans le fichier dev : `pytest`, `pytest-asyncio`, `freezegun` ;
- aucun changement du Dockerfile n'est nécessaire : il installe déjà uniquement `requirements.txt`.

## Effet
Les builds de production n'installent plus pytest/pytest-asyncio indirectement pour faire tourner le bot. Un environnement de développement installe le même runtime que la production, puis les dépendances de test, ce qui réduit aussi le risque de divergence entre les deux environnements.

## Tests
Ajout de `tests/test_dependency_requirements.py` pour vérifier que :
- les dépendances de test ne reviennent pas dans `requirements.txt` ;
- `requirements-dev.txt` hérite bien du runtime ;
- pytest, pytest-asyncio et freezegun restent disponibles en développement.

## Portée
3 fichiers uniquement : `requirements.txt`, `requirements-dev.txt` et le nouveau test statique. Aucun code métier, Dockerfile ou comportement du bot n'est modifié.

## Note sur le verrouillage des versions
Je n'ai pas figé arbitrairement les versions Python dans cette PR : le dépôt ne contient pas de snapshot résolu/validé de l'environnement courant, et `yt-dlp` évolue rapidement pour suivre les changements des plateformes. Le verrouillage reproductible reste donc un correctif séparé à traiter avec un jeu de versions réellement validé.

## Validation
La branche part du `main` après la PR #500. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation.