### PR TITLE
fix: disable retired F1 and NHL cogs

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -15,7 +15,7 @@ from typing import Final
 import discord
 from discord.ext import commands
 
-from config import GUILD_ID, LEVEL_FEED_CHANNEL_ID
+from config import DISABLED_COGS, GUILD_ID, LEVEL_FEED_CHANNEL_ID
 import cogs
 
 from storage.xp_store import xp_store
@@ -55,12 +55,16 @@ class RefugeBot(commands.Bot):
         await reset_http_error_counter()
         level_feed.setup(self)
 
-        # Load all cogs from the ``cogs`` package so every slash command is
-        # registered when the bot starts. ``load_extension`` is patched to an
-        # ``AsyncMock`` in the tests, so awaiting is safe.
+        # Load active cogs from the ``cogs`` package so every enabled slash
+        # command is registered when the bot starts. Retired/disabled modules
+        # stay in the repository for reference but must not start background
+        # tasks or register commands.
         discovered = list(pkgutil.iter_modules(cogs.__path__))
         loaded_names = set()
         for module in discovered:
+            if module.name in DISABLED_COGS:
+                logger.info("Skipping disabled cog: %s", module.name)
+                continue
             await self.load_extension(f"{cogs.__name__}.{module.name}")
             loaded_names.add(module.name)
 

