### PR TITLE
feat: migrate community goals to Components V2

### DIFF
--- a/cogs/community_goals.py
+++ b/cogs/community_goals.py
@@ -11,6 +11,7 @@ from discord.ext import commands, tasks
 from config import ANNOUNCE_CHANNEL_ID
 from storage.community_goal_store import ACTIVE_STATUS, community_goal_store
 from storage.season_store import season_store
+from ui.community_goals_view import CommunityGoalDisplay, CommunityGoalsView
 from utils.community_goals import (
     COMMUNITY_GOAL_METRICS,
     COMMUNITY_GOAL_METRICS_BY_KEY,
@@ -157,57 +158,54 @@ class CommunityGoalsCog(commands.Cog):
         active_goals = await community_goal_store.list_goals(status=ACTIVE_STATUS)
         completed = await community_goal_store.list_goals(status="completed")
 
-        embed = discord.Embed(title="🎯 Objectifs communautaires")
-        if not active_goals:
-            embed.description = "Aucun objectif communautaire actif pour le moment."
-        else:
-            for goal in active_goals:
-                metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(
-                    str(goal.get("metric_key", ""))
-                )
-                if metric is None:
-                    continue
-                progress = await self._goal_progress(goal)
-                target = int(goal.get("target", 0))
-                percent = progress_percent(progress, target)
-                try:
-                    ends_at = datetime.fromisoformat(str(goal.get("ends_at")))
-                    end_timestamp = int(ends_at.timestamp())
-                    deadline = f"<t:{end_timestamp}:R>"
-                except (TypeError, ValueError):
-                    deadline = "échéance inconnue"
+        display_goals: list[CommunityGoalDisplay] = []
+        for goal in active_goals:
+            metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(
+                str(goal.get("metric_key", ""))
+            )
+            if metric is None:
+                continue
+            progress = await self._goal_progress(goal)
+            target = int(goal.get("target", 0))
+            percent = progress_percent(progress, target)
+            try:
+                ends_at = datetime.fromisoformat(str(goal.get("ends_at")))
+                end_timestamp = int(ends_at.timestamp())
+                deadline = f"<t:{end_timestamp}:R>"
+            except (TypeError, ValueError):
+                deadline = "échéance inconnue"
 
-                title = str(goal.get("title") or metric.label)
-                value = (
-                    f"{progress_bar(progress, target)} **{percent}%**\n"
-                    f"{metric.emoji} {format_goal_value(metric.key, progress)} / "
-                    f"{format_goal_value(metric.key, target)}\n"
-                    f"⏳ Fin {deadline}"
+            display_goals.append(
+                CommunityGoalDisplay(
+                    title=str(goal.get("title") or metric.label),
+                    metric_emoji=metric.emoji,
+                    progress_value=format_goal_value(metric.key, progress),
+                    target_value=format_goal_value(metric.key, target),
+                    percent=percent,
+                    progress_bar=progress_bar(progress, target),
+                    deadline=deadline,
+                    reward_text=(
+                        str(goal["reward_text"])
+                        if goal.get("reward_text")
+                        else None
+                    ),
                 )
-                if goal.get("reward_text"):
-                    value += f"\n🎁 Récompense prévue : {goal['reward_text']}"
-                embed.add_field(name=title, value=value, inline=False)
+            )
 
-        if completed:
-            recent = completed[:3]
-            lines = []
-            for goal in recent:
-                metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(
-                    str(goal.get("metric_key", ""))
-                )
-                if metric is None:
-                    continue
-                title = str(goal.get("title") or metric.label)
-                lines.append(f"✅ {title}")
-            if lines:
-                embed.add_field(
-                    name="Derniers objectifs réussis",
-                    value="\n".join(lines),
-                    inline=False,
-                )
+        recent_completed: list[str] = []
+        for goal in completed[:3]:
+            metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(
+                str(goal.get("metric_key", ""))
+            )
+            if metric is None:
+                continue
+            recent_completed.append(str(goal.get("title") or metric.label))
 
-        embed.set_footer(text="Progression calculée depuis la création de chaque objectif")
-        await interaction.response.send_message(embed=embed)
+        view = CommunityGoalsView(
+            active_goals=tuple(display_goals),
+            completed_titles=tuple(recent_completed),
+        )
+        await interaction.response.send_message(view=view)
 
     @app_commands.command(
         name="objectif_creer",

--- a/tests/test_community_goals_view.py
+++ b/tests/test_community_goals_view.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import discord
+import pytest
+from discord.ext import commands
+
+import cogs.community_goals as community_goals_module
+from cogs.community_goals import CommunityGoalsCog
+from ui.community_goals_view import CommunityGoalDisplay, CommunityGoalsView
+
+
+def _container_text(view: CommunityGoalsView) -> str:
+    container = view.children[0]
+    return "\n".join(
+        item.content
+        for item in container.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+
+
+def test_community_goals_view_renders_active_and_recent_goals() -> None:
+    view = CommunityGoalsView(
+        active_goals=(
+            CommunityGoalDisplay(
+                title="Semaine active",
+                metric_emoji="💬",
+                progress_value="500 messages",
+                target_value="1000 messages",
+                percent=50,
+                progress_bar="█████░░░░░",
+                deadline="<t:1786406400:R>",
+                reward_text="Badge collectif",
+            ),
+        ),
+        completed_titles=("Objectif vocal", "Objectif XP"),
+    )
+
+    assert isinstance(view, discord.ui.LayoutView)
+    assert view.timeout is None
+    assert len(view.children) == 1
+    assert isinstance(view.children[0], discord.ui.Container)
+
+    text = _container_text(view)
+    assert "OBJECTIFS COMMUNAUTAIRES" in text
+    assert "Semaine active" in text
+    assert "█████░░░░░" in text
+    assert "**50%**" in text
+    assert "500 messages" in text
+    assert "1000 messages" in text
+    assert "<t:1786406400:R>" in text
+    assert "Badge collectif" in text
+    assert "Derniers objectifs réussis" in text
+    assert "Objectif vocal" in text
+    assert "Objectif XP" in text
+    assert "Progression calculée depuis la création" in text
+
+    assert not any(
+        isinstance(item, (discord.ui.Button, discord.ui.Select))
+        for item in view.walk_children()
+    )
+
+
+def test_community_goals_view_handles_no_active_goal() -> None:
+    view = CommunityGoalsView(completed_titles=("Ancien objectif",))
+    text = _container_text(view)
+
+    assert "Aucun objectif communautaire actif pour le moment." in text
+    assert "Ancien objectif" in text
+
+
+def test_community_goals_view_stays_under_components_limit_with_four_goals() -> None:
+    goal = CommunityGoalDisplay(
+        title="Objectif",
+        metric_emoji="⭐",
+        progress_value="100 XP",
+        target_value="1000 XP",
+        percent=10,
+        progress_bar="█░░░░░░░░░",
+        deadline="<t:1786406400:R>",
+    )
+    view = CommunityGoalsView(
+        active_goals=(goal, goal, goal, goal),
+        completed_titles=("A", "B", "C"),
+    )
+
+    assert sum(1 for _item in view.walk_children()) < 40
+
+
+@pytest.mark.asyncio
+async def test_objectif_communaute_sends_components_v2_view(monkeypatch) -> None:
+    active_goal = {
+        "id": "goal-1",
+        "metric_key": "messages",
+        "target": 1000,
+        "baseline_total": 100,
+        "ends_at": "2026-08-12T12:00:00+00:00",
+        "title": "Semaine active",
+        "reward_text": "Badge collectif",
+        "status": "active",
+    }
+    completed_goal = {
+        "id": "goal-2",
+        "metric_key": "xp",
+        "title": "Objectif XP",
+        "status": "completed",
+    }
+
+    class FakeGoalStore:
+        async def list_goals(self, *, status: str | None = None):
+            if status == "active":
+                return [active_goal]
+            if status == "completed":
+                return [completed_goal]
+            return []
+
+    class FakeResponse:
+        def __init__(self) -> None:
+            self.kwargs = None
+
+        async def send_message(self, **kwargs) -> None:
+            self.kwargs = kwargs
+
+    async def no_evaluation() -> None:
+        return None
+
+    async def fixed_progress(_goal) -> int:
+        return 500
+
+    monkeypatch.setattr(community_goals_module, "community_goal_store", FakeGoalStore())
+
+    bot = commands.Bot(command_prefix="!", intents=discord.Intents.none())
+    cog = CommunityGoalsCog(bot)
+    monkeypatch.setattr(cog, "_evaluate_goals", no_evaluation)
+    monkeypatch.setattr(cog, "_goal_progress", fixed_progress)
+
+    response = FakeResponse()
+    interaction = SimpleNamespace(response=response)
+    await CommunityGoalsCog.objectif_communaute.callback(cog, interaction)
+
+    assert response.kwargs is not None
+    assert set(response.kwargs) == {"view"}
+    view = response.kwargs["view"]
+    assert isinstance(view, CommunityGoalsView)
+
+    text = _container_text(view)
+    assert "Semaine active" in text
+    assert "█████░░░░░" in text
+    assert "**50%**" in text
+    assert "500 messages" in text
+    assert "1000 messages" in text
+    assert "Badge collectif" in text
+    assert "Objectif XP" in text

--- a/ui/community_goals_view.py
+++ b/ui/community_goals_view.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import discord
+
+
+COMMUNITY_GOALS_ACCENT = discord.Colour.gold()
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityGoalDisplay:
+    """Display-ready values for one community goal.
+
+    Progress calculation and metric formatting stay outside the UI layer.
+    """
+
+    title: str
+    metric_emoji: str
+    progress_value: str
+    target_value: str
+    percent: int
+    progress_bar: str
+    deadline: str
+    reward_text: str | None = None
+
+
+class CommunityGoalsView(discord.ui.LayoutView):
+    """Read-only Components V2 dashboard for community objectives."""
+
+    def __init__(
+        self,
+        *,
+        active_goals: tuple[CommunityGoalDisplay, ...] = (),
+        completed_titles: tuple[str, ...] = (),
+    ) -> None:
+        super().__init__(timeout=None)
+
+        container = discord.ui.Container(accent_colour=COMMUNITY_GOALS_ACCENT)
+        container.add_item(
+            discord.ui.TextDisplay(
+                "## 🎯 OBJECTIFS COMMUNAUTAIRES\n"
+                "Progression collective du Refuge"
+            )
+        )
+
+        if not active_goals:
+            container.add_item(discord.ui.Separator())
+            container.add_item(
+                discord.ui.TextDisplay(
+                    "Aucun objectif communautaire actif pour le moment."
+                )
+            )
+        else:
+            for goal in active_goals:
+                container.add_item(discord.ui.Separator())
+                lines = [
+                    f"### {goal.title}",
+                    f"`{goal.progress_bar}` **{goal.percent}%**",
+                    (
+                        f"{goal.metric_emoji} **{goal.progress_value}** / "
+                        f"**{goal.target_value}**"
+                    ),
+                    f"⏳ Fin {goal.deadline}",
+                ]
+                if goal.reward_text:
+                    lines.append(f"🎁 Récompense prévue : **{goal.reward_text}**")
+                container.add_item(discord.ui.TextDisplay("\n".join(lines)))
+
+        if completed_titles:
+            container.add_item(discord.ui.Separator())
+            recent_lines = ["### ✅ Derniers objectifs réussis"]
+            recent_lines.extend(f"• {title}" for title in completed_titles)
+            container.add_item(discord.ui.TextDisplay("\n".join(recent_lines)))
+
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "-# Progression calculée depuis la création de chaque objectif"
+            )
+        )
+        self.add_item(container)
+
+
+__all__ = [
+    "COMMUNITY_GOALS_ACCENT",
+    "CommunityGoalDisplay",
+    "CommunityGoalsView",
+]


### PR DESCRIPTION
## Objectif
Migrer l’affichage public `/objectif_communaute` vers Discord Components V2 sans modifier la logique métier des objectifs communautaires.

## Implémentation
- ajout de `ui/community_goals_view.py` basé sur `discord.ui.LayoutView` ;
- rendu dans un `Container` unique, mobile-first ;
- affichage des objectifs actifs avec titre, barre de progression, pourcentage, valeur courante, cible, échéance et récompense éventuelle ;
- affichage des trois derniers objectifs réussis ;
- conservation du message lorsqu’aucun objectif actif n’existe ;
- `/objectif_communaute` envoie désormais `view=CommunityGoalsView(...)` au lieu d’un `Embed`.

## Portée volontaire
Seul le tableau de bord public est migré. Restent inchangés :
- `/objectif_creer` ;
- `/objectif_annuler` ;
- l’évaluation automatique toutes les minutes ;
- l’expiration et la complétion automatiques ;
- l’annonce de complétion dans le salon configuré ;
- `community_goal_store` ;
- `utils/community_goals.py` et tous les calculs de baseline/progression.

## Architecture
La vue ne lit aucun store et ne calcule aucune progression. Le cog prépare des `CommunityGoalDisplay` déjà formatés, puis la couche UI se contente de les rendre.

## Tests ciblés
- rendu Components V2 avec objectif actif, récompense et historique récent ;
- état sans objectif actif ;
- absence de bouton/select inutile sur ce tableau de bord en lecture seule ;
- vérification que 4 objectifs actifs restent largement sous la limite de composants ;
- vérification que `/objectif_communaute` envoie uniquement une `CommunityGoalsView` et conserve les valeurs calculées attendues.

La suite pytest complète ne peut pas être exécutée dans ce runtime.

## Diff
3 fichiers uniquement :
- `cogs/community_goals.py` ;
- `ui/community_goals_view.py` ;
- `tests/test_community_goals_view.py`.

Après fusion et redéploiement, la validation Android consistera à lancer `/objectif_communaute` et vérifier la lisibilité du nouveau panneau avec et sans objectif actif.

Si tu valides, je fusionne #515.