### PR TITLE
fix: serialize Double XP boost updates

### DIFF
--- a/cogs/economy_ui.py
+++ b/cogs/economy_ui.py
@@ -12,6 +12,7 @@ from datetime import datetime, timezone
 from storage.economy import (
     ECONOMY_DIR,
     SHOP_FILE,
+    get_boost_lock,
     get_ticket_lock,
     load_boosts,
     load_tickets,
@@ -130,52 +131,58 @@ class EconomyUICog(commands.Cog):
         await self.bot.wait_until_ready()
 
     async def _cleanup_boosts_once(self) -> None:
-        try:
-            boosts = load_boosts()
-        except Exception as e:
-            logger.warning("Lecture boosts.json échouée: %s", e)
-            return
+        role_removals: list[tuple[typing.Any, typing.Any, str, int]] = []
 
-        now = datetime.now(timezone.utc)
-        changed = False
-        guild = self.bot.get_guild(getattr(config, "GUILD_ID", 0))
+        async with get_boost_lock():
+            try:
+                boosts = load_boosts()
+            except Exception as e:
+                logger.warning("Lecture boosts.json échouée: %s", e)
+                return
 
-        for uid, entries in list(boosts.items()):
-            new_entries = []
-            for entry in entries:
-                until_str = entry.get("until")
-                try:
-                    until = datetime.fromisoformat(until_str)
-                except Exception:
-                    changed = True
-                    continue
-                if until <= now:
-                    changed = True
-                    role_id = int(entry.get("role_id", 0))
-                    if role_id and guild:
-                        member = guild.get_member(int(uid))
-                        role = guild.get_role(role_id)
-                        if member and role:
-                            try:
-                                await member.remove_roles(
-                                    role, reason="Boost expiré"
-                                )
-                            except Exception:  # pragma: no cover - best effort
-                                logger.warning(
-                                    "Impossible de retirer le rôle %s de %s",
-                                    role_id,
-                                    uid,
-                                    exc_info=True,
-                                )
+            now = datetime.now(timezone.utc)
+            changed = False
+            guild = self.bot.get_guild(getattr(config, "GUILD_ID", 0))
+
+            for uid, entries in list(boosts.items()):
+                new_entries = []
+                for entry in entries:
+                    until_str = entry.get("until")
+                    try:
+                        until = datetime.fromisoformat(until_str)
+                    except Exception:
+                        changed = True
+                        continue
+                    if until <= now:
+                        changed = True
+                        role_id = int(entry.get("role_id", 0))
+                        if role_id and guild:
+                            member = guild.get_member(int(uid))
+                            role = guild.get_role(role_id)
+                            if member and role:
+                                role_removals.append((member, role, uid, role_id))
+                    else:
+                        new_entries.append(entry)
+                if new_entries:
+                    boosts[uid] = new_entries
                 else:
-                    new_entries.append(entry)
-            if new_entries:
-                boosts[uid] = new_entries
-            else:
-                boosts.pop(uid, None)
+                    boosts.pop(uid, None)
 
-        if changed:
-            await save_boosts(boosts)
+            if changed:
+                await save_boosts(boosts)
+
+        # Discord calls are intentionally performed after the persisted boost
+        # state is committed and the shared boost lock has been released.
+        for member, role, uid, role_id in role_removals:
+            try:
+                await member.remove_roles(role, reason="Boost expiré")
+            except Exception:  # pragma: no cover - best effort
+                logger.warning(
+                    "Impossible de retirer le rôle %s de %s",
+                    role_id,
+                    uid,
+                    exc_info=True,
+                )
 
     async def cog_load(self) -> None:  # pragma: no cover - requires discord context
         logger.info("Chargement de l'interface économie")
@@ -240,6 +247,7 @@ class EconomyUICog(commands.Cog):
         item_key: str,
         *,
         _ticket_locked: bool = False,
+        _boost_locked: bool = False,
     ) -> None:
         shop = _load_shop()
         if not shop:
@@ -259,6 +267,16 @@ class EconomyUICog(commands.Cog):
                     interaction,
                     item_key,
                     _ticket_locked=True,
+                    _boost_locked=_boost_locked,
+                )
+            return
+        if item_key == "double_xp_1h" and not _boost_locked:
+            async with get_boost_lock():
+                await self._handle_shop_purchase(
+                    interaction,
+                    item_key,
+                    _ticket_locked=_ticket_locked,
+                    _boost_locked=True,
                 )
             return
         user_id = interaction.user.id