--- a/cogs/economy_ui.py
+++ b/cogs/economy_ui.py
@@ -24,7 +24,7 @@ from storage.economy import (
 from utils import xp_adapter
 import config
 
-CHANNEL_ID = 1409633293791400108
+CHANNEL_ID = config.ECONOMY_CHANNEL_ID
 
 logger = logging.getLogger(__name__)
 

--- a/cogs/f1_standings.py
+++ b/cogs/f1_standings.py
@@ -17,13 +17,12 @@ import aiohttp
 import discord
 from discord.ext import commands
 
-from config import DATA_DIR
+from config import DATA_DIR, F1_CHANNEL_ID
 from utils.persistence import read_json_safe, atomic_write_json, ensure_dir
 
 logger = logging.getLogger(__name__)
 
 # Constants
-F1_CHANNEL_ID: int = 1413708410330939485
 OPENF1_API = "https://api.openf1.org/v1"
 F1_DATA_DIR = os.path.join(DATA_DIR, "f1")
 F1_STATE_FILE = os.path.join(F1_DATA_DIR, "f1_state.json")

--- a/config.py
+++ b/config.py
@@ -58,6 +58,13 @@ STATS_ONLINE_CHANNEL_ID = 1413712632711745648
 STATS_VOICE_CHANNEL_ID = 1406435190607184085
 
 
+# ── Salons de fonctionnalités ─────────────────────────────────
+ECONOMY_CHANNEL_ID: int = _get_int_env(
+    "ECONOMY_CHANNEL_ID", 1409633293791400108
+)
+F1_CHANNEL_ID: int = _get_int_env("F1_CHANNEL_ID", 1413708410330939485)
+
+
 # ── Rôles plateformes et notifications ────────────────────────
 ROLE_PC = 1400560541529018408
 ROLE_CONSOLE = 1400560660710162492

--- a/config.py
+++ b/config.py
@@ -38,6 +38,11 @@ def _resolve_data_dir() -> str:
 # ── Informations globales ──────────────────────────────────────
 GUILD_ID: int = int(os.getenv("GUILD_ID", "0"))
 
+# Fonctionnalités conservées dans le dépôt mais retirées du serveur actuel.
+# Le chargeur automatique ignore ces cogs afin qu'ils ne démarrent aucune
+# tâche de fond ni appel API tant qu'ils ne sont pas explicitement réactivés.
+DISABLED_COGS: frozenset[str] = frozenset({"f1_standings", "nhl_notifications"})
+
 TZ: str = os.getenv("TZ", "Europe/Paris")
 os.environ["TZ"] = TZ
 try:
@@ -62,7 +67,7 @@ STATS_VOICE_CHANNEL_ID = 1406435190607184085
 ECONOMY_CHANNEL_ID: int = _get_int_env(
     "ECONOMY_CHANNEL_ID", 1409633293791400108
 )
-F1_CHANNEL_ID: int = _get_int_env("F1_CHANNEL_ID", 1413708410330939485)
+F1_CHANNEL_ID: int = _get_int_env("F1_CHANNEL_ID", 0)
 
 
 # ── Rôles plateformes et notifications ────────────────────────

--- a/tests/test_discord_channel_config.py
+++ b/tests/test_discord_channel_config.py
@@ -4,16 +4,26 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_feature_channel_ids_are_centralized_in_config() -> None:
+def test_active_feature_channel_ids_are_centralized_in_config() -> None:
     config_text = (ROOT / "config.py").read_text(encoding="utf-8")
     economy_text = (ROOT / "cogs" / "economy_ui.py").read_text(encoding="utf-8")
     f1_text = (ROOT / "cogs" / "f1_standings.py").read_text(encoding="utf-8")
 
     assert '"ECONOMY_CHANNEL_ID", 1409633293791400108' in config_text
-    assert '"F1_CHANNEL_ID", 1413708410330939485' in config_text
+    assert '"F1_CHANNEL_ID", 0' in config_text
 
     assert "1409633293791400108" not in economy_text
     assert "CHANNEL_ID = config.ECONOMY_CHANNEL_ID" in economy_text
 
     assert "1413708410330939485" not in f1_text
     assert "from config import DATA_DIR, F1_CHANNEL_ID" in f1_text
+
+
+def test_retired_f1_and_nhl_cogs_are_disabled_from_auto_discovery() -> None:
+    config_text = (ROOT / "config.py").read_text(encoding="utf-8")
+    bot_text = (ROOT / "bot.py").read_text(encoding="utf-8")
+
+    assert 'frozenset({"f1_standings", "nhl_notifications"})' in config_text
+    assert "from config import DISABLED_COGS" in bot_text
+    assert "if module.name in DISABLED_COGS:" in bot_text
+    assert "Skipping disabled cog" in bot_text

--- a/tests/test_discord_channel_config.py
+++ b/tests/test_discord_channel_config.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_feature_channel_ids_are_centralized_in_config() -> None:
+    config_text = (ROOT / "config.py").read_text(encoding="utf-8")
+    economy_text = (ROOT / "cogs" / "economy_ui.py").read_text(encoding="utf-8")
+    f1_text = (ROOT / "cogs" / "f1_standings.py").read_text(encoding="utf-8")
+
+    assert '"ECONOMY_CHANNEL_ID", 1409633293791400108' in config_text
+    assert '"F1_CHANNEL_ID", 1413708410330939485' in config_text
+
+    assert "1409633293791400108" not in economy_text
+    assert "CHANNEL_ID = config.ECONOMY_CHANNEL_ID" in economy_text
+
+    assert "1413708410330939485" not in f1_text
+    assert "from config import DATA_DIR, F1_CHANNEL_ID" in f1_text


### PR DESCRIPTION
## Contexte
Les salons Discord F1 et NHL n'existent plus sur le serveur. Les cogs correspondants sont pourtant toujours présents dans `cogs/`, et `bot.py` auto-charge tous les modules découverts au démarrage. Cela signifie que les tâches de fond F1/NHL peuvent encore démarrer et effectuer des appels API alors qu'elles n'ont plus de destination utile.

## Correction
- ajout de `DISABLED_COGS = {"f1_standings", "nhl_notifications"}` dans `config.py` ;
- l'auto-discovery de `bot.py` ignore désormais explicitement les cogs désactivés ;
- F1 et NHL ne démarrent donc plus leurs tâches de fond, leurs clients HTTP ni leurs commandes au démarrage normal du bot ;
- le code des deux fonctionnalités reste dans le dépôt pour référence/réactivation future ;
- `F1_CHANNEL_ID` vaut désormais `0` par défaut au lieu de conserver l'ancien salon supprimé ;
- le salon de la boutique économie reste centralisé dans `config.py` via `ECONOMY_CHANNEL_ID`, avec la valeur actuelle comme fallback.

## Compatibilité
Le comportement actif du serveur est conservé : la boutique continue d'utiliser son salon actuel. Les fonctionnalités F1/NHL sont volontairement retirées du chargement automatique car leurs salons n'existent plus.

## Tests
`tests/test_discord_channel_config.py` vérifie que :
- l'ID de la boutique est centralisé ;
- F1 ne conserve plus l'ancien ID supprimé comme valeur par défaut ;
- `f1_standings` et `nhl_notifications` figurent dans `DISABLED_COGS` ;
- le chargeur de cogs ignore explicitement les modules désactivés.

## Portée
5 fichiers uniquement : `bot.py`, `config.py`, `cogs/economy_ui.py`, `cogs/f1_standings.py` et le test de garde. Aucun calcul XP, économie, stockage ou autre fonctionnalité Discord n'est modifié.

## Validation
La branche part du `main` après la PR #501. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation.