### PR TITLE
feat: add community goals

### DIFF
--- a/cogs/community_goals.py
+++ b/cogs/community_goals.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import discord
+from discord import app_commands
+from discord.ext import commands, tasks
+
+from config import ANNOUNCE_CHANNEL_ID
+from storage.community_goal_store import ACTIVE_STATUS, community_goal_store
+from storage.season_store import season_store
+from utils.community_goals import (
+    COMMUNITY_GOAL_METRICS,
+    COMMUNITY_GOAL_METRICS_BY_KEY,
+    aggregate_metric_total,
+    format_goal_value,
+    goal_progress,
+    progress_bar,
+    progress_percent,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class CommunityGoalsCog(commands.Cog):
+    """Staff-created collective objectives backed by seasonal activity data."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def cog_load(self) -> None:
+        self.evaluate_community_goals.start()
+
+    def cog_unload(self) -> None:
+        self.evaluate_community_goals.cancel()
+
+    async def _metric_total(self, field: str) -> int:
+        season_ids = await season_store.list_seasons()
+        payloads: list[dict[str, Any]] = []
+        for season_id in season_ids:
+            payload = await season_store.get_season(season_id)
+            if isinstance(payload, dict):
+                payloads.append(payload)
+        return aggregate_metric_total(payloads, field)
+
+    async def _goal_progress(self, goal: dict[str, Any]) -> int:
+        metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(str(goal.get("metric_key", "")))
+        if metric is None:
+            return 0
+        current_total = await self._metric_total(metric.season_field)
+        return goal_progress(
+            current_total,
+            int(goal.get("baseline_total", 0)),
+            int(goal.get("target", 0)),
+        )
+
+    async def _announce_completion(
+        self,
+        goal: dict[str, Any],
+        progress: int,
+    ) -> None:
+        if ANNOUNCE_CHANNEL_ID <= 0:
+            return
+        channel = self.bot.get_channel(ANNOUNCE_CHANNEL_ID)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(ANNOUNCE_CHANNEL_ID)
+            except discord.HTTPException:
+                return
+        if not isinstance(channel, (discord.TextChannel, discord.Thread)):
+            return
+
+        metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(str(goal.get("metric_key", "")))
+        if metric is None:
+            return
+        title = str(goal.get("title") or metric.label)
+        target = int(goal.get("target", 0))
+        reward = goal.get("reward_text")
+        description = (
+            f"🎉 La communauté a atteint **{title}** !\n"
+            f"{metric.emoji} {format_goal_value(metric.key, progress)} / "
+            f"{format_goal_value(metric.key, target)}"
+        )
+        if reward:
+            description += f"\n🎁 Récompense prévue : **{reward}**"
+        embed = discord.Embed(title="🏆 Objectif communautaire atteint", description=description)
+        try:
+            await channel.send(embed=embed)
+        except discord.HTTPException:
+            logger.warning("Impossible d'annoncer l'objectif communautaire atteint")
+
+    async def _evaluate_goals(self) -> None:
+        active_goals = await community_goal_store.list_goals(status=ACTIVE_STATUS)
+        if not active_goals:
+            return
+
+        now = datetime.now(timezone.utc)
+        totals: dict[str, int] = {}
+        for goal in active_goals:
+            metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(str(goal.get("metric_key", "")))
+            if metric is None:
+                continue
+            if metric.season_field not in totals:
+                totals[metric.season_field] = await self._metric_total(metric.season_field)
+
+            progress = goal_progress(
+                totals[metric.season_field],
+                int(goal.get("baseline_total", 0)),
+                int(goal.get("target", 0)),
+            )
+            try:
+                ends_at = datetime.fromisoformat(str(goal.get("ends_at")))
+                if ends_at.tzinfo is None:
+                    ends_at = ends_at.replace(tzinfo=timezone.utc)
+            except (TypeError, ValueError):
+                ends_at = now
+
+            if now >= ends_at:
+                await community_goal_store.finish_goal(
+                    str(goal["id"]),
+                    status="expired",
+                    final_progress=progress,
+                    at=now,
+                )
+                continue
+
+            if progress >= int(goal.get("target", 0)):
+                finished = await community_goal_store.finish_goal(
+                    str(goal["id"]),
+                    status="completed",
+                    final_progress=progress,
+                    at=now,
+                )
+                if finished is not None:
+                    await self._announce_completion(finished, progress)
+
+    @tasks.loop(minutes=1)
+    async def evaluate_community_goals(self) -> None:
+        try:
+            await self._evaluate_goals()
+        except Exception:
+            logger.exception("Erreur pendant l'évaluation des objectifs communautaires")
+
+    @evaluate_community_goals.before_loop
+    async def before_evaluate_community_goals(self) -> None:
+        await self.bot.wait_until_ready()
+
+    @app_commands.command(
+        name="objectif_communaute",
+        description="Affiche les objectifs communautaires en cours",
+    )
+    async def objectif_communaute(self, interaction: discord.Interaction) -> None:
+        await self._evaluate_goals()
+        active_goals = await community_goal_store.list_goals(status=ACTIVE_STATUS)
+        completed = await community_goal_store.list_goals(status="completed")
+
+        embed = discord.Embed(title="🎯 Objectifs communautaires")
+        if not active_goals:
+            embed.description = "Aucun objectif communautaire actif pour le moment."
+        else:
+            for goal in active_goals:
+                metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(
+                    str(goal.get("metric_key", ""))
+                )
+                if metric is None:
+                    continue
+                progress = await self._goal_progress(goal)
+                target = int(goal.get("target", 0))
+                percent = progress_percent(progress, target)
+                try:
+                    ends_at = datetime.fromisoformat(str(goal.get("ends_at")))
+                    end_timestamp = int(ends_at.timestamp())
+                    deadline = f"<t:{end_timestamp}:R>"
+                except (TypeError, ValueError):
+                    deadline = "échéance inconnue"
+
+                title = str(goal.get("title") or metric.label)
+                value = (
+                    f"{progress_bar(progress, target)} **{percent}%**\n"
+                    f"{metric.emoji} {format_goal_value(metric.key, progress)} / "
+                    f"{format_goal_value(metric.key, target)}\n"
+                    f"⏳ Fin {deadline}"
+                )
+                if goal.get("reward_text"):
+                    value += f"\n🎁 Récompense prévue : {goal['reward_text']}"
+                embed.add_field(name=title, value=value, inline=False)
+
+        if completed:
+            recent = completed[:3]
+            lines = []
+            for goal in recent:
+                metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(
+                    str(goal.get("metric_key", ""))
+                )
+                if metric is None:
+                    continue
+                title = str(goal.get("title") or metric.label)
+                lines.append(f"✅ {title}")
+            if lines:
+                embed.add_field(
+                    name="Derniers objectifs réussis",
+                    value="\n".join(lines),
+                    inline=False,
+                )
+
+        embed.set_footer(text="Progression calculée depuis la création de chaque objectif")
+        await interaction.response.send_message(embed=embed)
+
+    @app_commands.command(
+        name="objectif_creer",
+        description="Crée un objectif communautaire",
+    )
+    @app_commands.checks.has_permissions(manage_guild=True)
+    @app_commands.describe(
+        categorie="Type de progression collective",
+        cible="Valeur à atteindre (heures pour le vocal)",
+        duree_jours="Durée de l'objectif en jours",
+        titre="Titre personnalisé facultatif",
+        recompense="Récompense prévue, affichée sans distribution automatique",
+    )
+    @app_commands.choices(
+        categorie=[
+            app_commands.Choice(name=metric.label, value=metric.key)
+            for metric in COMMUNITY_GOAL_METRICS
+        ]
+    )
+    async def objectif_creer(
+        self,
+        interaction: discord.Interaction,
+        categorie: app_commands.Choice[str],
+        cible: app_commands.Range[int, 1, 10_000_000],
+        duree_jours: app_commands.Range[int, 1, 90],
+        titre: str | None = None,
+        recompense: str | None = None,
+    ) -> None:
+        await self._evaluate_goals()
+        metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(categorie.value)
+        if metric is None:
+            await interaction.response.send_message(
+                "Catégorie d'objectif inconnue.", ephemeral=True
+            )
+            return
+
+        target = metric.to_base_value(int(cible))
+        baseline = await self._metric_total(metric.season_field)
+        now = datetime.now(timezone.utc)
+        try:
+            goal = await community_goal_store.create_goal(
+                metric_key=metric.key,
+                target=target,
+                baseline_total=baseline,
+                created_by=interaction.user.id,
+                created_at=now,
+                ends_at=now + timedelta(days=int(duree_jours)),
+                title=titre,
+                reward_text=recompense,
+            )
+        except ValueError as exc:
+            if "already exists" in str(exc):
+                message = "Un objectif actif existe déjà pour cette catégorie."
+            else:
+                message = "Impossible de créer cet objectif."
+            await interaction.response.send_message(message, ephemeral=True)
+            return
+
+        end_timestamp = int(datetime.fromisoformat(str(goal["ends_at"])).timestamp())
+        await interaction.response.send_message(
+            (
+                f"✅ Objectif créé : **{goal.get('title') or metric.label}**\n"
+                f"Cible : **{format_goal_value(metric.key, target)}**\n"
+                f"Fin : <t:{end_timestamp}:F>"
+            ),
+            ephemeral=True,
+        )
+
+    @app_commands.command(
+        name="objectif_annuler",
+        description="Annule l'objectif actif d'une catégorie",
+    )
+    @app_commands.checks.has_permissions(manage_guild=True)
+    @app_commands.choices(
+        categorie=[
+            app_commands.Choice(name=metric.label, value=metric.key)
+            for metric in COMMUNITY_GOAL_METRICS
+        ]
+    )
+    async def objectif_annuler(
+        self,
+        interaction: discord.Interaction,
+        categorie: app_commands.Choice[str],
+    ) -> None:
+        await self._evaluate_goals()
+        active_goals = await community_goal_store.list_goals(status=ACTIVE_STATUS)
+        goal = next(
+            (
+                item
+                for item in active_goals
+                if item.get("metric_key") == categorie.value
+            ),
+            None,
+        )
+        if goal is None:
+            await interaction.response.send_message(
+                "Aucun objectif actif dans cette catégorie.", ephemeral=True
+            )
+            return
+        progress = await self._goal_progress(goal)
+        await community_goal_store.finish_goal(
+            str(goal["id"]),
+            status="cancelled",
+            final_progress=progress,
+        )
+        await interaction.response.send_message("Objectif annulé.", ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(CommunityGoalsCog(bot))

--- a/storage/community_goal_store.py
+++ b/storage/community_goal_store.py
@@ -147,23 +147,6 @@ class CommunityGoalStore:
             await atomic_write_json_async(self.path, self._data)
             return deepcopy(payload)
 
-    async def cancel_active_metric(
-        self,
-        metric_key: str,
-        *,
-        at: datetime | None = None,
-    ) -> dict[str, Any] | None:
-        active = await self.list_goals(status=ACTIVE_STATUS)
-        for goal in active:
-            if goal.get("metric_key") == metric_key:
-                return await self.finish_goal(
-                    str(goal["id"]),
-                    status="cancelled",
-                    final_progress=int(goal.get("final_progress") or 0),
-                    at=at,
-                )
-        return None
-
 
 community_goal_store = CommunityGoalStore()
 

--- a/storage/community_goal_store.py
+++ b/storage/community_goal_store.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+import weakref
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from config import DATA_DIR
+from utils.persistence import atomic_write_json_async, read_json_safe
+
+
+COMMUNITY_GOALS_FILE = Path(DATA_DIR) / "community_goals.json"
+ACTIVE_STATUS = "active"
+TERMINAL_STATUSES = frozenset({"completed", "expired", "cancelled"})
+
+
+class CommunityGoalStore:
+    """Persist staff-created community goals and their lifecycle."""
+
+    def __init__(self, path: str | Path = COMMUNITY_GOALS_FILE) -> None:
+        self.path = Path(path)
+        self._loaded = False
+        self._data: dict[str, Any] = {"schema_version": 1, "goals": {}}
+        self._locks: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Lock
+        ] = weakref.WeakKeyDictionary()
+
+    def _get_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[loop] = lock
+        return lock
+
+    async def _load_locked(self) -> None:
+        if self._loaded:
+            return
+        raw = await asyncio.to_thread(read_json_safe, self.path, {})
+        goals: dict[str, Any] = {}
+        if isinstance(raw, dict):
+            raw_goals = raw.get("goals", {})
+            if isinstance(raw_goals, dict):
+                goals = {
+                    str(goal_id): dict(payload)
+                    for goal_id, payload in raw_goals.items()
+                    if isinstance(payload, dict)
+                }
+        self._data = {"schema_version": 1, "goals": goals}
+        self._loaded = True
+
+    async def create_goal(
+        self,
+        *,
+        metric_key: str,
+        target: int,
+        baseline_total: int,
+        created_by: int,
+        ends_at: datetime,
+        title: str | None = None,
+        reward_text: str | None = None,
+        created_at: datetime | None = None,
+    ) -> dict[str, Any]:
+        now = created_at or datetime.now(timezone.utc)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        end = ends_at
+        if end.tzinfo is None:
+            end = end.replace(tzinfo=timezone.utc)
+        if end <= now:
+            raise ValueError("ends_at must be after created_at")
+        if int(target) <= 0:
+            raise ValueError("target must be positive")
+
+        async with self._get_lock():
+            await self._load_locked()
+            goals = self._data["goals"]
+            for payload in goals.values():
+                if (
+                    isinstance(payload, dict)
+                    and payload.get("status") == ACTIVE_STATUS
+                    and payload.get("metric_key") == metric_key
+                ):
+                    raise ValueError("an active goal already exists for this metric")
+
+            goal_id = uuid.uuid4().hex[:10]
+            payload = {
+                "id": goal_id,
+                "metric_key": str(metric_key),
+                "target": int(target),
+                "baseline_total": int(baseline_total),
+                "created_by": int(created_by),
+                "created_at": now.astimezone(timezone.utc).isoformat(),
+                "ends_at": end.astimezone(timezone.utc).isoformat(),
+                "title": str(title).strip() if title else None,
+                "reward_text": str(reward_text).strip() if reward_text else None,
+                "status": ACTIVE_STATUS,
+                "completed_at": None,
+                "expired_at": None,
+                "cancelled_at": None,
+                "final_progress": None,
+            }
+            goals[goal_id] = payload
+            await atomic_write_json_async(self.path, self._data)
+            return deepcopy(payload)
+
+    async def list_goals(self, *, status: str | None = None) -> list[dict[str, Any]]:
+        async with self._get_lock():
+            await self._load_locked()
+            items = [
+                deepcopy(payload)
+                for payload in self._data["goals"].values()
+                if isinstance(payload, dict)
+                and (status is None or payload.get("status") == status)
+            ]
+        items.sort(key=lambda item: str(item.get("created_at", "")), reverse=True)
+        return items
+
+    async def finish_goal(
+        self,
+        goal_id: str,
+        *,
+        status: str,
+        final_progress: int,
+        at: datetime | None = None,
+    ) -> dict[str, Any] | None:
+        if status not in TERMINAL_STATUSES:
+            raise ValueError("invalid terminal status")
+        now = at or datetime.now(timezone.utc)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+        timestamp = now.astimezone(timezone.utc).isoformat()
+
+        async with self._get_lock():
+            await self._load_locked()
+            payload = self._data["goals"].get(str(goal_id))
+            if not isinstance(payload, dict):
+                return None
+            if payload.get("status") != ACTIVE_STATUS:
+                return deepcopy(payload)
+            payload["status"] = status
+            payload["final_progress"] = max(0, int(final_progress))
+            payload[f"{status}_at"] = timestamp
+            await atomic_write_json_async(self.path, self._data)
+            return deepcopy(payload)
+
+    async def cancel_active_metric(
+        self,
+        metric_key: str,
+        *,
+        at: datetime | None = None,
+    ) -> dict[str, Any] | None:
+        active = await self.list_goals(status=ACTIVE_STATUS)
+        for goal in active:
+            if goal.get("metric_key") == metric_key:
+                return await self.finish_goal(
+                    str(goal["id"]),
+                    status="cancelled",
+                    final_progress=int(goal.get("final_progress") or 0),
+                    at=at,
+                )
+        return None
+
+
+community_goal_store = CommunityGoalStore()
+
+
+__all__ = [
+    "ACTIVE_STATUS",
+    "COMMUNITY_GOALS_FILE",
+    "CommunityGoalStore",
+    "TERMINAL_STATUSES",
+    "community_goal_store",
+]

--- a/tests/test_community_goals.py
+++ b/tests/test_community_goals.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from storage.community_goal_store import CommunityGoalStore
+from utils.community_goals import (
+    COMMUNITY_GOAL_METRICS_BY_KEY,
+    aggregate_metric_total,
+    format_goal_value,
+    goal_progress,
+    progress_bar,
+    progress_percent,
+)
+
+
+def test_goal_metric_units_and_formatting():
+    vocal = COMMUNITY_GOAL_METRICS_BY_KEY["vocal"]
+    assert vocal.to_base_value(25) == 25 * 3600
+    assert format_goal_value("vocal", 25 * 3600 + 30 * 60) == "25h 30m"
+
+    xp = COMMUNITY_GOAL_METRICS_BY_KEY["xp"]
+    assert xp.to_base_value(5000) == 5000
+    assert format_goal_value("xp", 5000) == "5000 XP"
+
+
+def test_aggregate_metric_total_across_seasons_and_users():
+    seasons = [
+        {
+            "users": {
+                "1": {"messages": 10, "voice_seconds": 120},
+                "2": {"messages": 7, "voice_seconds": 60},
+            }
+        },
+        {
+            "users": {
+                "1": {"messages": 5, "voice_seconds": 30},
+                "3": {"messages": 8},
+            }
+        },
+    ]
+
+    assert aggregate_metric_total(seasons, "messages") == 30
+    assert aggregate_metric_total(seasons, "voice_seconds") == 210
+
+
+def test_goal_progress_uses_creation_baseline_only():
+    assert goal_progress(1250, 1000, 500) == 250
+    assert goal_progress(900, 1000, 500) == 0
+    assert progress_percent(250, 500) == 50
+    assert progress_percent(700, 500) == 100
+    assert progress_bar(250, 500) == "█████░░░░░"
+
+
+@pytest.mark.asyncio
+async def test_store_rejects_second_active_goal_for_same_metric(tmp_path):
+    store = CommunityGoalStore(tmp_path / "goals.json")
+    now = datetime(2026, 8, 8, 18, 0, tzinfo=timezone.utc)
+
+    first = await store.create_goal(
+        metric_key="messages",
+        target=1000,
+        baseline_total=500,
+        created_by=42,
+        created_at=now,
+        ends_at=now + timedelta(days=7),
+        title="Semaine active",
+    )
+    assert first["status"] == "active"
+
+    with pytest.raises(ValueError, match="already exists"):
+        await store.create_goal(
+            metric_key="messages",
+            target=2000,
+            baseline_total=500,
+            created_by=42,
+            created_at=now,
+            ends_at=now + timedelta(days=14),
+        )
+
+
+@pytest.mark.asyncio
+async def test_finished_goal_allows_new_goal_same_metric(tmp_path):
+    path = tmp_path / "goals.json"
+    store = CommunityGoalStore(path)
+    now = datetime(2026, 8, 8, 18, 0, tzinfo=timezone.utc)
+
+    first = await store.create_goal(
+        metric_key="xp",
+        target=5000,
+        baseline_total=10000,
+        created_by=7,
+        created_at=now,
+        ends_at=now + timedelta(days=10),
+        reward_text="Badge collectif",
+    )
+    finished = await store.finish_goal(
+        first["id"],
+        status="completed",
+        final_progress=5200,
+        at=now + timedelta(days=2),
+    )
+    assert finished is not None
+    assert finished["status"] == "completed"
+    assert finished["final_progress"] == 5200
+    assert finished["completed_at"] is not None
+
+    second = await store.create_goal(
+        metric_key="xp",
+        target=8000,
+        baseline_total=15200,
+        created_by=7,
+        created_at=now + timedelta(days=3),
+        ends_at=now + timedelta(days=20),
+    )
+    assert second["status"] == "active"
+    assert second["id"] != first["id"]
+
+    reloaded = CommunityGoalStore(path)
+    goals = await reloaded.list_goals()
+    assert {goal["status"] for goal in goals} == {"active", "completed"}
+
+
+@pytest.mark.asyncio
+async def test_cancelled_goal_is_persisted(tmp_path):
+    path = tmp_path / "goals.json"
+    store = CommunityGoalStore(path)
+    now = datetime(2026, 8, 8, 18, 0, tzinfo=timezone.utc)
+
+    goal = await store.create_goal(
+        metric_key="casino",
+        target=100,
+        baseline_total=40,
+        created_by=99,
+        created_at=now,
+        ends_at=now + timedelta(days=5),
+    )
+    cancelled = await store.finish_goal(
+        goal["id"],
+        status="cancelled",
+        final_progress=12,
+        at=now + timedelta(hours=1),
+    )
+    assert cancelled is not None
+    assert cancelled["cancelled_at"] is not None
+    assert cancelled["final_progress"] == 12
+
+    reloaded = CommunityGoalStore(path)
+    active = await reloaded.list_goals(status="active")
+    assert active == []
+    cancelled_goals = await reloaded.list_goals(status="cancelled")
+    assert len(cancelled_goals) == 1

--- a/utils/community_goals.py
+++ b/utils/community_goals.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityGoalMetric:
+    key: str
+    label: str
+    season_field: str
+    emoji: str
+    input_unit: str
+
+    def to_base_value(self, value: int) -> int:
+        amount = max(0, int(value))
+        if self.key == "vocal":
+            return amount * 3600
+        return amount
+
+
+COMMUNITY_GOAL_METRICS: tuple[CommunityGoalMetric, ...] = (
+    CommunityGoalMetric("xp", "XP collective", "xp_earned", "⭐", "XP"),
+    CommunityGoalMetric("messages", "Messages", "messages", "💬", "messages"),
+    CommunityGoalMetric("vocal", "Temps vocal", "voice_seconds", "🎧", "heures"),
+    CommunityGoalMetric("casino", "Paris casino", "casino_bets", "🎰", "paris"),
+)
+COMMUNITY_GOAL_METRICS_BY_KEY = {
+    metric.key: metric for metric in COMMUNITY_GOAL_METRICS
+}
+
+
+def aggregate_metric_total(
+    season_payloads: Iterable[dict[str, Any]],
+    field: str,
+) -> int:
+    """Sum one user metric across multiple seasonal snapshots."""
+
+    total = 0
+    for season in season_payloads:
+        if not isinstance(season, dict):
+            continue
+        users = season.get("users", {})
+        if not isinstance(users, dict):
+            continue
+        for payload in users.values():
+            if not isinstance(payload, dict):
+                continue
+            try:
+                total += int(payload.get(field, 0))
+            except (TypeError, ValueError):
+                continue
+    return total
+
+
+def goal_progress(current_total: int, baseline_total: int, target: int) -> int:
+    """Return prospective progress since goal creation, clamped at zero."""
+
+    if target <= 0:
+        return 0
+    return max(0, int(current_total) - int(baseline_total))
+
+
+def progress_percent(progress: int, target: int) -> int:
+    if target <= 0:
+        return 0
+    return min(100, max(0, int(progress * 100 / target)))
+
+
+def progress_bar(progress: int, target: int, width: int = 10) -> str:
+    if width <= 0:
+        return ""
+    ratio = 0.0 if target <= 0 else min(1.0, max(0.0, progress / target))
+    filled = min(width, max(0, int(ratio * width)))
+    return "█" * filled + "░" * (width - filled)
+
+
+def format_goal_value(metric_key: str, value: int) -> str:
+    value = max(0, int(value))
+    if metric_key == "xp":
+        return f"{value} XP"
+    if metric_key == "messages":
+        return f"{value} messages"
+    if metric_key == "vocal":
+        hours, remainder = divmod(value, 3600)
+        minutes = remainder // 60
+        return f"{hours}h {minutes:02d}m"
+    if metric_key == "casino":
+        return f"{value} paris"
+    return str(value)
+
+
+__all__ = [
+    "COMMUNITY_GOAL_METRICS",
+    "COMMUNITY_GOAL_METRICS_BY_KEY",
+    "CommunityGoalMetric",
+    "aggregate_metric_total",
+    "format_goal_value",
+    "goal_progress",
+    "progress_bar",
+    "progress_percent",
+]


### PR DESCRIPTION
## Objectif
Ajouter des objectifs communautaires configurables qui réutilisent les compteurs saisonniers déjà existants, sans créer de nouveaux compteurs XP/messages/vocal/casino.

## Fonctionnement
- 4 catégories : XP collective, messages, temps vocal et nombre de paris casino ;
- création par le staff avec `/objectif_creer` ;
- affichage public avec `/objectif_communaute` ;
- annulation staff avec `/objectif_annuler` ;
- un seul objectif actif par catégorie ;
- durée configurable de 1 à 90 jours ;
- cible configurable ; pour le vocal, la cible est saisie en heures ;
- titre personnalisé facultatif ;
- texte de récompense facultatif affiché à la communauté ;
- progression avec barre, pourcentage et échéance Discord ;
- historique des objectifs réussis conservé dans `community_goals.json`.

## Baseline / historique
Chaque objectif mémorise le total de sa métrique au moment de sa création. La progression correspond uniquement à l'activité produite ensuite. Cela fonctionne même si l'objectif commence au milieu d'un mois ou traverse plusieurs saisons mensuelles.

## Cycle de vie
- évaluation automatique chaque minute ;
- objectif marqué `completed` dès que la cible est atteinte ;
- objectif marqué `expired` à l'échéance ;
- objectif marqué `cancelled` via la commande staff ;
- annonce automatique dans le salon d'annonces existant lorsqu'un objectif est atteint ;
- aucune donnée globale ou saisonnière n'est remise à zéro.

## Récompense
La V1 stocke et affiche une `récompense prévue`, mais ne distribue pas automatiquement d'XP ou de rôle. Ce choix évite de modifier arbitrairement l'économie et évite les risques de double distribution après redémarrage. L'automatisation d'une récompense pourra être ajoutée séparément avec une règle explicitement validée.

## Architecture
- `utils/community_goals.py` : métriques, conversions, agrégation et rendu de progression ;
- `storage/community_goal_store.py` : persistance atomique et cycle de vie ;
- `cogs/community_goals.py` : commandes slash, évaluation périodique et annonce ;
- `tests/test_community_goals.py` : tests de seuils, baseline et persistance.

## Tests
Les tests ciblés couvrent notamment :
- conversion heures → secondes pour le vocal ;
- agrégation de plusieurs saisons et plusieurs membres ;
- progression calculée uniquement après le baseline ;
- impossibilité de créer deux objectifs actifs de même catégorie ;
- création d'un nouvel objectif après réussite du précédent ;
- persistance des statuts completed/cancelled.

## Portée
4 nouveaux fichiers uniquement. Aucun fichier existant n'est modifié, et aucun calcul XP, casino, message ou vocal n'est changé.

## Discord
Aucun salon ou rôle supplémentaire n'est nécessaire. Les commandes de création/annulation utilisent la permission Discord existante `Gérer le serveur`.

## Validation
La branche part du `main` après la PR #507. La suite pytest complète ne peut pas être exécutée dans ce runtime ; la PR reste en brouillon jusqu'à validation utilisateur.