### PR TITLE
feat: add monthly seasonal leaderboards

### DIFF
--- a/cogs/first_message.py
+++ b/cogs/first_message.py
@@ -12,6 +12,7 @@ from discord.ext import commands, tasks
 
 from config import DATA_DIR
 from storage.xp_store import xp_store
+from storage.season_store import season_store
 from utils.persistence import (
     atomic_write_json_async,
     ensure_dir,
@@ -131,6 +132,18 @@ class FirstMessageCog(commands.Cog):
             guild_id=message.guild.id if message.guild else 0,
             source="message",
         )
+        seasonal_delta = total_xp - old_xp
+        if seasonal_delta > 0:
+            try:
+                await season_store.record(
+                    message.author.id,
+                    at=message.created_at,
+                    xp_earned=seasonal_delta,
+                )
+            except Exception:
+                logger.exception(
+                    "[season] Impossible d'enregistrer la récompense premier message"
+                )
         await message.channel.send(
             f"🎉 Félicitations {message.author.mention}, tu es le premier de la journée et tu gagnes 400 XP !",
         )

--- a/cogs/seasonal_leaderboards.py
+++ b/cogs/seasonal_leaderboards.py
@@ -2,12 +2,16 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
 
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
 
+from config import DATA_DIR
 from storage.season_store import season_store
+from utils.persistence import read_json_safe
 from utils.seasons import (
     SEASON_METRICS,
     SEASON_METRICS_BY_KEY,
@@ -20,6 +24,22 @@ from utils.seasons import (
 )
 
 
+CASINO_STATE_FILE = Path(DATA_DIR) / "pari_xp_state.json"
+
+
+def _casino_players_from_raw(raw: Any) -> dict[str, dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return {}
+    players = raw.get("players", {})
+    if not isinstance(players, dict):
+        return {}
+    return {
+        str(user_id): dict(payload)
+        for user_id, payload in players.items()
+        if isinstance(payload, dict)
+    }
+
+
 class SeasonalLeaderboardsCog(commands.Cog):
     """Monthly activity leaderboards that never reset global bot data."""
 
@@ -27,8 +47,16 @@ class SeasonalLeaderboardsCog(commands.Cog):
         self.bot = bot
         self._voice_sessions: dict[int, datetime] = {}
 
+    async def _sync_casino(self) -> None:
+        raw = await asyncio.to_thread(read_json_safe, CASINO_STATE_FILE, {})
+        await season_store.sync_casino_totals(_casino_players_from_raw(raw))
+
     async def cog_load(self) -> None:
         await season_store.ensure_tracking_started()
+        # First observation is baseline-only: no pre-feature casino history is
+        # injected into the current season.
+        await self._sync_casino()
+        await season_store.flush()
         self.flush_season_stats.start()
 
     def cog_unload(self) -> None:
@@ -93,6 +121,7 @@ class SeasonalLeaderboardsCog(commands.Cog):
 
     @tasks.loop(seconds=30)
     async def flush_season_stats(self) -> None:
+        await self._sync_casino()
         await season_store.flush()
 
     @flush_season_stats.before_loop
@@ -155,8 +184,8 @@ class SeasonalLeaderboardsCog(commands.Cog):
             users = {}
         rows = rank_rows(users, metric.field)
 
-        lines: list[str] = []
-        for rank, (user_id, value) in enumerate(rows[:10], start=1):
+        visible_rows: list[tuple[str, int, str]] = []
+        for user_id, value in rows:
             display = f"<@{user_id}>"
             if interaction.guild is not None:
                 try:
@@ -167,6 +196,12 @@ class SeasonalLeaderboardsCog(commands.Cog):
                     if member.bot:
                         continue
                     display = member.display_name
+            visible_rows.append((user_id, value, display))
+            if len(visible_rows) >= 10:
+                break
+
+        lines: list[str] = []
+        for rank, (_user_id, value, display) in enumerate(visible_rows, start=1):
             medal = {1: "🥇", 2: "🥈", 3: "🥉"}.get(rank, f"**#{rank}**")
             lines.append(
                 f"{medal} {display} — **{format_metric_value(metric.key, value)}**"

--- a/cogs/seasonal_leaderboards.py
+++ b/cogs/seasonal_leaderboards.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from storage.season_store import season_store
+from utils.seasons import (
+    SEASON_METRICS,
+    SEASON_METRICS_BY_KEY,
+    format_metric_value,
+    parse_season_id,
+    rank_rows,
+    season_id_for,
+    season_label,
+    split_interval_by_season,
+)
+
+
+class SeasonalLeaderboardsCog(commands.Cog):
+    """Monthly activity leaderboards that never reset global bot data."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._voice_sessions: dict[int, datetime] = {}
+
+    async def cog_load(self) -> None:
+        await season_store.ensure_tracking_started()
+        self.flush_season_stats.start()
+
+    def cog_unload(self) -> None:
+        self.flush_season_stats.cancel()
+        try:
+            asyncio.create_task(season_store.flush())
+        except RuntimeError:
+            pass
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        """Start prospective voice timing for members already connected."""
+
+        now = datetime.now(timezone.utc)
+        active_ids: set[int] = set()
+        for guild in self.bot.guilds:
+            for channel in guild.voice_channels:
+                for member in channel.members:
+                    if member.bot:
+                        continue
+                    active_ids.add(member.id)
+                    self._voice_sessions.setdefault(member.id, now)
+
+        for user_id in list(self._voice_sessions):
+            if user_id not in active_ids:
+                self._voice_sessions.pop(user_id, None)
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message) -> None:
+        if message.author.bot or message.guild is None:
+            return
+        await season_store.record(
+            message.author.id,
+            at=message.created_at,
+            messages=1,
+        )
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(
+        self,
+        member: discord.Member,
+        before: discord.VoiceState,
+        after: discord.VoiceState,
+    ) -> None:
+        if member.bot or before.channel == after.channel:
+            return
+
+        now = datetime.now(timezone.utc)
+        if before.channel is not None:
+            started_at = self._voice_sessions.pop(member.id, None)
+            if started_at is not None:
+                for season_id, seconds in split_interval_by_season(started_at, now):
+                    await season_store.record(
+                        member.id,
+                        season_id=season_id,
+                        at=now,
+                        voice_seconds=seconds,
+                    )
+
+        if after.channel is not None:
+            self._voice_sessions[member.id] = now
+
+    @tasks.loop(seconds=30)
+    async def flush_season_stats(self) -> None:
+        await season_store.flush()
+
+    @flush_season_stats.before_loop
+    async def before_flush_season_stats(self) -> None:
+        await self.bot.wait_until_ready()
+
+    @app_commands.command(
+        name="classement_saison",
+        description="Affiche le classement mensuel du Refuge",
+    )
+    @app_commands.describe(
+        categorie="Classement à afficher",
+        saison="Mois historique au format AAAA-MM (mois actuel par défaut)",
+    )
+    @app_commands.choices(
+        categorie=[
+            app_commands.Choice(name=metric.label, value=metric.key)
+            for metric in SEASON_METRICS
+        ]
+    )
+    async def classement_saison(
+        self,
+        interaction: discord.Interaction,
+        categorie: app_commands.Choice[str],
+        saison: str | None = None,
+    ) -> None:
+        metric = SEASON_METRICS_BY_KEY.get(categorie.value)
+        if metric is None:
+            await interaction.response.send_message(
+                "Catégorie saisonnière inconnue.", ephemeral=True
+            )
+            return
+
+        season_id = saison or season_id_for()
+        try:
+            parse_season_id(season_id)
+        except ValueError:
+            await interaction.response.send_message(
+                "Format de saison invalide. Utilise `AAAA-MM`, par exemple `2026-08`.",
+                ephemeral=True,
+            )
+            return
+
+        payload = await season_store.get_season(season_id)
+        if payload is None:
+            available = await season_store.list_seasons()
+            suffix = (
+                " Saisons disponibles : " + ", ".join(available[:6]) + "."
+                if available
+                else " Le suivi commencera avec la première activité enregistrée."
+            )
+            await interaction.response.send_message(
+                f"Aucune donnée pour {season_label(season_id)}.{suffix}",
+                ephemeral=True,
+            )
+            return
+
+        users = payload.get("users", {})
+        if not isinstance(users, dict):
+            users = {}
+        rows = rank_rows(users, metric.field)
+
+        lines: list[str] = []
+        for rank, (user_id, value) in enumerate(rows[:10], start=1):
+            display = f"<@{user_id}>"
+            if interaction.guild is not None:
+                try:
+                    member = interaction.guild.get_member(int(user_id))
+                except (TypeError, ValueError):
+                    member = None
+                if member is not None:
+                    if member.bot:
+                        continue
+                    display = member.display_name
+            medal = {1: "🥇", 2: "🥈", 3: "🥉"}.get(rank, f"**#{rank}**")
+            lines.append(
+                f"{medal} {display} — **{format_metric_value(metric.key, value)}**"
+            )
+
+        if not lines:
+            lines.append("Aucune activité enregistrée dans cette catégorie.")
+
+        started_at = payload.get("started_at")
+        tracking_note = ""
+        if started_at:
+            try:
+                started = datetime.fromisoformat(str(started_at))
+                tracking_note = f"\nSuivi de cette saison depuis <t:{int(started.timestamp())}:d>."
+            except ValueError:
+                pass
+
+        embed = discord.Embed(
+            title=f"🏆 {metric.label} — {season_label(season_id)}",
+            description="\n".join(lines) + tracking_note,
+        )
+        embed.set_footer(
+            text="Saisons mensuelles · Europe/Paris · historique conservé"
+        )
+        await interaction.response.send_message(embed=embed)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(SeasonalLeaderboardsCog(bot))

--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -31,8 +31,10 @@ from utils.persistence import (
 )
 from utils.metrics import measure
 from storage.xp_store import xp_store
+from storage.season_store import season_store
 from utils.game_events import get_multiplier, record_participant
 from utils.voice_bonus import get_voice_multiplier
+from utils.seasons import should_count_xp_source
 logger = logging.getLogger(__name__)
 
 # Fichiers de persistance
@@ -137,7 +139,7 @@ async def award_xp(
     """Modifie l'XP de ``user_id`` via le :class:`XPStore`.
 
     Lorsque ``amount`` est positif et que l'utilisateur bénéficie d'un bonus
-    « Double XP », le gain est doublé automatiquement. Les montants négatifs
+    « Double XP », le gain est doublé automatiquement. Les montants négatifs
     permettent de retirer de l'XP, sans bonus.
     """
     now = datetime.now(timezone.utc)
@@ -149,9 +151,21 @@ async def award_xp(
             else:
                 XP_BOOSTS.pop(str(user_id), None)
                 asyncio.create_task(save_xp_boosts_to_disk())
-    return await xp_store.add_xp(
+    result = await xp_store.add_xp(
         user_id, amount, guild_id=guild_id, source=source
     )
+    old_level, new_level, old_xp, new_xp = result
+    delta = new_xp - old_xp
+    if should_count_xp_source(source, delta):
+        try:
+            await season_store.record(user_id, at=now, xp_earned=delta)
+        except Exception:
+            logger.exception(
+                "[season] Impossible d'enregistrer %s XP saisonnière pour %s",
+                delta,
+                user_id,
+            )
+    return result
 
 
 def add_xp_boost(user_id: int, duration_minutes: int) -> None:

--- a/storage/season_store.py
+++ b/storage/season_store.py
@@ -5,7 +5,7 @@ import weakref
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from config import DATA_DIR
 from utils.persistence import atomic_write_json_async, read_json_safe
@@ -25,6 +25,7 @@ class SeasonStore:
         self._data: dict[str, Any] = {
             "schema_version": 1,
             "tracking_started_at": None,
+            "casino_baseline": {},
             "seasons": {},
         }
         self._locks: weakref.WeakKeyDictionary[
@@ -44,6 +45,7 @@ class SeasonStore:
             return
         raw = await asyncio.to_thread(read_json_safe, self.path, {})
         seasons: dict[str, Any] = {}
+        casino_baseline: dict[str, Any] = {}
         tracking_started_at = None
         if isinstance(raw, dict):
             raw_seasons = raw.get("seasons", {})
@@ -53,12 +55,20 @@ class SeasonStore:
                     for season_id, payload in raw_seasons.items()
                     if isinstance(payload, dict)
                 }
+            raw_baseline = raw.get("casino_baseline", {})
+            if isinstance(raw_baseline, dict):
+                casino_baseline = {
+                    str(user_id): dict(payload)
+                    for user_id, payload in raw_baseline.items()
+                    if isinstance(payload, dict)
+                }
             value = raw.get("tracking_started_at")
             if value:
                 tracking_started_at = str(value)
         self._data = {
             "schema_version": 1,
             "tracking_started_at": tracking_started_at,
+            "casino_baseline": casino_baseline,
             "seasons": seasons,
         }
         self._loaded = True
@@ -82,6 +92,31 @@ class SeasonStore:
             self._dirty = False
             return current
 
+    def _apply_increments_locked(
+        self,
+        user_id: int,
+        season_id: str,
+        timestamp: str,
+        increments: Mapping[str, int],
+    ) -> None:
+        if not self._data.get("tracking_started_at"):
+            self._data["tracking_started_at"] = timestamp
+
+        seasons = self._data["seasons"]
+        season = seasons.setdefault(
+            season_id,
+            {
+                "label": season_label(season_id),
+                "started_at": timestamp,
+                "users": {},
+            },
+        )
+        users = season.setdefault("users", {})
+        payload = users.setdefault(str(user_id), {})
+        for field, value in increments.items():
+            payload[field] = int(payload.get(field, 0)) + int(value)
+        self._dirty = True
+
     async def record(
         self,
         user_id: int,
@@ -103,30 +138,91 @@ class SeasonStore:
             return
 
         resolved_season_id = season_id or season_id_for(at)
-        now = (at or datetime.now(timezone.utc))
+        now = at or datetime.now(timezone.utc)
         if now.tzinfo is None:
             now = now.replace(tzinfo=timezone.utc)
         timestamp = now.astimezone(timezone.utc).isoformat()
 
         async with self._get_lock():
             await self._load_locked()
-            if not self._data.get("tracking_started_at"):
-                self._data["tracking_started_at"] = timestamp
-
-            seasons = self._data["seasons"]
-            season = seasons.setdefault(
+            self._apply_increments_locked(
+                user_id,
                 resolved_season_id,
-                {
-                    "label": season_label(resolved_season_id),
-                    "started_at": timestamp,
-                    "users": {},
-                },
+                timestamp,
+                normalized,
             )
-            users = season.setdefault("users", {})
-            payload = users.setdefault(str(user_id), {})
-            for field, value in normalized.items():
-                payload[field] = int(payload.get(field, 0)) + value
-            self._dirty = True
+
+    async def sync_casino_totals(
+        self,
+        players: Mapping[str, Mapping[str, Any]],
+        *,
+        at: datetime | None = None,
+    ) -> None:
+        """Convert cumulative casino totals into prospective seasonal deltas.
+
+        The first observation becomes a baseline only. Later observations are
+        diffed against that persisted baseline, so bot restarts do not duplicate
+        casino activity and pre-feature history is never backfilled.
+        """
+
+        now = at or datetime.now(timezone.utc)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        timestamp = now.astimezone(timezone.utc).isoformat()
+        resolved_season_id = season_id_for(now)
+
+        async with self._get_lock():
+            await self._load_locked()
+            baseline = self._data.setdefault("casino_baseline", {})
+
+            for raw_user_id, payload in players.items():
+                if not isinstance(payload, Mapping):
+                    continue
+                try:
+                    user_id = int(raw_user_id)
+                    current = {
+                        "bets": max(0, int(payload.get("bets", 0))),
+                        "wagered": max(0, int(payload.get("wagered", 0))),
+                        "winnings": max(0, int(payload.get("winnings", 0))),
+                    }
+                except (TypeError, ValueError):
+                    continue
+
+                previous = baseline.get(str(user_id))
+                baseline[str(user_id)] = current
+                if not isinstance(previous, dict):
+                    self._dirty = True
+                    continue
+
+                try:
+                    delta_bets = current["bets"] - int(previous.get("bets", 0))
+                    delta_wagered = current["wagered"] - int(
+                        previous.get("wagered", 0)
+                    )
+                    delta_winnings = current["winnings"] - int(
+                        previous.get("winnings", 0)
+                    )
+                except (TypeError, ValueError):
+                    self._dirty = True
+                    continue
+
+                # A reset/corruption of the source should reset the baseline,
+                # never fabricate negative seasonal activity.
+                if delta_bets < 0 or delta_wagered < 0 or delta_winnings < 0:
+                    self._dirty = True
+                    continue
+                if delta_bets == 0 and delta_wagered == 0 and delta_winnings == 0:
+                    continue
+
+                self._apply_increments_locked(
+                    user_id,
+                    resolved_season_id,
+                    timestamp,
+                    {
+                        "casino_bets": delta_bets,
+                        "casino_net": delta_winnings - delta_wagered,
+                    },
+                )
 
     async def get_season(self, season_id: str) -> dict[str, Any] | None:
         async with self._get_lock():

--- a/storage/season_store.py
+++ b/storage/season_store.py
@@ -25,6 +25,7 @@ class SeasonStore:
         self._data: dict[str, Any] = {
             "schema_version": 1,
             "tracking_started_at": None,
+            "casino_baseline_initialized": False,
             "casino_baseline": {},
             "seasons": {},
         }
@@ -46,6 +47,7 @@ class SeasonStore:
         raw = await asyncio.to_thread(read_json_safe, self.path, {})
         seasons: dict[str, Any] = {}
         casino_baseline: dict[str, Any] = {}
+        casino_baseline_initialized = False
         tracking_started_at = None
         if isinstance(raw, dict):
             raw_seasons = raw.get("seasons", {})
@@ -62,12 +64,16 @@ class SeasonStore:
                     for user_id, payload in raw_baseline.items()
                     if isinstance(payload, dict)
                 }
+            casino_baseline_initialized = bool(
+                raw.get("casino_baseline_initialized", False)
+            )
             value = raw.get("tracking_started_at")
             if value:
                 tracking_started_at = str(value)
         self._data = {
             "schema_version": 1,
             "tracking_started_at": tracking_started_at,
+            "casino_baseline_initialized": casino_baseline_initialized,
             "casino_baseline": casino_baseline,
             "seasons": seasons,
         }
@@ -160,9 +166,9 @@ class SeasonStore:
     ) -> None:
         """Convert cumulative casino totals into prospective seasonal deltas.
 
-        The first observation becomes a baseline only. Later observations are
-        diffed against that persisted baseline, so bot restarts do not duplicate
-        casino activity and pre-feature history is never backfilled.
+        Exactly one global snapshot is used as the deployment baseline. After
+        that, a player appearing for the first time is treated as genuinely new
+        activity and their cumulative counters are diffed from zero.
         """
 
         now = at or datetime.now(timezone.utc)
@@ -174,6 +180,9 @@ class SeasonStore:
         async with self._get_lock():
             await self._load_locked()
             baseline = self._data.setdefault("casino_baseline", {})
+            initializing = not bool(
+                self._data.get("casino_baseline_initialized", False)
+            )
 
             for raw_user_id, payload in players.items():
                 if not isinstance(payload, Mapping):
@@ -190,9 +199,11 @@ class SeasonStore:
 
                 previous = baseline.get(str(user_id))
                 baseline[str(user_id)] = current
-                if not isinstance(previous, dict):
+                if initializing:
                     self._dirty = True
                     continue
+                if not isinstance(previous, dict):
+                    previous = {"bets": 0, "wagered": 0, "winnings": 0}
 
                 try:
                     delta_bets = current["bets"] - int(previous.get("bets", 0))
@@ -223,6 +234,10 @@ class SeasonStore:
                         "casino_net": delta_winnings - delta_wagered,
                     },
                 )
+
+            if initializing:
+                self._data["casino_baseline_initialized"] = True
+                self._dirty = True
 
     async def get_season(self, season_id: str) -> dict[str, Any] | None:
         async with self._get_lock():

--- a/storage/season_store.py
+++ b/storage/season_store.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import asyncio
+import weakref
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from config import DATA_DIR
+from utils.persistence import atomic_write_json_async, read_json_safe
+from utils.seasons import SEASON_FIELDS, season_id_for, season_label
+
+
+SEASON_STATS_FILE = Path(DATA_DIR) / "season_stats.json"
+
+
+class SeasonStore:
+    """In-memory seasonal counters with periodic atomic persistence."""
+
+    def __init__(self, path: str | Path = SEASON_STATS_FILE) -> None:
+        self.path = Path(path)
+        self._loaded = False
+        self._dirty = False
+        self._data: dict[str, Any] = {
+            "schema_version": 1,
+            "tracking_started_at": None,
+            "seasons": {},
+        }
+        self._locks: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Lock
+        ] = weakref.WeakKeyDictionary()
+
+    def _get_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[loop] = lock
+        return lock
+
+    async def _load_locked(self) -> None:
+        if self._loaded:
+            return
+        raw = await asyncio.to_thread(read_json_safe, self.path, {})
+        seasons: dict[str, Any] = {}
+        tracking_started_at = None
+        if isinstance(raw, dict):
+            raw_seasons = raw.get("seasons", {})
+            if isinstance(raw_seasons, dict):
+                seasons = {
+                    str(season_id): dict(payload)
+                    for season_id, payload in raw_seasons.items()
+                    if isinstance(payload, dict)
+                }
+            value = raw.get("tracking_started_at")
+            if value:
+                tracking_started_at = str(value)
+        self._data = {
+            "schema_version": 1,
+            "tracking_started_at": tracking_started_at,
+            "seasons": seasons,
+        }
+        self._loaded = True
+
+    async def load(self) -> None:
+        async with self._get_lock():
+            await self._load_locked()
+
+    async def ensure_tracking_started(self) -> str:
+        """Set the first deployment timestamp once and keep it across seasons."""
+
+        async with self._get_lock():
+            await self._load_locked()
+            current = self._data.get("tracking_started_at")
+            if current:
+                return str(current)
+            current = datetime.now(timezone.utc).isoformat()
+            self._data["tracking_started_at"] = current
+            self._dirty = True
+            await atomic_write_json_async(self.path, self._data)
+            self._dirty = False
+            return current
+
+    async def record(
+        self,
+        user_id: int,
+        *,
+        season_id: str | None = None,
+        at: datetime | None = None,
+        **increments: int,
+    ) -> None:
+        """Add one or more metric deltas to a season without immediate disk I/O."""
+
+        normalized: dict[str, int] = {}
+        for field, raw_value in increments.items():
+            if field not in SEASON_FIELDS:
+                raise ValueError(f"unsupported season metric: {field}")
+            value = int(raw_value)
+            if value:
+                normalized[field] = value
+        if not normalized:
+            return
+
+        resolved_season_id = season_id or season_id_for(at)
+        now = (at or datetime.now(timezone.utc))
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        timestamp = now.astimezone(timezone.utc).isoformat()
+
+        async with self._get_lock():
+            await self._load_locked()
+            if not self._data.get("tracking_started_at"):
+                self._data["tracking_started_at"] = timestamp
+
+            seasons = self._data["seasons"]
+            season = seasons.setdefault(
+                resolved_season_id,
+                {
+                    "label": season_label(resolved_season_id),
+                    "started_at": timestamp,
+                    "users": {},
+                },
+            )
+            users = season.setdefault("users", {})
+            payload = users.setdefault(str(user_id), {})
+            for field, value in normalized.items():
+                payload[field] = int(payload.get(field, 0)) + value
+            self._dirty = True
+
+    async def get_season(self, season_id: str) -> dict[str, Any] | None:
+        async with self._get_lock():
+            await self._load_locked()
+            payload = self._data["seasons"].get(season_id)
+            return deepcopy(payload) if isinstance(payload, dict) else None
+
+    async def list_seasons(self) -> list[str]:
+        async with self._get_lock():
+            await self._load_locked()
+            return sorted(self._data["seasons"].keys(), reverse=True)
+
+    async def tracking_started_at(self) -> str | None:
+        async with self._get_lock():
+            await self._load_locked()
+            value = self._data.get("tracking_started_at")
+            return str(value) if value else None
+
+    async def flush(self) -> None:
+        """Atomically persist the latest snapshot only when counters changed."""
+
+        async with self._get_lock():
+            await self._load_locked()
+            if not self._dirty:
+                return
+            await atomic_write_json_async(self.path, self._data)
+            self._dirty = False
+
+
+season_store = SeasonStore()
+
+
+__all__ = ["SEASON_STATS_FILE", "SeasonStore", "season_store"]

--- a/tests/test_seasonal_leaderboards.py
+++ b/tests/test_seasonal_leaderboards.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cogs.xp as xp
+from storage.season_store import SeasonStore
+from utils.persistence import read_json_safe
+from utils.seasons import (
+    rank_rows,
+    season_id_for,
+    should_count_xp_source,
+    split_interval_by_season,
+)
+from utils.timezones import PARIS_TZ
+
+
+def test_season_id_uses_paris_calendar_month():
+    # 22:30 UTC on July 31 is already August 1 in Paris (UTC+2).
+    moment = datetime(2026, 7, 31, 22, 30, tzinfo=timezone.utc)
+    assert season_id_for(moment) == "2026-08"
+
+
+def test_voice_interval_is_split_across_month_boundary():
+    start = datetime(2026, 8, 31, 23, 30, tzinfo=PARIS_TZ)
+    end = datetime(2026, 9, 1, 0, 30, tzinfo=PARIS_TZ)
+
+    assert split_interval_by_season(start, end) == [
+        ("2026-08", 1800),
+        ("2026-09", 1800),
+    ]
+
+
+def test_staff_grants_do_not_count_as_competitive_xp():
+    assert should_count_xp_source("message", 8) is True
+    assert should_count_xp_source("voice_leave", 90) is True
+    assert should_count_xp_source("don_xp", 500) is False
+    assert should_count_xp_source("message", 0) is False
+    assert should_count_xp_source("pari_xp", -100) is False
+
+
+def test_casino_ranking_keeps_players_with_negative_net_results():
+    rows = rank_rows(
+        {
+            "1": {"casino_bets": 3, "casino_net": -50},
+            "2": {"casino_bets": 1, "casino_net": 200},
+            "3": {"casino_bets": 0, "casino_net": 999},
+        },
+        "casino_net",
+    )
+
+    assert rows == [("2", 200), ("1", -50)]
+
+
+@pytest.mark.asyncio
+async def test_store_keeps_months_separate_and_persists(tmp_path):
+    path = tmp_path / "season_stats.json"
+    store = SeasonStore(path)
+
+    await store.record(
+        42,
+        at=datetime(2026, 8, 31, 20, tzinfo=timezone.utc),
+        messages=3,
+        xp_earned=24,
+    )
+    await store.record(
+        42,
+        at=datetime(2026, 9, 1, 20, tzinfo=timezone.utc),
+        messages=2,
+        xp_earned=16,
+    )
+    await store.flush()
+
+    persisted = read_json_safe(path, {})
+    assert persisted["seasons"]["2026-08"]["users"]["42"]["messages"] == 3
+    assert persisted["seasons"]["2026-09"]["users"]["42"]["messages"] == 2
+    assert persisted["seasons"]["2026-08"]["users"]["42"]["xp_earned"] == 24
+    assert persisted["seasons"]["2026-09"]["users"]["42"]["xp_earned"] == 16
+
+
+@pytest.mark.asyncio
+async def test_first_casino_snapshot_is_baseline_only_and_survives_restart(tmp_path):
+    path = tmp_path / "season_stats.json"
+    first = SeasonStore(path)
+    moment = datetime(2026, 8, 8, 18, tzinfo=timezone.utc)
+
+    await first.sync_casino_totals(
+        {"1": {"bets": 10, "wagered": 1000, "winnings": 1200}},
+        at=moment,
+    )
+    assert await first.get_season("2026-08") is None
+    await first.flush()
+
+    restarted = SeasonStore(path)
+    await restarted.sync_casino_totals(
+        {"1": {"bets": 12, "wagered": 1200, "winnings": 1300}},
+        at=moment,
+    )
+
+    season = await restarted.get_season("2026-08")
+    assert season is not None
+    assert season["users"]["1"]["casino_bets"] == 2
+    assert season["users"]["1"]["casino_net"] == -100
+
+
+@pytest.mark.asyncio
+async def test_new_casino_player_counts_from_zero_after_global_baseline(tmp_path):
+    store = SeasonStore(tmp_path / "season_stats.json")
+    moment = datetime(2026, 8, 8, 18, tzinfo=timezone.utc)
+
+    await store.sync_casino_totals(
+        {"1": {"bets": 5, "wagered": 500, "winnings": 400}},
+        at=moment,
+    )
+    await store.sync_casino_totals(
+        {
+            "1": {"bets": 5, "wagered": 500, "winnings": 400},
+            "2": {"bets": 1, "wagered": 100, "winnings": 200},
+        },
+        at=moment,
+    )
+
+    season = await store.get_season("2026-08")
+    assert season is not None
+    assert season["users"]["2"]["casino_bets"] == 1
+    assert season["users"]["2"]["casino_net"] == 100
+
+
+@pytest.mark.asyncio
+async def test_award_xp_records_actual_positive_delta(monkeypatch):
+    xp.XP_BOOSTS.clear()
+    add_xp = AsyncMock(return_value=(2, 2, 200, 208))
+    record = AsyncMock()
+    monkeypatch.setattr(xp.xp_store, "add_xp", add_xp)
+    monkeypatch.setattr(xp.season_store, "record", record)
+
+    result = await xp.award_xp(7, 8, guild_id=123, source="message")
+
+    assert result == (2, 2, 200, 208)
+    record.assert_awaited_once()
+    kwargs = record.await_args.kwargs
+    assert kwargs["xp_earned"] == 8
+
+
+@pytest.mark.asyncio
+async def test_award_xp_excludes_staff_grants(monkeypatch):
+    xp.XP_BOOSTS.clear()
+    monkeypatch.setattr(
+        xp.xp_store,
+        "add_xp",
+        AsyncMock(return_value=(2, 3, 200, 700)),
+    )
+    record = AsyncMock()
+    monkeypatch.setattr(xp.season_store, "record", record)
+
+    await xp.award_xp(7, 500, guild_id=123, source="don_xp")
+
+    record.assert_not_awaited()

--- a/utils/seasons.py
+++ b/utils/seasons.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Iterable
 
 from utils.timezones import PARIS_TZ
 
@@ -145,11 +144,12 @@ def rank_rows(
             continue
         try:
             value = int(payload.get(field, 0))
+            casino_bets = int(payload.get("casino_bets", 0) or 0)
         except (TypeError, ValueError):
             continue
         if field != "casino_net" and value <= 0:
             continue
-        if field == "casino_net" and int(payload.get("casino_bets", 0) or 0) <= 0:
+        if field == "casino_net" and casino_bets <= 0:
             continue
         rows.append((str(user_id), value))
     rows.sort(key=lambda row: (row[1], row[0]), reverse=True)

--- a/utils/seasons.py
+++ b/utils/seasons.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Iterable
+
+from utils.timezones import PARIS_TZ
+
+
+MONTH_NAMES_FR = (
+    "janvier",
+    "février",
+    "mars",
+    "avril",
+    "mai",
+    "juin",
+    "juillet",
+    "août",
+    "septembre",
+    "octobre",
+    "novembre",
+    "décembre",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SeasonMetric:
+    key: str
+    label: str
+    field: str
+    unit: str
+
+
+SEASON_METRICS: tuple[SeasonMetric, ...] = (
+    SeasonMetric("xp", "XP gagnée", "xp_earned", "XP"),
+    SeasonMetric("messages", "Messages", "messages", "messages"),
+    SeasonMetric("vocal", "Temps vocal", "voice_seconds", "secondes"),
+    SeasonMetric("casino", "Casino net", "casino_net", "XP net"),
+)
+SEASON_METRICS_BY_KEY = {metric.key: metric for metric in SEASON_METRICS}
+SEASON_FIELDS = frozenset(
+    {metric.field for metric in SEASON_METRICS} | {"casino_bets"}
+)
+
+# Staff grants should not influence a competitive XP season.
+EXCLUDED_XP_SOURCES = frozenset({"don_xp"})
+
+
+def _as_paris(dt: datetime | None = None) -> datetime:
+    current = dt or datetime.now(PARIS_TZ)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=PARIS_TZ)
+    return current.astimezone(PARIS_TZ)
+
+
+def season_id_for(dt: datetime | None = None) -> str:
+    """Return the calendar-month season identifier in Europe/Paris."""
+
+    current = _as_paris(dt)
+    return f"{current.year:04d}-{current.month:02d}"
+
+
+def parse_season_id(season_id: str) -> tuple[int, int]:
+    """Validate and parse a ``YYYY-MM`` season identifier."""
+
+    try:
+        year_text, month_text = season_id.split("-", 1)
+        year = int(year_text)
+        month = int(month_text)
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ValueError("season_id must use YYYY-MM") from exc
+    if len(year_text) != 4 or len(month_text) != 2 or not 1 <= month <= 12:
+        raise ValueError("season_id must use YYYY-MM")
+    return year, month
+
+
+def season_bounds(season_id: str) -> tuple[datetime, datetime]:
+    """Return inclusive start and exclusive end for one Paris calendar month."""
+
+    year, month = parse_season_id(season_id)
+    start = datetime(year, month, 1, tzinfo=PARIS_TZ)
+    if month == 12:
+        end = datetime(year + 1, 1, 1, tzinfo=PARIS_TZ)
+    else:
+        end = datetime(year, month + 1, 1, tzinfo=PARIS_TZ)
+    return start, end
+
+
+def season_label(season_id: str) -> str:
+    year, month = parse_season_id(season_id)
+    return f"{MONTH_NAMES_FR[month - 1].capitalize()} {year}"
+
+
+def should_count_xp_source(source: str, delta: int) -> bool:
+    return delta > 0 and source not in EXCLUDED_XP_SOURCES
+
+
+def split_interval_by_season(
+    started_at: datetime,
+    ended_at: datetime,
+) -> list[tuple[str, int]]:
+    """Split a voice interval across Paris month boundaries."""
+
+    start = _as_paris(started_at)
+    end = _as_paris(ended_at)
+    if end <= start:
+        return []
+
+    parts: list[tuple[str, int]] = []
+    cursor = start
+    while cursor < end:
+        season_id = season_id_for(cursor)
+        _, season_end = season_bounds(season_id)
+        chunk_end = min(end, season_end)
+        seconds = int((chunk_end - cursor).total_seconds())
+        if seconds > 0:
+            parts.append((season_id, seconds))
+        cursor = chunk_end
+    return parts
+
+
+def format_metric_value(metric_key: str, value: int) -> str:
+    if metric_key == "xp":
+        return f"{value} XP"
+    if metric_key == "messages":
+        return f"{value} messages"
+    if metric_key == "vocal":
+        hours, remainder = divmod(max(0, value), 3600)
+        minutes = remainder // 60
+        return f"{hours}h {minutes:02d}m"
+    if metric_key == "casino":
+        return f"{value:+d} XP net"
+    return str(value)
+
+
+def rank_rows(
+    users: dict[str, dict[str, int]],
+    field: str,
+) -> list[tuple[str, int]]:
+    """Return positive/meaningful rows sorted descending for one metric."""
+
+    rows: list[tuple[str, int]] = []
+    for user_id, payload in users.items():
+        if not isinstance(payload, dict):
+            continue
+        try:
+            value = int(payload.get(field, 0))
+        except (TypeError, ValueError):
+            continue
+        if field != "casino_net" and value <= 0:
+            continue
+        if field == "casino_net" and int(payload.get("casino_bets", 0) or 0) <= 0:
+            continue
+        rows.append((str(user_id), value))
+    rows.sort(key=lambda row: (row[1], row[0]), reverse=True)
+    return rows
+
+
+__all__ = [
+    "SEASON_METRICS",
+    "SEASON_METRICS_BY_KEY",
+    "SEASON_FIELDS",
+    "EXCLUDED_XP_SOURCES",
+    "SeasonMetric",
+    "format_metric_value",
+    "parse_season_id",
+    "rank_rows",
+    "season_bounds",
+    "season_id_for",
+    "season_label",
+    "should_count_xp_source",
+    "split_interval_by_season",
+]


### PR DESCRIPTION
## Objectif
Ajouter des classements saisonniers mensuels sans remettre à zéro ni altérer les statistiques globales existantes.

## Fonctionnement
- saisons mensuelles basées sur le fuseau Europe/Paris (`AAAA-MM`) ;
- 4 classements : XP gagnée, messages, temps vocal, casino net ;
- historique conservé par mois dans `season_stats.json` ;
- commande `/classement_saison` avec choix de catégorie et consultation facultative d'une saison historique ;
- top 10 avec podium et format adapté à chaque métrique ;
- aucune donnée antérieure au déploiement n'est inventée ou rétroactivement injectée.

## Règles de comptage
- XP : seul le delta positif réellement crédité compte ; les dons staff `don_xp` sont exclus ;
- le bonus quotidien du premier message compte bien dans l'XP saisonnière ;
- messages : chaque message non-bot sur le serveur compte ;
- vocal : durée réelle, avec découpage correct si une session traverse un changement de mois ;
- casino : résultat net `gains - mises`, calculé à partir des compteurs persistants existants.

## Sécurité / isolation
- aucune remise à zéro de l'XP, du casino ou des statistiques globales ;
- la roulette XP n'est pas modifiée ; le casino est suivi par delta sur un baseline persistant ;
- le premier snapshot casino sert uniquement de baseline afin de ne pas importer l'historique préexistant ;
- les nouveaux joueurs casino apparus après ce baseline sont comptés dès leur premier pari ;
- une erreur du stockage saisonnier ne bloque jamais un crédit XP principal ;
- les écritures saisonnières sont regroupées et flushées périodiquement, pas à chaque message.

## Tests
`tests/test_seasonal_leaderboards.py` couvre notamment :
- bascule de mois selon l'heure de Paris ;
- session vocale traversant deux saisons ;
- exclusion des dons staff de l'XP compétitive ;
- classement casino avec résultats nets négatifs ;
- séparation/persistance des mois ;
- baseline casino non rétroactif et persistant après redémarrage ;
- premier nouveau joueur casino après baseline ;
- raccord `award_xp()` sur le delta positif réel.

## Portée
6 fichiers :
- nouveaux : `cogs/seasonal_leaderboards.py`, `storage/season_store.py`, `utils/seasons.py`, `tests/test_seasonal_leaderboards.py` ;
- raccords ciblés : `cogs/xp.py`, `cogs/first_message.py`.

La roulette, les prix, les règles de gain, les niveaux et les soldes XP ne sont pas modifiés.

## Validation
La branche part du `main` après la PR #506. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation utilisateur.