--- a/storage/economy.py
+++ b/storage/economy.py
@@ -41,6 +41,24 @@ def get_ticket_lock() -> asyncio.Lock:
     return lock
 
 
+# Boost inventory is also mutated by both purchases and periodic cleanup.
+# Use a separate loop-aware lock so those read/check/mutate/write cycles cannot
+# overwrite one another without coupling them to unrelated ticket operations.
+_boost_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def get_boost_lock() -> asyncio.Lock:
+    """Return the shared boost transaction lock for the running event loop."""
+    loop = asyncio.get_running_loop()
+    lock = _boost_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _boost_locks[loop] = lock
+    return lock
+
+
 def load_boosts() -> Dict[str, Any]:
     """Load boosts from disk or return an empty dict."""
     return load_json(BOOSTS_FILE, {})

--- a/tests/test_economy_boost_concurrency.py
+++ b/tests/test_economy_boost_concurrency.py
@@ -1,0 +1,192 @@
+import asyncio
+from copy import deepcopy
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cogs.economy_ui as economy_ui
+from cogs.economy_ui import EconomyUICog
+
+
+def _interaction(user_id: int = 1):
+    return SimpleNamespace(
+        user=SimpleNamespace(id=user_id),
+        guild_id=123,
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+
+
+def _double_xp_shop():
+    return {"double_xp_1h": {"name": "Double XP 1h", "price": 300}}
+
+
+@pytest.mark.asyncio
+async def test_concurrent_double_xp_purchases_respect_active_limit(monkeypatch):
+    now = datetime.now(timezone.utc)
+    state = {
+        "1": [
+            {
+                "type": "double_xp",
+                "until": (now + timedelta(hours=1)).isoformat(),
+            }
+        ]
+    }
+
+    monkeypatch.setattr(economy_ui, "_load_shop", _double_xp_shop)
+    monkeypatch.setattr(economy_ui, "load_boosts", lambda: deepcopy(state))
+
+    async def save_boosts(data):
+        state.clear()
+        state.update(deepcopy(data))
+
+    monkeypatch.setattr(economy_ui, "save_boosts", save_boosts)
+    monkeypatch.setattr(economy_ui.xp_adapter, "get_balance", lambda _uid: 1000)
+    monkeypatch.setattr(
+        economy_ui,
+        "_activate_personal_double_xp",
+        lambda _uid, _minutes: now + timedelta(hours=2),
+    )
+
+    first_debit_started = asyncio.Event()
+    release_first_debit = asyncio.Event()
+    debit_calls = []
+
+    async def blocked_debit(user_id, *, amount, guild_id, source):
+        debit_calls.append((user_id, amount, guild_id, source))
+        first_debit_started.set()
+        await release_first_debit.wait()
+
+    monkeypatch.setattr(economy_ui.xp_adapter, "add_xp", blocked_debit)
+    transaction_add = AsyncMock()
+    monkeypatch.setattr(
+        economy_ui,
+        "transactions",
+        SimpleNamespace(add=transaction_add),
+    )
+
+    cog = EconomyUICog(object())
+    first = _interaction()
+    second = _interaction()
+
+    first_task = asyncio.create_task(
+        cog._handle_shop_purchase(first, "double_xp_1h")
+    )
+    await first_debit_started.wait()
+
+    second_task = asyncio.create_task(
+        cog._handle_shop_purchase(second, "double_xp_1h")
+    )
+    await asyncio.sleep(0)
+
+    # The second purchase must still be waiting on the shared boost lock. If it
+    # reaches the debit concurrently, both purchases could pass the active=1
+    # check and create a third active boost.
+    assert len(debit_calls) == 1
+
+    release_first_debit.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert len(debit_calls) == 1
+    assert len(state["1"]) == 2
+    transaction_add.assert_awaited_once()
+
+    responses = [
+        first.response.send_message.await_args.args[0],
+        second.response.send_message.await_args.args[0],
+    ]
+    assert sum("effectu" in response.lower() for response in responses) == 1
+    assert sum("limite" in response.lower() for response in responses) == 1
+
+
+@pytest.mark.asyncio
+async def test_boost_cleanup_serializes_disk_write_but_not_discord_role_removal(
+    monkeypatch,
+):
+    now = datetime.now(timezone.utc)
+    state = {
+        "1": [
+            {
+                "type": "role_boost",
+                "role_id": 777,
+                "until": (now - timedelta(minutes=1)).isoformat(),
+            }
+        ]
+    }
+
+    monkeypatch.setattr(economy_ui, "load_boosts", lambda: deepcopy(state))
+
+    save_started = asyncio.Event()
+    release_save = asyncio.Event()
+
+    async def blocked_save(data):
+        save_started.set()
+        await release_save.wait()
+        state.clear()
+        state.update(deepcopy(data))
+
+    monkeypatch.setattr(economy_ui, "save_boosts", blocked_save)
+
+    role_removal_started = asyncio.Event()
+    release_role_removal = asyncio.Event()
+
+    async def blocked_remove_role(*_args, **_kwargs):
+        role_removal_started.set()
+        await release_role_removal.wait()
+
+    member = SimpleNamespace(remove_roles=AsyncMock(side_effect=blocked_remove_role))
+    role = object()
+    guild = SimpleNamespace(
+        get_member=lambda _uid: member,
+        get_role=lambda _rid: role,
+    )
+    bot = SimpleNamespace(get_guild=lambda _gid: guild)
+    cog = EconomyUICog(bot)
+
+    cleanup_task = asyncio.create_task(cog._cleanup_boosts_once())
+    await save_started.wait()
+
+    monkeypatch.setattr(economy_ui, "_load_shop", _double_xp_shop)
+    monkeypatch.setattr(economy_ui.xp_adapter, "get_balance", lambda _uid: 1000)
+    monkeypatch.setattr(
+        economy_ui,
+        "_activate_personal_double_xp",
+        lambda _uid, _minutes: now + timedelta(hours=1),
+    )
+
+    debit_started = asyncio.Event()
+
+    async def debit(user_id, *, amount, guild_id, source):
+        debit_started.set()
+
+    monkeypatch.setattr(economy_ui.xp_adapter, "add_xp", debit)
+    monkeypatch.setattr(
+        economy_ui,
+        "transactions",
+        SimpleNamespace(add=AsyncMock()),
+    )
+
+    purchase = _interaction()
+    purchase_task = asyncio.create_task(
+        cog._handle_shop_purchase(purchase, "double_xp_1h")
+    )
+    await asyncio.sleep(0)
+
+    # Cleanup still owns the boost lock while its persisted state is blocked,
+    # so the purchase cannot debit XP yet.
+    assert not debit_started.is_set()
+
+    release_save.set()
+    await role_removal_started.wait()
+
+    # The role removal is a Discord network operation. It must happen after the
+    # boost lock is released, allowing the purchase to proceed immediately.
+    await asyncio.wait_for(debit_started.wait(), timeout=1)
+
+    release_role_removal.set()
+    await asyncio.gather(cleanup_task, purchase_task)
+
+    assert len(state["1"]) == 1
+    assert state["1"][0]["type"] == "double_xp"
+    member.remove_roles.assert_awaited_once_with(role, reason="Boost expiré")


### PR DESCRIPTION
## Problème
Les achats `double_xp_1h` et le nettoyage périodique de `boosts.json` effectuaient chacun un cycle lecture → contrôle/mutation → écriture sans verrou partagé. Deux achats simultanés pouvaient donc tous deux passer la limite active avant écriture, et un cleanup concurrent pouvait écraser un boost acheté au même moment.

## Correction
- ajout de `get_boost_lock()` dans `storage/economy.py`, avec le même modèle loop-aware déjà utilisé pour les Tickets Royal ;
- l'achat `double_xp_1h` acquiert ce verrou avant le contrôle de limite, le débit XP, l'activation et la sauvegarde du boost ;
- `_cleanup_boosts_once()` utilise le même verrou pendant son read-modify-write ;
- les retraits de rôles Discord déclenchés par le cleanup sont différés après la sauvegarde et exécutés une fois le verrou libéré, afin de ne pas bloquer les achats sur une opération réseau externe.

## Tests
Ajout de `tests/test_economy_boost_concurrency.py` :
- deux achats simultanés avec déjà un boost actif ne peuvent pas créer un troisième boost ni débiter deux fois ;
- un achat attend bien qu'un cleanup termine son écriture persistée ;
- une fois cette écriture terminée, l'achat peut continuer même si le retrait de rôle Discord du cleanup est encore bloqué.

## Portée
3 fichiers uniquement : `storage/economy.py`, `cogs/economy_ui.py` et le nouveau test de concurrence. Aucun calcul XP, prix, durée de boost ou limite métier n'est modifié.

## Validation
La branche part du `main` après la PR #504. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation.