### PR TITLE
fix: simplify roulette result wording

### DIFF
--- a/cogs/pari_xp.py
+++ b/cogs/pari_xp.py
@@ -61,6 +61,12 @@ def _draw_number_for_roll(selected_number: int, roll: float) -> int:
     return other_numbers[index]
 
 
+def _build_result_description(outcome_line: str | None, result_message: str) -> str:
+    """Join only meaningful roulette result lines."""
+
+    return "\n".join(line for line in (outcome_line, result_message) if line)
+
+
 class BetAmountModal(discord.ui.Modal):
     def __init__(self, cog: "PariXPCog", bet_type: str) -> None:
         super().__init__(title="Parier XP")
@@ -387,17 +393,17 @@ class PariXPCog(commands.Cog):
             else:
                 msg = "❌ Perdu."
             if zero_hit:
-                outcome_line = "🟢 Zéro Vert (0) ! La maison gagne."
+                outcome_line: str | None = "🟢 Zéro Vert (0) ! La maison gagne."
             elif bet_type == "number":
                 outcome_line = f"🎯 Numéro tiré : {drawn_number} — ton choix : {number}."
             else:
-                outcome_line = "🎯 Pas de zéro vert cette fois."
+                outcome_line = None
             self.state["total_bets"] = self.state.get("total_bets", 0) + amount
             self._record_player_result(interaction.user.id, amount, payout)
             await self._save_state()
             result_embed = discord.Embed(
                 title="🎰 Résultat",
-                description=f"{outcome_line}\n{msg}",
+                description=_build_result_description(outcome_line, msg),
             )
             spin_embed = discord.Embed(title="La roue tourne...")
             spin_embed.set_image(url=SPINNING_GIF_URL)

--- a/tests/test_pari_xp_result_text.py
+++ b/tests/test_pari_xp_result_text.py
@@ -1,0 +1,19 @@
+from cogs.pari_xp import _build_result_description
+
+
+def test_result_without_context_uses_only_main_message() -> None:
+    description = _build_result_description(None, "Résultat principal")
+
+    assert description == "Résultat principal"
+
+
+def test_result_with_context_keeps_both_lines() -> None:
+    description = _build_result_description("Contexte", "Résultat principal")
+
+    assert description == "Contexte\nRésultat principal"
+
+
+def test_empty_context_does_not_add_blank_line() -> None:
+    description = _build_result_description("", "Résultat principal")
+
+    assert description == "Résultat principal"


### PR DESCRIPTION
## Problème
Les résultats Rouge/Noir/Pair/Impair affichaient systématiquement la ligne `Pas de zéro vert cette fois.`, même lorsque cette information n'apportait rien au résultat.

## Correction
- suppression de cette ligne pour les résultats classiques hors zéro ;
- conservation du message spécifique lorsque le zéro vert sort réellement ;
- conservation du détail `numéro tiré / ton choix` pour les paris sur numéro ;
- ajout d'un petit helper de formatage pour éviter les lignes vides ;
- aucune modification des probabilités, mises, gains, multiplicateurs ou statistiques.

## Tests
Un test ciblé vérifie :
- qu'un résultat sans contexte n'affiche que le message principal ;
- qu'un résultat avec contexte conserve les deux lignes ;
- qu'un contexte vide ne crée pas de ligne blanche.

La suite pytest complète ne peut pas être exécutée dans ce runtime.

## Portée
- `cogs/pari_xp.py` : 9 ajouts / 3 suppressions ;
- `tests/test_pari_xp_result_text.py` : nouveau test ciblé.

Si tu valides, je fusionne #509.