### PR TITLE
chore: prepare discord.py for Components V2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-discord.py[voice]>=2.4,<3
+discord.py[voice]>=2.7,<3
 python-dotenv>=1.0,<2
 Pillow>=10.0,<13
 yt-dlp>=2024.7.1


### PR DESCRIPTION
## Objectif
Préparer le bot à l'utilisation de Discord Components V2 sans modifier aucune interface ni logique métier.

## Modification
- `discord.py[voice]>=2.4,<3` devient `discord.py[voice]>=2.7,<3` ;
- Components V2 est pris en charge par discord.py depuis 2.6 ;
- 2.7.1 est la version stable actuelle vérifiée avant ce changement ;
- aucun cog, aucune commande, aucune donnée et aucun comportement du bot ne sont modifiés dans cette étape.

## Compatibilité mobile
Components V2 est un système natif de composants de messages Discord. Le futur travail sera conçu mobile-first et validable depuis l'application Android. Cette PR n'affiche encore aucun Components V2.

## Tests / validation
- diff comparé à `main` : un seul fichier modifié, une seule ligne remplacée ;
- aucun test artificiel ajouté pour verrouiller une simple chaîne de dépendance ;
- la suite pytest complète ne peut pas être exécutée dans ce runtime ;
- après déploiement, le contrôle demandé est uniquement que le bot démarre et que les commandes actuelles restent utilisables.

## Portée
`requirements.txt` uniquement : 1 ajout / 1 suppression.

Si tu valides, je fusionne #510.