### PR TITLE
feat: add achievements and persistent badges

### DIFF
--- a/cogs/achievements.py
+++ b/cogs/achievements.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from config import DATA_DIR
+from storage.achievement_store import achievement_store
+from storage.xp_store import xp_store
+from utils.achievements import (
+    ACHIEVEMENTS,
+    CATEGORY_LABELS,
+    achievement_progress,
+    qualifying_achievement_ids,
+)
+from utils.persistence import read_json_safe
+
+
+logger = logging.getLogger(__name__)
+CASINO_STATE_FILE = Path(DATA_DIR) / "pari_xp_state.json"
+
+
+def _load_casino_players() -> dict[str, dict[str, Any]]:
+    raw = read_json_safe(CASINO_STATE_FILE, {})
+    if not isinstance(raw, dict):
+        return {}
+    players = raw.get("players", {})
+    if not isinstance(players, dict):
+        return {}
+    return {
+        str(user_id): dict(payload)
+        for user_id, payload in players.items()
+        if isinstance(payload, dict)
+    }
+
+
+def _member_metrics(
+    member: discord.Member,
+    xp_snapshot: Mapping[str, Mapping[str, Any]],
+    casino_players: Mapping[str, Mapping[str, Any]],
+    *,
+    now: datetime | None = None,
+) -> dict[str, int]:
+    """Build achievement metrics only from existing authoritative data."""
+
+    uid = str(member.id)
+    xp_payload = xp_snapshot.get(uid, {})
+    casino_payload = casino_players.get(uid, {})
+
+    try:
+        level = int(xp_payload.get("level", 0))
+    except (TypeError, ValueError):
+        level = 0
+    try:
+        casino_bets = int(casino_payload.get("bets", 0))
+    except (TypeError, ValueError):
+        casino_bets = 0
+
+    tenure_days = 0
+    joined_at = member.joined_at
+    if joined_at is not None:
+        if joined_at.tzinfo is None:
+            joined_at = joined_at.replace(tzinfo=timezone.utc)
+        current = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        tenure_days = max(0, (current - joined_at.astimezone(timezone.utc)).days)
+
+    return {
+        "level": max(0, level),
+        "casino_bets": max(0, casino_bets),
+        "tenure_days": tenure_days,
+    }
+
+
+def _format_progress(metric: str, current: int, target: int) -> str:
+    if metric == "level":
+        return f"niveau {current}/{target}"
+    if metric == "casino_bets":
+        return f"{current}/{target} paris"
+    if metric == "tenure_days":
+        return f"{current}/{target} jours"
+    return f"{current}/{target}"
+
+
+class AchievementsCog(commands.Cog):
+    """Persistent achievements derived from existing XP, casino and tenure data."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def cog_load(self) -> None:
+        self.achievement_sync.start()
+
+    def cog_unload(self) -> None:
+        self.achievement_sync.cancel()
+
+    async def _xp_snapshot(self) -> dict[str, dict[str, Any]]:
+        async with xp_store.lock:
+            return {
+                str(user_id): dict(payload)
+                for user_id, payload in xp_store.data.items()
+                if isinstance(payload, dict)
+            }
+
+    async def _sync_member(
+        self,
+        member: discord.Member,
+        casino_players: Mapping[str, Mapping[str, Any]] | None = None,
+    ) -> tuple[dict[str, int], list[str]]:
+        xp_snapshot = await self._xp_snapshot()
+        players = casino_players if casino_players is not None else _load_casino_players()
+        metrics = _member_metrics(member, xp_snapshot, players)
+        newly_unlocked = await achievement_store.unlock_many(
+            member.id,
+            qualifying_achievement_ids(metrics),
+        )
+        return metrics, newly_unlocked
+
+    @tasks.loop(minutes=15)
+    async def achievement_sync(self) -> None:
+        """Recognize newly reached badges without requiring the slash command."""
+
+        xp_snapshot = await self._xp_snapshot()
+        casino_players = _load_casino_players()
+        current = datetime.now(timezone.utc)
+        unlocks: dict[int, list[str]] = {}
+
+        for guild in self.bot.guilds:
+            for member in guild.members:
+                if member.bot:
+                    continue
+                metrics = _member_metrics(
+                    member,
+                    xp_snapshot,
+                    casino_players,
+                    now=current,
+                )
+                qualified = qualifying_achievement_ids(metrics)
+                if qualified:
+                    unlocks[member.id] = qualified
+
+        if unlocks:
+            await achievement_store.unlock_batch(unlocks, unlocked_at=current)
+
+    @achievement_sync.before_loop
+    async def before_achievement_sync(self) -> None:
+        await self.bot.wait_until_ready()
+
+    @app_commands.command(
+        name="succes",
+        description="Affiche les succès et badges d'un membre",
+    )
+    @app_commands.describe(membre="Membre à consulter (toi par défaut)")
+    async def succes(
+        self,
+        interaction: discord.Interaction,
+        membre: discord.Member | None = None,
+    ) -> None:
+        target = membre
+        if target is None and isinstance(interaction.user, discord.Member):
+            target = interaction.user
+        if target is None and interaction.guild is not None:
+            target = interaction.guild.get_member(interaction.user.id)
+        if target is None:
+            await interaction.response.send_message(
+                "Impossible de déterminer le membre à afficher.",
+                ephemeral=True,
+            )
+            return
+
+        metrics, newly_unlocked = await self._sync_member(target)
+        unlocked = await achievement_store.get_user_achievements(target.id)
+
+        embed = discord.Embed(
+            title=f"🏅 Succès de {target.display_name}",
+            description=(
+                f"**{len(unlocked)}/{len(ACHIEVEMENTS)}** badges débloqués."
+            ),
+        )
+        if newly_unlocked:
+            embed.description += (
+                f"\n✨ **{len(newly_unlocked)} nouveau(x) succès** reconnu(s) maintenant."
+            )
+
+        for category, label in CATEGORY_LABELS.items():
+            lines: list[str] = []
+            for achievement in ACHIEVEMENTS:
+                if achievement.category != category:
+                    continue
+                if achievement.id in unlocked:
+                    lines.append(
+                        f"✅ {achievement.emoji} **{achievement.name}** — {achievement.description}"
+                    )
+                else:
+                    current, target_value = achievement_progress(achievement, metrics)
+                    progress = _format_progress(
+                        achievement.metric,
+                        current,
+                        target_value,
+                    )
+                    lines.append(
+                        f"🔒 {achievement.emoji} **{achievement.name}** — {progress}"
+                    )
+            embed.add_field(name=label, value="\n".join(lines), inline=False)
+
+        await interaction.response.send_message(embed=embed)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(AchievementsCog(bot))

--- a/storage/achievement_store.py
+++ b/storage/achievement_store.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+import weakref
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from config import DATA_DIR
+from utils.persistence import atomic_write_json_async, read_json_safe
+
+
+ACHIEVEMENTS_FILE = Path(DATA_DIR) / "achievements.json"
+
+
+class AchievementStore:
+    """Persist unlocked achievements without rewriting on read-only checks."""
+
+    def __init__(self, path: str | Path = ACHIEVEMENTS_FILE) -> None:
+        self.path = Path(path)
+        self._loaded = False
+        self._data: dict[str, Any] = {"schema_version": 1, "users": {}}
+        self._locks: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Lock
+        ] = weakref.WeakKeyDictionary()
+
+    def _get_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[loop] = lock
+        return lock
+
+    async def _ensure_loaded_locked(self) -> None:
+        if self._loaded:
+            return
+        raw = await asyncio.to_thread(read_json_safe, self.path, {})
+        users: dict[str, Any] = {}
+        if isinstance(raw, dict):
+            raw_users = raw.get("users", {})
+            if isinstance(raw_users, dict):
+                users = {
+                    str(user_id): dict(payload)
+                    for user_id, payload in raw_users.items()
+                    if isinstance(payload, dict)
+                }
+        self._data = {"schema_version": 1, "users": users}
+        self._loaded = True
+
+    async def get_user_achievements(self, user_id: int) -> dict[str, str]:
+        """Return a copy of one user's ``achievement_id -> unlocked_at`` map."""
+
+        async with self._get_lock():
+            await self._ensure_loaded_locked()
+            users = self._data["users"]
+            payload = users.get(str(user_id), {})
+            return {
+                str(achievement_id): str(unlocked_at)
+                for achievement_id, unlocked_at in payload.items()
+            }
+
+    async def unlock_many(
+        self,
+        user_id: int,
+        achievement_ids: Iterable[str],
+        *,
+        unlocked_at: datetime | None = None,
+    ) -> list[str]:
+        """Persist newly unlocked IDs and return only the IDs added this call."""
+
+        unique_ids = list(dict.fromkeys(str(item) for item in achievement_ids))
+        if not unique_ids:
+            return []
+
+        timestamp = (unlocked_at or datetime.now(timezone.utc)).astimezone(
+            timezone.utc
+        ).isoformat()
+
+        async with self._get_lock():
+            await self._ensure_loaded_locked()
+            users = self._data["users"]
+            user_payload = users.setdefault(str(user_id), {})
+            newly_unlocked: list[str] = []
+            for achievement_id in unique_ids:
+                if achievement_id in user_payload:
+                    continue
+                user_payload[achievement_id] = timestamp
+                newly_unlocked.append(achievement_id)
+
+            if newly_unlocked:
+                await atomic_write_json_async(self.path, self._data)
+            return newly_unlocked
+
+
+achievement_store = AchievementStore()

--- a/storage/achievement_store.py
+++ b/storage/achievement_store.py
@@ -4,7 +4,7 @@ import asyncio
 import weakref
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable
+from typing import Any, Iterable, Mapping
 
 from config import DATA_DIR
 from utils.persistence import atomic_write_json_async, read_json_safe
@@ -69,9 +69,31 @@ class AchievementStore:
     ) -> list[str]:
         """Persist newly unlocked IDs and return only the IDs added this call."""
 
-        unique_ids = list(dict.fromkeys(str(item) for item in achievement_ids))
-        if not unique_ids:
-            return []
+        result = await self.unlock_batch(
+            {user_id: achievement_ids},
+            unlocked_at=unlocked_at,
+        )
+        return result.get(user_id, [])
+
+    async def unlock_batch(
+        self,
+        unlocks: Mapping[int, Iterable[str]],
+        *,
+        unlocked_at: datetime | None = None,
+    ) -> dict[int, list[str]]:
+        """Persist achievement unlocks for many users with at most one disk write."""
+
+        normalized = {
+            int(user_id): list(dict.fromkeys(str(item) for item in achievement_ids))
+            for user_id, achievement_ids in unlocks.items()
+        }
+        normalized = {
+            user_id: achievement_ids
+            for user_id, achievement_ids in normalized.items()
+            if achievement_ids
+        }
+        if not normalized:
+            return {}
 
         timestamp = (unlocked_at or datetime.now(timezone.utc)).astimezone(
             timezone.utc
@@ -80,17 +102,24 @@ class AchievementStore:
         async with self._get_lock():
             await self._ensure_loaded_locked()
             users = self._data["users"]
-            user_payload = users.setdefault(str(user_id), {})
-            newly_unlocked: list[str] = []
-            for achievement_id in unique_ids:
-                if achievement_id in user_payload:
-                    continue
-                user_payload[achievement_id] = timestamp
-                newly_unlocked.append(achievement_id)
+            result: dict[int, list[str]] = {}
+            changed = False
 
-            if newly_unlocked:
+            for user_id, achievement_ids in normalized.items():
+                user_payload = users.setdefault(str(user_id), {})
+                newly_unlocked: list[str] = []
+                for achievement_id in achievement_ids:
+                    if achievement_id in user_payload:
+                        continue
+                    user_payload[achievement_id] = timestamp
+                    newly_unlocked.append(achievement_id)
+                    changed = True
+                if newly_unlocked:
+                    result[user_id] = newly_unlocked
+
+            if changed:
                 await atomic_write_json_async(self.path, self._data)
-            return newly_unlocked
+            return result
 
 
 achievement_store = AchievementStore()

--- a/tests/test_achievements.py
+++ b/tests/test_achievements.py
@@ -1,0 +1,110 @@
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from cogs.achievements import _member_metrics
+from storage.achievement_store import AchievementStore
+from utils.achievements import ACHIEVEMENTS, qualifying_achievement_ids
+
+
+def test_initial_catalog_has_nine_unique_achievements() -> None:
+    assert len(ACHIEVEMENTS) == 9
+    assert len({achievement.id for achievement in ACHIEVEMENTS}) == 9
+
+
+def test_qualification_unlocks_reached_thresholds_only() -> None:
+    qualified = qualifying_achievement_ids(
+        {
+            "level": 10,
+            "casino_bets": 12,
+            "tenure_days": 40,
+        }
+    )
+
+    assert qualified == [
+        "level_5",
+        "level_10",
+        "casino_1_bet",
+        "casino_10_bets",
+        "tenure_30_days",
+    ]
+
+
+def test_member_metrics_reuse_existing_authoritative_sources() -> None:
+    now = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+    member = SimpleNamespace(
+        id=42,
+        joined_at=now - timedelta(days=200, hours=3),
+    )
+
+    metrics = _member_metrics(
+        member,
+        {"42": {"level": 12, "xp": 99999}},
+        {"42": {"bets": 15, "wagered": 1000, "winnings": 800}},
+        now=now,
+    )
+
+    assert metrics == {
+        "level": 12,
+        "casino_bets": 15,
+        "tenure_days": 200,
+    }
+
+
+@pytest.mark.asyncio
+async def test_unlock_many_is_idempotent_and_persistent(tmp_path) -> None:
+    path = tmp_path / "achievements.json"
+    unlocked_at = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+    store = AchievementStore(path)
+
+    first = await store.unlock_many(
+        42,
+        ["level_5", "level_10", "level_5"],
+        unlocked_at=unlocked_at,
+    )
+    second = await store.unlock_many(
+        42,
+        ["level_5", "level_10"],
+        unlocked_at=unlocked_at + timedelta(days=1),
+    )
+
+    assert first == ["level_5", "level_10"]
+    assert second == []
+
+    reloaded = AchievementStore(path)
+    assert await reloaded.get_user_achievements(42) == {
+        "level_5": unlocked_at.isoformat(),
+        "level_10": unlocked_at.isoformat(),
+    }
+
+
+@pytest.mark.asyncio
+async def test_unlock_batch_persists_multiple_members_in_one_snapshot(tmp_path) -> None:
+    path = tmp_path / "achievements.json"
+    unlocked_at = datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc)
+    store = AchievementStore(path)
+
+    result = await store.unlock_batch(
+        {
+            1: ["level_5", "tenure_30_days"],
+            2: ["casino_1_bet"],
+        },
+        unlocked_at=unlocked_at,
+    )
+
+    assert result == {
+        1: ["level_5", "tenure_30_days"],
+        2: ["casino_1_bet"],
+    }
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert payload["users"]["1"] == {
+        "level_5": unlocked_at.isoformat(),
+        "tenure_30_days": unlocked_at.isoformat(),
+    }
+    assert payload["users"]["2"] == {
+        "casino_1_bet": unlocked_at.isoformat(),
+    }

