### PR TITLE
feat: add interactive profile navigation

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -58,6 +58,7 @@ class ProfileCog(commands.Cog):
             snapshot,
             display_name=target.display_name,
             avatar_url=avatar_url,
+            owner_user_id=interaction.user.id,
         )
         await interaction.response.send_message(view=view)
 

--- a/tests/test_profile_view.py
+++ b/tests/test_profile_view.py
@@ -146,6 +146,28 @@ def test_profile_view_rejects_unknown_page() -> None:
 
 
 @pytest.mark.asyncio
+async def test_navigation_button_edits_the_same_message() -> None:
+    class FakeResponse:
+        def __init__(self) -> None:
+            self.edited_view = None
+
+        async def edit_message(self, *, view) -> None:
+            self.edited_view = view
+
+    view = ProfileView(_snapshot(), display_name="Kevin", owner_user_id=99)
+    row = view.children[0].children[-1]
+    achievements_button = row.children[0]
+    response = FakeResponse()
+    interaction = SimpleNamespace(response=response)
+
+    await achievements_button.callback(interaction)
+
+    assert view.current_page == "achievements"
+    assert response.edited_view is view
+    assert "SUCCÈS" in _container_text(view)
+
+
+@pytest.mark.asyncio
 async def test_profile_navigation_is_restricted_to_command_author() -> None:
     class FakeResponse:
         def __init__(self) -> None:

--- a/tests/test_profile_view.py
+++ b/tests/test_profile_view.py
@@ -1,7 +1,11 @@
+from types import SimpleNamespace
+
 import discord
+import pytest
 
 from services.member_profile import MemberProfileSnapshot
 from ui.profile_view import (
+    ProfileNavigationButton,
     ProfileView,
     _format_rank,
     _format_signed_xp,
@@ -17,7 +21,14 @@ def _snapshot() -> MemberProfileSnapshot:
         level=18,
         achievements_unlocked=6,
         achievements_total=9,
-        achievement_ids=("level_5", "level_10"),
+        achievement_ids=(
+            "casino_1_bet",
+            "casino_10_bets",
+            "level_5",
+            "level_10",
+            "tenure_30_days",
+            "tenure_180_days",
+        ),
         season_id="2026-08",
         season_xp=3210,
         season_xp_rank=4,
@@ -34,6 +45,15 @@ def _snapshot() -> MemberProfileSnapshot:
     )
 
 
+def _container_text(view: ProfileView) -> str:
+    container = view.children[0]
+    return "\n".join(
+        item.content
+        for item in container.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+
+
 def test_profile_formatters_are_mobile_compact() -> None:
     assert _format_rank(4) == "#4"
     assert _format_rank(None) == "—"
@@ -43,14 +63,17 @@ def test_profile_formatters_are_mobile_compact() -> None:
     assert _format_signed_xp(-50) == "-50 XP"
 
 
-def test_profile_view_uses_components_v2_with_avatar() -> None:
+def test_profile_overview_uses_active_components_v2_navigation() -> None:
     view = ProfileView(
         _snapshot(),
         display_name="Kevin",
         avatar_url="https://cdn.discordapp.com/embed/avatars/0.png",
+        owner_user_id=99,
     )
 
     assert isinstance(view, discord.ui.LayoutView)
+    assert view.current_page == "overview"
+    assert view.owner_user_id == 99
     assert len(view.children) == 1
 
     container = view.children[0]
@@ -58,11 +81,7 @@ def test_profile_view_uses_components_v2_with_avatar() -> None:
     assert isinstance(container.children[0], discord.ui.Section)
     assert isinstance(container.children[0].accessory, discord.ui.Thumbnail)
 
-    text = "\n".join(
-        item.content
-        for item in container.walk_children()
-        if isinstance(item, discord.ui.TextDisplay)
-    )
+    text = _container_text(view)
     assert "PROFIL DU REFUGE" in text
     assert "Kevin" in text
     assert "Niveau **18**" in text
@@ -73,7 +92,42 @@ def test_profile_view_uses_components_v2_with_avatar() -> None:
     row = container.children[-1]
     assert isinstance(row, discord.ui.ActionRow)
     assert [button.label for button in row.children] == ["Succès", "Saison", "Casino"]
-    assert all(button.disabled for button in row.children)
+    assert all(isinstance(button, ProfileNavigationButton) for button in row.children)
+    assert all(not button.disabled for button in row.children)
+
+
+def test_profile_pages_replace_content_and_offer_one_back_button() -> None:
+    view = ProfileView(_snapshot(), display_name="Kevin")
+
+    view.show_page("achievements")
+    assert view.current_page == "achievements"
+    text = _container_text(view)
+    assert "SUCCÈS" in text
+    assert "Membre Bronze" in text
+    assert "Membre Or" in text
+    assert "✅" in text
+    assert "🔒" in text
+
+    row = view.children[0].children[-1]
+    assert [button.label for button in row.children] == ["Retour au profil"]
+
+    view.show_page("season")
+    text = _container_text(view)
+    assert "SAISON · Août 2026" in text
+    assert "3 210 XP" in text
+    assert "rang **#4**" in text
+    assert "27h 14m" in text
+
+    view.show_page("casino")
+    text = _container_text(view)
+    assert "CASINO" in text
+    assert "Mises : **9 000 XP**" in text
+    assert "Gains : **10 320 XP**" in text
+    assert "Résultat net : **+1320 XP**" in text
+
+    view.show_page("overview")
+    assert view.current_page == "overview"
+    assert "PROFIL DU REFUGE" in _container_text(view)
 
 
 def test_profile_view_without_avatar_keeps_identity_visible() -> None:
@@ -83,3 +137,39 @@ def test_profile_view_without_avatar_keeps_identity_visible() -> None:
     assert isinstance(container, discord.ui.Container)
     assert isinstance(container.children[0], discord.ui.TextDisplay)
     assert "Kevin" in container.children[0].content
+
+
+def test_profile_view_rejects_unknown_page() -> None:
+    view = ProfileView(_snapshot(), display_name="Kevin")
+    with pytest.raises(ValueError):
+        view.show_page("unknown")  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_profile_navigation_is_restricted_to_command_author() -> None:
+    class FakeResponse:
+        def __init__(self) -> None:
+            self.messages: list[tuple[str, bool]] = []
+
+        async def send_message(self, content: str, *, ephemeral: bool = False) -> None:
+            self.messages.append((content, ephemeral))
+
+    view = ProfileView(_snapshot(), display_name="Kevin", owner_user_id=99)
+
+    owner_response = FakeResponse()
+    owner_interaction = SimpleNamespace(
+        user=SimpleNamespace(id=99),
+        response=owner_response,
+    )
+    assert await view.interaction_check(owner_interaction) is True
+    assert owner_response.messages == []
+
+    other_response = FakeResponse()
+    other_interaction = SimpleNamespace(
+        user=SimpleNamespace(id=100),
+        response=other_response,
+    )
+    assert await view.interaction_check(other_interaction) is False
+    assert other_response.messages == [
+        ("Ce panneau est contrôlé par la personne qui a lancé `/profil`.", True)
+    ]

--- a/ui/profile_view.py
+++ b/ui/profile_view.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+from typing import Literal
+
 import discord
 
 from services.member_profile import MemberProfileSnapshot
+from utils.achievements import ACHIEVEMENTS, CATEGORY_LABELS
 from utils.seasons import season_label
 
 
 PROFILE_ACCENT = discord.Colour.blurple()
+ProfilePage = Literal["overview", "achievements", "season", "casino"]
 
 
 def _format_rank(rank: int | None) -> str:
@@ -27,12 +31,35 @@ def _format_signed_xp(value: int) -> str:
     return f"{int(value):+d} XP"
 
 
-class ProfileView(discord.ui.LayoutView):
-    """Read-only Components V2 overview for one Refuge member.
+class ProfileNavigationButton(discord.ui.Button):
+    """Button that switches one ProfileView page in-place."""
 
-    Navigation buttons are intentionally disabled in the first iteration.
-    They become interactive in the dedicated navigation step of the rollout.
-    """
+    def __init__(
+        self,
+        *,
+        page: ProfilePage,
+        label: str,
+        emoji: str | None = None,
+        style: discord.ButtonStyle = discord.ButtonStyle.secondary,
+    ) -> None:
+        super().__init__(
+            label=label,
+            emoji=emoji,
+            style=style,
+            custom_id=f"refuge_profile:{page}",
+        )
+        self.page = page
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, ProfileView):
+            return
+        view.show_page(self.page)
+        await interaction.response.edit_message(view=view)
+
+
+class ProfileView(discord.ui.LayoutView):
+    """Interactive Components V2 profile for one Refuge member."""
 
     def __init__(
         self,
@@ -40,29 +67,73 @@ class ProfileView(discord.ui.LayoutView):
         *,
         display_name: str,
         avatar_url: str | None = None,
+        owner_user_id: int | None = None,
     ) -> None:
-        super().__init__(timeout=180)
+        super().__init__(timeout=300)
+        self.snapshot = snapshot
+        self.display_name = display_name
+        self.avatar_url = avatar_url
+        self.owner_user_id = int(owner_user_id or snapshot.user_id)
+        self.current_page: ProfilePage = "overview"
+        self.show_page("overview")
 
-        container = discord.ui.Container(accent_colour=PROFILE_ACCENT)
-
-        identity = discord.ui.TextDisplay(
-            "## 🏆 PROFIL DU REFUGE\n"
-            f"**{display_name}**\n"
-            f"Niveau **{snapshot.level}** · **{_format_xp(snapshot.xp)}**"
+    async def interaction_check(self, interaction: discord.Interaction, /) -> bool:
+        if interaction.user.id == self.owner_user_id:
+            return True
+        await interaction.response.send_message(
+            "Ce panneau est contrôlé par la personne qui a lancé `/profil`.",
+            ephemeral=True,
         )
-        if avatar_url:
-            container.add_item(
-                discord.ui.Section(
-                    identity,
-                    accessory=discord.ui.Thumbnail(
-                        avatar_url,
-                        description=f"Avatar de {display_name}",
-                    ),
-                )
-            )
-        else:
-            container.add_item(identity)
+        return False
 
+    def show_page(self, page: ProfilePage) -> None:
+        builders = {
+            "overview": self._build_overview,
+            "achievements": self._build_achievements,
+            "season": self._build_season,
+            "casino": self._build_casino,
+        }
+        builder = builders.get(page)
+        if builder is None:
+            raise ValueError(f"unknown profile page: {page}")
+        self.current_page = page
+        self.clear_items()
+        self.add_item(builder())
+
+    def _identity_item(self, title: str) -> discord.ui.Item:
+        text = discord.ui.TextDisplay(
+            f"## {title}\n"
+            f"**{self.display_name}**\n"
+            f"Niveau **{self.snapshot.level}** · **{_format_xp(self.snapshot.xp)}**"
+        )
+        if not self.avatar_url:
+            return text
+        return discord.ui.Section(
+            text,
+            accessory=discord.ui.Thumbnail(
+                self.avatar_url,
+                description=f"Avatar de {self.display_name}",
+            ),
+        )
+
+    def _container(self, title: str) -> discord.ui.Container:
+        container = discord.ui.Container(accent_colour=PROFILE_ACCENT)
+        container.add_item(self._identity_item(title))
+        return container
+
+    def _back_row(self) -> discord.ui.ActionRow:
+        return discord.ui.ActionRow(
+            ProfileNavigationButton(
+                page="overview",
+                label="Retour au profil",
+                emoji="↩️",
+                style=discord.ButtonStyle.primary,
+            )
+        )
+
+    def _build_overview(self) -> discord.ui.Container:
+        snapshot = self.snapshot
+        container = self._container("🏆 PROFIL DU REFUGE")
         container.add_item(discord.ui.Separator())
         container.add_item(
             discord.ui.TextDisplay(
@@ -73,7 +144,6 @@ class ProfileView(discord.ui.LayoutView):
                 f"🎰 Casino net : **{_format_signed_xp(snapshot.season_casino_net)}** · **{_format_rank(snapshot.season_casino_rank)}**"
             )
         )
-
         container.add_item(discord.ui.Separator())
         container.add_item(
             discord.ui.TextDisplay(
@@ -81,7 +151,6 @@ class ProfileView(discord.ui.LayoutView):
                 f"**{snapshot.achievements_unlocked}/{snapshot.achievements_total}** badges débloqués"
             )
         )
-
         container.add_item(discord.ui.Separator())
         container.add_item(
             discord.ui.TextDisplay(
@@ -89,35 +158,82 @@ class ProfileView(discord.ui.LayoutView):
                 f"**{snapshot.casino_bets}** paris · résultat global **{_format_signed_xp(snapshot.casino_net)}**"
             )
         )
-
         container.add_item(
             discord.ui.ActionRow(
-                discord.ui.Button(
-                    label="Succès",
-                    emoji="🏅",
-                    style=discord.ButtonStyle.secondary,
-                    disabled=True,
-                ),
-                discord.ui.Button(
-                    label="Saison",
-                    emoji="📊",
-                    style=discord.ButtonStyle.secondary,
-                    disabled=True,
-                ),
-                discord.ui.Button(
-                    label="Casino",
-                    emoji="🎰",
-                    style=discord.ButtonStyle.secondary,
-                    disabled=True,
-                ),
+                ProfileNavigationButton(page="achievements", label="Succès", emoji="🏅"),
+                ProfileNavigationButton(page="season", label="Saison", emoji="📊"),
+                ProfileNavigationButton(page="casino", label="Casino", emoji="🎰"),
             )
         )
+        return container
 
-        self.add_item(container)
+    def _build_achievements(self) -> discord.ui.Container:
+        container = self._container("🏅 SUCCÈS")
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                f"**{self.snapshot.achievements_unlocked}/{self.snapshot.achievements_total}** badges débloqués"
+            )
+        )
+        unlocked = set(self.snapshot.achievement_ids)
+        for category, label in CATEGORY_LABELS.items():
+            lines = []
+            for achievement in ACHIEVEMENTS:
+                if achievement.category != category:
+                    continue
+                status = "✅" if achievement.id in unlocked else "🔒"
+                lines.append(f"{status} {achievement.emoji} **{achievement.name}**")
+            if lines:
+                container.add_item(discord.ui.Separator())
+                container.add_item(
+                    discord.ui.TextDisplay(f"### {label}\n" + "\n".join(lines))
+                )
+        container.add_item(self._back_row())
+        return container
+
+    def _build_season(self) -> discord.ui.Container:
+        snapshot = self.snapshot
+        container = self._container(f"📊 SAISON · {season_label(snapshot.season_id)}")
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                f"⚡ **XP gagnée**\n{_format_xp(snapshot.season_xp)} · rang **{_format_rank(snapshot.season_xp_rank)}**\n\n"
+                f"💬 **Messages**\n{snapshot.season_messages} · rang **{_format_rank(snapshot.season_messages_rank)}**\n\n"
+                f"🎧 **Temps vocal**\n{_format_voice(snapshot.season_voice_seconds)} · rang **{_format_rank(snapshot.season_voice_rank)}**\n\n"
+                f"🎰 **Casino net**\n{_format_signed_xp(snapshot.season_casino_net)} · rang **{_format_rank(snapshot.season_casino_rank)}**"
+            )
+        )
+        container.add_item(self._back_row())
+        return container
+
+    def _build_casino(self) -> discord.ui.Container:
+        snapshot = self.snapshot
+        container = self._container("🎰 CASINO")
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "### Bilan global\n"
+                f"Paris : **{snapshot.casino_bets}**\n"
+                f"Mises : **{_format_xp(snapshot.casino_wagered)}**\n"
+                f"Gains : **{_format_xp(snapshot.casino_winnings)}**\n"
+                f"Résultat net : **{_format_signed_xp(snapshot.casino_net)}**"
+            )
+        )
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                f"### {season_label(snapshot.season_id)}\n"
+                f"Résultat net : **{_format_signed_xp(snapshot.season_casino_net)}**\n"
+                f"Rang saisonnier : **{_format_rank(snapshot.season_casino_rank)}**"
+            )
+        )
+        container.add_item(self._back_row())
+        return container
 
 
 __all__ = [
     "PROFILE_ACCENT",
+    "ProfileNavigationButton",
     "ProfileView",
     "_format_rank",
     "_format_signed_xp",


### PR DESCRIPTION
## Objectif
Activer la navigation Components V2 du `/profil` sans modifier les calculs métier ni les stockages existants.

## Fonctionnement
- les boutons `Succès`, `Saison` et `Casino` deviennent actifs ;
- chaque clic remplace le contenu du même message via `interaction.response.edit_message(view=...)` ;
- chaque sous-écran propose `↩️ Retour au profil` ;
- l’écran Succès affiche les badges débloqués/verrouillés à partir du snapshot existant ;
- l’écran Saison détaille XP, messages, vocal et casino net avec rangs ;
- l’écran Casino détaille paris, mises, gains, résultat net global et résultat saisonnier.

## Sécurité d’interaction
- seul l’utilisateur qui a lancé `/profil` peut piloter les boutons ;
- un autre membre reçoit une réponse éphémère et le panneau reste inchangé ;
- lorsqu’un autre membre est consulté avec `/profil membre:...`, le contrôle reste à l’auteur de la commande.

## Mobile Android
Le layout reste mobile-first : trois boutons sur l’écran principal, puis un seul bouton de retour dans chaque sous-écran. Discord peut répartir les trois boutons sur deux lignes selon la largeur disponible, comme observé lors de la validation Android de l’étape 3.

## Tests ciblés
- boutons actifs sur l’overview ;
- bascule vers Succès / Saison / Casino ;
- retour à l’overview ;
- contenu détaillé des trois pages ;
- callback qui édite le même message ;
- verrouillage des interactions à l’auteur de la commande ;
- fallback sans avatar et formatage mobile conservés.

La suite pytest complète ne peut pas être exécutée dans ce runtime.

## Portée
3 fichiers modifiés uniquement :
- `cogs/profile.py` ;
- `ui/profile_view.py` ;
- `tests/test_profile_view.py`.

Aucun store, aucune logique XP/casino, aucun calcul de saison et aucune logique de succès ne sont modifiés.

Si tu valides, je fusionne #513.