### PR TITLE
feat: add Components V2 member profile

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from services.member_profile import member_profile_service
+from ui.profile_view import ProfileView
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProfileCog(commands.Cog):
+    """Expose the Refuge member profile as a Components V2 layout."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    @app_commands.command(
+        name="profil",
+        description="Affiche le profil Refuge d'un membre",
+    )
+    @app_commands.describe(membre="Membre à consulter (toi par défaut)")
+    async def profil(
+        self,
+        interaction: discord.Interaction,
+        membre: discord.Member | None = None,
+    ) -> None:
+        target = membre
+        if target is None and isinstance(interaction.user, discord.Member):
+            target = interaction.user
+        if target is None and interaction.guild is not None:
+            target = interaction.guild.get_member(interaction.user.id)
+
+        if target is None:
+            await interaction.response.send_message(
+                "Impossible de déterminer le membre à afficher.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            snapshot = await member_profile_service.get_snapshot(target.id)
+        except Exception:
+            logger.exception("failed to build profile for user %s", target.id)
+            await interaction.response.send_message(
+                "Impossible de charger ce profil pour le moment.",
+                ephemeral=True,
+            )
+            return
+
+        avatar = getattr(target, "display_avatar", None)
+        avatar_url = str(avatar.url) if getattr(avatar, "url", None) else None
+        view = ProfileView(
+            snapshot,
+            display_name=target.display_name,
+            avatar_url=avatar_url,
+        )
+        await interaction.response.send_message(view=view)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(ProfileCog(bot))

--- a/tests/test_profile_cog.py
+++ b/tests/test_profile_cog.py
@@ -1,0 +1,14 @@
+import discord
+from discord.ext import commands
+
+from cogs.profile import ProfileCog
+
+
+def test_profile_cog_registers_profile_command() -> None:
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = ProfileCog(bot)
+
+    commands_registered = cog.get_app_commands()
+
+    assert [command.name for command in commands_registered] == ["profil"]
+    assert commands_registered[0].description == "Affiche le profil Refuge d'un membre"

--- a/tests/test_profile_view.py
+++ b/tests/test_profile_view.py
@@ -1,0 +1,85 @@
+import discord
+
+from services.member_profile import MemberProfileSnapshot
+from ui.profile_view import (
+    ProfileView,
+    _format_rank,
+    _format_signed_xp,
+    _format_voice,
+    _format_xp,
+)
+
+
+def _snapshot() -> MemberProfileSnapshot:
+    return MemberProfileSnapshot(
+        user_id=42,
+        xp=12450,
+        level=18,
+        achievements_unlocked=6,
+        achievements_total=9,
+        achievement_ids=("level_5", "level_10"),
+        season_id="2026-08",
+        season_xp=3210,
+        season_xp_rank=4,
+        season_messages=1482,
+        season_messages_rank=7,
+        season_voice_seconds=98040,
+        season_voice_rank=2,
+        season_casino_net=250,
+        season_casino_rank=5,
+        casino_bets=48,
+        casino_wagered=9000,
+        casino_winnings=10320,
+        casino_net=1320,
+    )
+
+
+def test_profile_formatters_are_mobile_compact() -> None:
+    assert _format_rank(4) == "#4"
+    assert _format_rank(None) == "—"
+    assert _format_voice(98040) == "27h 14m"
+    assert _format_xp(12450) == "12 450 XP"
+    assert _format_signed_xp(1320) == "+1320 XP"
+    assert _format_signed_xp(-50) == "-50 XP"
+
+
+def test_profile_view_uses_components_v2_with_avatar() -> None:
+    view = ProfileView(
+        _snapshot(),
+        display_name="Kevin",
+        avatar_url="https://cdn.discordapp.com/embed/avatars/0.png",
+    )
+
+    assert isinstance(view, discord.ui.LayoutView)
+    assert len(view.children) == 1
+
+    container = view.children[0]
+    assert isinstance(container, discord.ui.Container)
+    assert isinstance(container.children[0], discord.ui.Section)
+    assert isinstance(container.children[0].accessory, discord.ui.Thumbnail)
+
+    text = "\n".join(
+        item.content
+        for item in container.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+    assert "PROFIL DU REFUGE" in text
+    assert "Kevin" in text
+    assert "Niveau **18**" in text
+    assert "Août 2026" in text
+    assert "**6/9** badges" in text
+    assert "**48** paris" in text
+
+    row = container.children[-1]
+    assert isinstance(row, discord.ui.ActionRow)
+    assert [button.label for button in row.children] == ["Succès", "Saison", "Casino"]
+    assert all(button.disabled for button in row.children)
+
+
+def test_profile_view_without_avatar_keeps_identity_visible() -> None:
+    view = ProfileView(_snapshot(), display_name="Kevin")
+    container = view.children[0]
+
+    assert isinstance(container, discord.ui.Container)
+    assert isinstance(container.children[0], discord.ui.TextDisplay)
+    assert "Kevin" in container.children[0].content

--- a/ui/__init__.py
+++ b/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Discord UI components for Refuge bot interfaces."""

--- a/ui/profile_view.py
+++ b/ui/profile_view.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import discord
+
+from services.member_profile import MemberProfileSnapshot
+from utils.seasons import season_label
+
+
+PROFILE_ACCENT = discord.Colour.blurple()
+
+
+def _format_rank(rank: int | None) -> str:
+    return f"#{rank}" if rank is not None else "—"
+
+
+def _format_voice(seconds: int) -> str:
+    hours, remainder = divmod(max(0, int(seconds)), 3600)
+    minutes = remainder // 60
+    return f"{hours}h {minutes:02d}m"
+
+
+def _format_xp(value: int) -> str:
+    return f"{int(value):,}".replace(",", " ") + " XP"
+
+
+def _format_signed_xp(value: int) -> str:
+    return f"{int(value):+d} XP"
+
+
+class ProfileView(discord.ui.LayoutView):
+    """Read-only Components V2 overview for one Refuge member.
+
+    Navigation buttons are intentionally disabled in the first iteration.
+    They become interactive in the dedicated navigation step of the rollout.
+    """
+
+    def __init__(
+        self,
+        snapshot: MemberProfileSnapshot,
+        *,
+        display_name: str,
+        avatar_url: str | None = None,
+    ) -> None:
+        super().__init__(timeout=180)
+
+        container = discord.ui.Container(accent_colour=PROFILE_ACCENT)
+
+        identity = discord.ui.TextDisplay(
+            "## 🏆 PROFIL DU REFUGE\n"
+            f"**{display_name}**\n"
+            f"Niveau **{snapshot.level}** · **{_format_xp(snapshot.xp)}**"
+        )
+        if avatar_url:
+            container.add_item(
+                discord.ui.Section(
+                    identity,
+                    accessory=discord.ui.Thumbnail(
+                        avatar_url,
+                        description=f"Avatar de {display_name}",
+                    ),
+                )
+            )
+        else:
+            container.add_item(identity)
+
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                f"### 📊 {season_label(snapshot.season_id)}\n"
+                f"⚡ XP gagnée : **{_format_xp(snapshot.season_xp)}** · **{_format_rank(snapshot.season_xp_rank)}**\n"
+                f"💬 Messages : **{snapshot.season_messages}** · **{_format_rank(snapshot.season_messages_rank)}**\n"
+                f"🎧 Vocal : **{_format_voice(snapshot.season_voice_seconds)}** · **{_format_rank(snapshot.season_voice_rank)}**\n"
+                f"🎰 Casino net : **{_format_signed_xp(snapshot.season_casino_net)}** · **{_format_rank(snapshot.season_casino_rank)}**"
+            )
+        )
+
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "### 🏅 Succès\n"
+                f"**{snapshot.achievements_unlocked}/{snapshot.achievements_total}** badges débloqués"
+            )
+        )
+
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "### 🎰 Casino\n"
+                f"**{snapshot.casino_bets}** paris · résultat global **{_format_signed_xp(snapshot.casino_net)}**"
+            )
+        )
+
+        container.add_item(
+            discord.ui.ActionRow(
+                discord.ui.Button(
+                    label="Succès",
+                    emoji="🏅",
+                    style=discord.ButtonStyle.secondary,
+                    disabled=True,
+                ),
+                discord.ui.Button(
+                    label="Saison",
+                    emoji="📊",
+                    style=discord.ButtonStyle.secondary,
+                    disabled=True,
+                ),
+                discord.ui.Button(
+                    label="Casino",
+                    emoji="🎰",
+                    style=discord.ButtonStyle.secondary,
+                    disabled=True,
+                ),
+            )
+        )
+
+        self.add_item(container)
+
+
+__all__ = [
+    "PROFILE_ACCENT",
+    "ProfileView",
+    "_format_rank",
+    "_format_signed_xp",
+    "_format_voice",
+    "_format_xp",
+]


### PR DESCRIPTION
## Objectif
Créer le premier écran Discord Components V2 du bot avec `/profil`, sans encore activer la navigation détaillée prévue à l'étape 4.

## Implémentation
- ajout de `cogs/profile.py` avec `/profil` et paramètre membre facultatif ;
- ajout de `ui/profile_view.py` basé sur `discord.ui.LayoutView` ;
- utilisation d'un `Container`, d'une `Section` avec avatar, de `TextDisplay`, `Separator` et `ActionRow` ;
- lecture exclusive via `member_profile_service` créé à l'étape 2 ;
- aucun calcul XP, casino, succès ou classement n'est déplacé dans l'interface ;
- aucun nouveau stockage.

## Contenu affiché
- identité, niveau et XP ;
- saison courante : XP gagnée, messages, vocal et casino net avec rangs ;
- nombre de succès débloqués ;
- nombre de paris et bilan casino global.

## Étape 3 uniquement
Les boutons `Succès`, `Saison` et `Casino` sont présents mais volontairement désactivés. Leur navigation interactive sera développée séparément à l'étape 4 après validation visuelle du rendu.

## Mobile Android
Le layout est conçu mobile-first : une seule colonne principale, textes courts et un unique `ActionRow` de trois boutons. Discord rend nativement Components V2 sur ses clients ; la validation visuelle devra être faite sur Android après fusion/déploiement.

## Tests ciblés
- vérification du type `LayoutView` et du `Container` ;
- vérification de la section avatar et du fallback sans avatar ;
- vérification des contenus saison/succès/casino ;
- vérification des trois boutons présents et désactivés ;
- vérification de l'enregistrement de la commande `/profil` ;
- vérification des helpers de formatage mobile.

La suite pytest complète ne peut pas être exécutée dans ce runtime.

## Portée
5 nouveaux fichiers uniquement :
- `cogs/profile.py` ;
- `ui/__init__.py` ;
- `ui/profile_view.py` ;
- `tests/test_profile_cog.py` ;
- `tests/test_profile_view.py`.

Aucun fichier existant n'est modifié.

Si tu valides, je fusionne #512.