--- a/utils/achievements.py
+++ b/utils/achievements.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class AchievementDefinition:
+    """Static definition of one user achievement."""
+
+    id: str
+    name: str
+    description: str
+    category: str
+    metric: str
+    threshold: int
+    emoji: str
+
+
+ACHIEVEMENTS: tuple[AchievementDefinition, ...] = (
+    AchievementDefinition(
+        id="level_5",
+        name="Membre Bronze",
+        description="Atteindre le niveau 5.",
+        category="xp",
+        metric="level",
+        threshold=5,
+        emoji="🥉",
+    ),
+    AchievementDefinition(
+        id="level_10",
+        name="Membre Argent",
+        description="Atteindre le niveau 10.",
+        category="xp",
+        metric="level",
+        threshold=10,
+        emoji="🥈",
+    ),
+    AchievementDefinition(
+        id="level_20",
+        name="Membre Or",
+        description="Atteindre le niveau 20.",
+        category="xp",
+        metric="level",
+        threshold=20,
+        emoji="🥇",
+    ),
+    AchievementDefinition(
+        id="casino_1_bet",
+        name="Premier pari",
+        description="Participer à un premier pari XP.",
+        category="casino",
+        metric="casino_bets",
+        threshold=1,
+        emoji="🎲",
+    ),
+    AchievementDefinition(
+        id="casino_10_bets",
+        name="Habitué du casino",
+        description="Participer à 10 paris XP.",
+        category="casino",
+        metric="casino_bets",
+        threshold=10,
+        emoji="🎰",
+    ),
+    AchievementDefinition(
+        id="casino_50_bets",
+        name="Vétéran du casino",
+        description="Participer à 50 paris XP.",
+        category="casino",
+        metric="casino_bets",
+        threshold=50,
+        emoji="🃏",
+    ),
+    AchievementDefinition(
+        id="tenure_30_days",
+        name="Un mois au Refuge",
+        description="Être membre du Refuge depuis 30 jours.",
+        category="anciennete",
+        metric="tenure_days",
+        threshold=30,
+        emoji="🌱",
+    ),
+    AchievementDefinition(
+        id="tenure_180_days",
+        name="Pilier du Refuge",
+        description="Être membre du Refuge depuis 180 jours.",
+        category="anciennete",
+        metric="tenure_days",
+        threshold=180,
+        emoji="🏕️",
+    ),
+    AchievementDefinition(
+        id="tenure_365_days",
+        name="Un an au Refuge",
+        description="Être membre du Refuge depuis 365 jours.",
+        category="anciennete",
+        metric="tenure_days",
+        threshold=365,
+        emoji="🏆",
+    ),
+)
+
+ACHIEVEMENT_BY_ID = {achievement.id: achievement for achievement in ACHIEVEMENTS}
+CATEGORY_LABELS = {
+    "xp": "Progression XP",
+    "casino": "Casino XP",
+    "anciennete": "Ancienneté",
+}
+
+
+def qualifying_achievement_ids(metrics: Mapping[str, int]) -> list[str]:
+    """Return all achievements whose metric threshold is currently reached."""
+
+    qualified: list[str] = []
+    for achievement in ACHIEVEMENTS:
+        try:
+            value = int(metrics.get(achievement.metric, 0))
+        except (TypeError, ValueError):
+            value = 0
+        if value >= achievement.threshold:
+            qualified.append(achievement.id)
+    return qualified
+
+
+def achievement_progress(
+    achievement: AchievementDefinition,
+    metrics: Mapping[str, int],
+) -> tuple[int, int]:
+    """Return clamped ``(current, target)`` progress for display."""
+
+    try:
+        current = int(metrics.get(achievement.metric, 0))
+    except (TypeError, ValueError):
+        current = 0
+    current = max(0, min(current, achievement.threshold))
+    return current, achievement.threshold


### PR DESCRIPTION
## Objectif
Ajouter une première version du système de succès/badges sans dupliquer les compteurs existants et sans modifier les calculs XP, casino ou vocal.

## Fonctionnement
- nouveau catalogue de 9 succès persistants ;
- 3 succès XP : niveaux 5, 10 et 20 ;
- 3 succès casino : 1, 10 et 50 paris XP ;
- 3 succès d'ancienneté : 30, 180 et 365 jours ;
- nouveau fichier persistant `achievements.json` sous `DATA_DIR`, avec date de déblocage par badge ;
- synchronisation automatique toutes les 15 minutes à partir des données déjà autoritaires ;
- synchronisation immédiate lors de `/succes`, ce qui permet de reconnaître rétroactivement les membres déjà éligibles ;
- affichage de tous les badges obtenus et de la progression vers les badges verrouillés.

## Architecture
- `utils/achievements.py` : catalogue et calcul pur des seuils/progressions ;
- `storage/achievement_store.py` : stockage atomique et idempotent des badges ;
- `cogs/achievements.py` : synchronisation périodique + commande `/succes` ;
- le batch de synchronisation de plusieurs membres produit au maximum une écriture persistante.

## Données réutilisées
- XP/niveau : `xp_store.data` ;
- casino : `pari_xp_state.json` (`players[*].bets`) ;
- ancienneté : `discord.Member.joined_at`.

La V1 n'ajoute pas encore de succès messages/vocal, car le bot ne conserve actuellement que les statistiques quotidiennes pour ces dimensions. Aucun historique artificiel n'est inventé.

## Tests
`tests/test_achievements.py` couvre :
- unicité et taille du catalogue ;
- qualification exacte selon les seuils ;
- calcul des métriques à partir des sources existantes ;
- idempotence et persistance ;
- déblocage batch de plusieurs membres.

## Portée
4 nouveaux fichiers uniquement. Aucun fichier existant n'est modifié ; aucun prix, gain XP, règle casino, rôle ou compteur métier existant n'est changé.

## Validation
La branche part du `main` après la PR #505. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation.