### PR TITLE
fix: keep XP balance fallback read-only

### DIFF
--- a/tests/test_xp_adapter_balance_fallback.py
+++ b/tests/test_xp_adapter_balance_fallback.py
@@ -1,0 +1,41 @@
+import json
+
+from storage.xp_store import xp_store
+from utils import xp_adapter
+
+
+def test_disk_balance_fallback_does_not_overwrite_newer_cached_xp(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "xp.json"
+    path.write_text(
+        json.dumps(
+            {
+                "1": {"xp": 100, "level": 1},
+                "2": {"xp": 200, "level": 1},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cached_data = {"1": {"xp": 500, "level": 2}}
+    monkeypatch.setattr(xp_store, "path", path)
+    monkeypatch.setattr(xp_store, "data", cached_data)
+
+    assert xp_adapter.get_balance(2) == 200
+
+    # Reading user 2 from disk must not merge the whole stale disk snapshot
+    # into the authoritative in-memory cache and roll user 1 back to 100 XP.
+    assert xp_store.data == {"1": {"xp": 500, "level": 2}}
+    assert "2" not in xp_store.data
+
+
+def test_cached_balance_is_authoritative_without_disk_read(monkeypatch):
+    monkeypatch.setattr(xp_store, "data", {"7": {"xp": 750, "level": 2}})
+
+    def unexpected_disk_read(_path):
+        raise AssertionError("cached balance must not read the disk")
+
+    monkeypatch.setattr(xp_adapter, "read_json_safe", unexpected_disk_read)
+
+    assert xp_adapter.get_balance(7) == 750

--- a/utils/xp_adapter.py
+++ b/utils/xp_adapter.py
@@ -12,26 +12,29 @@ class InsufficientXPError(ValueError):
 def get_balance(user_id: int) -> int:
     """Return current XP balance for ``user_id``.
 
-    The underlying :mod:`storage.xp_store` lazily loads its data and may not
-    be initialised when this function is called. If the requested user is not
-    present in the in-memory cache we fallback to reading the JSON file from
-    disk so that features relying on the XP store can operate even before it
-    is fully started.
+    The in-memory XP store is authoritative once a user is cached. If the
+    requested user is absent, read the on-disk snapshot only as a fallback for
+    the returned balance. The fallback must never merge the whole disk snapshot
+    into ``xp_store.data`` because that could overwrite newer, unflushed XP for
+    other users with stale persisted values.
     """
 
     uid = str(user_id)
-    if uid not in xp_store.data:
-        # Load the on-disk data lazily. ``read_json_safe`` returns ``{}`` on
-        # failure so this remains a best-effort operation.
-        try:
-            xp_store.data.update(read_json_safe(xp_store.path))
-        except Exception:
-            # If anything goes wrong we leave the cache untouched and return 0
-            # below. This mirrors the previous behaviour while avoiding hard
-            # failures during bot start-up.
-            pass
+    cached = xp_store.data.get(uid)
+    if cached is not None:
+        return int(cached.get("xp", 0))
 
-    return int(xp_store.data.get(uid, {}).get("xp", 0))
+    try:
+        disk_data = read_json_safe(xp_store.path)
+    except Exception:
+        return 0
+
+    if not isinstance(disk_data, dict):
+        return 0
+    disk_user = disk_data.get(uid)
+    if not isinstance(disk_user, dict):
+        return 0
+    return int(disk_user.get("xp", 0))
 
 
 async def add_xp(user_id: int, amount: int, guild_id: int, source: str) -> None:


### PR DESCRIPTION
## Problème
`utils/xp_adapter.get_balance()` rechargeait tout le fichier XP disque avec `xp_store.data.update(...)` lorsqu'un utilisateur demandé était absent du cache mémoire. Si le disque contenait des valeurs plus anciennes pour d'autres utilisateurs, cette fusion pouvait écraser leurs XP plus récents encore non flushés en mémoire.

Exemple : utilisateur A = 500 XP en mémoire, 100 XP sur disque ; consultation du solde d'un utilisateur B absent du cache => l'ancien code pouvait remettre A à 100 XP.

## Correction
- le cache mémoire reste la source autoritaire lorsqu'un utilisateur y est présent ;
- si l'utilisateur demandé manque du cache, le fichier disque est lu uniquement pour calculer son solde retourné ;
- le snapshot disque n'est plus fusionné dans `xp_store.data` ;
- le débit réel reste protégé par `XPStore.try_spend_xp()`, qui recharge uniquement l'utilisateur concerné sous verrou si nécessaire.

## Tests
Ajout de `tests/test_xp_adapter_balance_fallback.py` :
- prouve qu'une lecture disque pour un utilisateur B ne peut plus ramener un utilisateur A de 500 XP mémoire à 100 XP disque ;
- vérifie qu'un utilisateur déjà en cache est servi sans lecture disque.

## Portée
2 fichiers uniquement : `utils/xp_adapter.py` et un nouveau test. Aucun calcul de gain, débit atomique, niveau ou persistance du store XP n'est modifié.

## Validation
La branche part du `main` après la PR #503. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation.