### PR TITLE
feat: add member profile context menu

### DIFF
--- a/cogs/profile.py
+++ b/cogs/profile.py
@@ -18,6 +18,55 @@ class ProfileCog(commands.Cog):
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
+        self.profile_context_menu = app_commands.ContextMenu(
+            name="Profil du Refuge",
+            callback=self.profile_context_menu_callback,
+        )
+        self.bot.tree.add_command(self.profile_context_menu)
+
+    def cog_unload(self) -> None:
+        """Remove the manually registered context menu when the cog unloads."""
+
+        self.bot.tree.remove_command(
+            self.profile_context_menu.name,
+            type=self.profile_context_menu.type,
+        )
+
+    async def _send_profile(
+        self,
+        interaction: discord.Interaction,
+        target: discord.Member,
+    ) -> None:
+        """Build and send the same profile view for every entry point."""
+
+        try:
+            snapshot = await member_profile_service.get_snapshot(target.id)
+        except Exception:
+            logger.exception("failed to build profile for user %s", target.id)
+            await interaction.response.send_message(
+                "Impossible de charger ce profil pour le moment.",
+                ephemeral=True,
+            )
+            return
+
+        avatar = getattr(target, "display_avatar", None)
+        avatar_url = str(avatar.url) if getattr(avatar, "url", None) else None
+        view = ProfileView(
+            snapshot,
+            display_name=target.display_name,
+            avatar_url=avatar_url,
+            owner_user_id=interaction.user.id,
+        )
+        await interaction.response.send_message(view=view)
+
+    async def profile_context_menu_callback(
+        self,
+        interaction: discord.Interaction,
+        membre: discord.Member,
+    ) -> None:
+        """Open the Refuge profile from Discord's member Apps menu."""
+
+        await self._send_profile(interaction, membre)
 
     @app_commands.command(
         name="profil",
@@ -42,25 +91,7 @@ class ProfileCog(commands.Cog):
             )
             return
 
-        try:
-            snapshot = await member_profile_service.get_snapshot(target.id)
-        except Exception:
-            logger.exception("failed to build profile for user %s", target.id)
-            await interaction.response.send_message(
-                "Impossible de charger ce profil pour le moment.",
-                ephemeral=True,
-            )
-            return
-
-        avatar = getattr(target, "display_avatar", None)
-        avatar_url = str(avatar.url) if getattr(avatar, "url", None) else None
-        view = ProfileView(
-            snapshot,
-            display_name=target.display_name,
-            avatar_url=avatar_url,
-            owner_user_id=interaction.user.id,
-        )
-        await interaction.response.send_message(view=view)
+        await self._send_profile(interaction, target)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/tests/test_profile_cog.py
+++ b/tests/test_profile_cog.py
@@ -1,14 +1,57 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import discord
+import pytest
 from discord.ext import commands
 
 from cogs.profile import ProfileCog
 
 
-def test_profile_cog_registers_profile_command() -> None:
+def test_profile_cog_registers_profile_command_and_member_context_menu() -> None:
     bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
     cog = ProfileCog(bot)
 
     commands_registered = cog.get_app_commands()
+    context_menu = bot.tree.get_command(
+        "Profil du Refuge",
+        type=discord.AppCommandType.user,
+    )
 
     assert [command.name for command in commands_registered] == ["profil"]
     assert commands_registered[0].description == "Affiche le profil Refuge d'un membre"
+    assert context_menu is cog.profile_context_menu
+    assert cog.profile_context_menu.type is discord.AppCommandType.user
+
+    cog.cog_unload()
+
+
+def test_profile_context_menu_is_removed_when_cog_unloads() -> None:
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = ProfileCog(bot)
+
+    assert bot.tree.get_command(
+        "Profil du Refuge",
+        type=discord.AppCommandType.user,
+    ) is not None
+
+    cog.cog_unload()
+
+    assert bot.tree.get_command(
+        "Profil du Refuge",
+        type=discord.AppCommandType.user,
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_profile_context_menu_reuses_shared_profile_sender() -> None:
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = ProfileCog(bot)
+    cog._send_profile = AsyncMock()  # type: ignore[method-assign]
+    interaction = SimpleNamespace()
+    member = SimpleNamespace(id=42)
+
+    await cog.profile_context_menu_callback(interaction, member)  # type: ignore[arg-type]
+
+    cog._send_profile.assert_awaited_once_with(interaction, member)
+    cog.cog_unload()


### PR DESCRIPTION
## Objectif
Ajouter l’accès au profil Refuge depuis le menu contextuel d’un membre Discord, sans créer une seconde implémentation du profil.

## Fonctionnement
- ajout d’un context menu utilisateur `Profil du Refuge` ;
- le menu est enregistré explicitement dans le `CommandTree` via `app_commands.ContextMenu` ;
- le menu appelle exactement la même méthode interne `_send_profile()` que `/profil` ;
- le rendu, les données et la navigation Components V2 restent donc identiques entre les deux points d’entrée ;
- le membre ciblé est celui sur lequel l’utilisateur ouvre le menu Discord.

## Cycle de vie
- le context menu est ajouté au chargement du cog ;
- il est retiré du tree dans `cog_unload()` pour éviter les doublons lors d’un reload d’extension.

## Tests ciblés
- `/profil` reste enregistré ;
- `Profil du Refuge` est enregistré comme context menu de type utilisateur ;
- le menu est retiré lors du déchargement du cog ;
- le callback contextuel réutilise bien `_send_profile()`.

La suite pytest complète ne peut pas être exécutée dans ce runtime.

## Portée
2 fichiers modifiés uniquement :
- `cogs/profile.py` ;
- `tests/test_profile_cog.py`.

Aucune vue Components V2, aucun store, aucun calcul XP/casino/saison/succès n’est modifié.

## Validation Discord Android après fusion
Sur Android : ouvrir le profil d’un membre, ouvrir `Apps`, choisir `Profil du Refuge`, puis vérifier que le même panneau Components V2 s’affiche et que ses boutons restent fonctionnels.

Si tu valides, je fusionne #514.