### PR TITLE
chore: bound runtime dependency major versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-discord.py[voice]>=2.4
-python-dotenv>=1.0
-Pillow>=10.0
+discord.py[voice]>=2.4,<3
+python-dotenv>=1.0,<2
+Pillow>=10.0,<13
 yt-dlp>=2024.7.1
-imageio-ffmpeg>=0.4
-aiohttp>=3.8
+imageio-ffmpeg>=0.4,<1
+aiohttp>=3.8,<4

--- a/tests/test_dependency_requirements.py
+++ b/tests/test_dependency_requirements.py
@@ -26,3 +26,19 @@ def test_dev_requirements_extend_runtime_and_include_test_tools():
     assert "pytest" in dev
     assert "pytest-asyncio" in dev
     assert "freezegun" in dev
+
+
+def test_runtime_dependencies_have_breaking_change_guards():
+    runtime = set(_requirements("requirements.txt"))
+
+    assert "discord.py[voice]>=2.4,<3" in runtime
+    assert "python-dotenv>=1.0,<2" in runtime
+    assert "Pillow>=10.0,<13" in runtime
+    assert "imageio-ffmpeg>=0.4,<1" in runtime
+    assert "aiohttp>=3.8,<4" in runtime
+
+
+def test_yt_dlp_remains_updateable():
+    runtime = set(_requirements("requirements.txt"))
+
+    assert "yt-dlp>=2024.7.1" in runtime


### PR DESCRIPTION
## Problème
`requirements.txt` autorise actuellement toutes les versions futures au-dessus d'une borne minimale. Un rebuild Docker peut donc installer une future version majeure incompatible sans aucun changement Git dans le dépôt.

## Correction
Ajout de bornes supérieures sur les dépendances à versionnage classique :
- `discord.py[voice]>=2.4,<3`
- `python-dotenv>=1.0,<2`
- `Pillow>=10.0,<13`
- `imageio-ffmpeg>=0.4,<1`
- `aiohttp>=3.8,<4`

`yt-dlp>=2024.7.1` reste volontairement non plafonné : ce projet doit suivre fréquemment les changements externes des plateformes vidéo et recommande lui-même des mises à jour régulières.

## Pourquoi pas un lock exact
Le dépôt ne contient toujours pas de snapshot résolu et validé de toutes les dépendances transitives. Générer ici un lock exact avec des versions arbitraires donnerait une fausse garantie de reproductibilité et pourrait figer une combinaison non testée. Cette PR ajoute donc une garde contre les ruptures majeures tout en conservant les mises à jour correctives/mineures compatibles.

## Tests
`tests/test_dependency_requirements.py` vérifie désormais que les cinq dépendances classiques possèdent bien leur borne supérieure et que `yt-dlp` conserve son comportement volontairement updateable.

## Portée
2 fichiers uniquement : `requirements.txt` et `tests/test_dependency_requirements.py`. Aucun code métier ou Dockerfile n'est modifié.

## Validation
La branche part du `main` après la PR #502. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation.