### PR TITLE
feat: migrate casino presentation to Components V2

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -48,6 +48,7 @@ SPIN_GIF_URL = "https://media.tenor.com/2roX3zvclxkAAAAC/slot-machine.gif"
 WIN_GIF_URL = "https://media.tenor.com/XwI-iYdkfVIAAAAi/lottery-winner.gif"
 CASINO_CLOSED_MESSAGE = "🌙 Le Casino est fermé. Horaires : 10h00 - 02h00."
 
+
 def _fmt(dt: datetime) -> str:
     return dt.strftime("%Y-%m-%d %H:%M:%S")
 
@@ -61,9 +62,101 @@ def _is_casino_open(now: Optional[datetime] = None) -> bool:
     return hour >= CASINO_OPEN_HOUR or hour < CASINO_CLOSE_HOUR
 
 
-class MachineASousView(discord.ui.View):
-    def __init__(self):
+def _poster_component_metadata(message: discord.Message) -> tuple[list[str], list[str]]:
+    """Extract text and custom IDs from legacy or V2 message components."""
+
+    texts: list[str] = []
+    custom_ids: list[str] = []
+    stack = list(getattr(message, "components", []) or [])
+    while stack:
+        component = stack.pop()
+        content = getattr(component, "content", None)
+        if content:
+            texts.append(str(content))
+        custom_id = getattr(component, "custom_id", None)
+        if custom_id:
+            custom_ids.append(str(custom_id))
+        stack.extend(list(getattr(component, "children", []) or []))
+    return texts, custom_ids
+
+
+def _is_machine_poster_message(message: discord.Message) -> bool:
+    embeds = list(getattr(message, "embeds", []) or [])
+    if embeds and getattr(embeds[0], "title", None) == "🎰 Machine à sous":
+        return True
+    texts, _ = _poster_component_metadata(message)
+    return any("🎰 Machine à sous" in text for text in texts)
+
+
+def _poster_has_play_button(message: discord.Message) -> bool:
+    _, custom_ids = _poster_component_metadata(message)
+    return "machineasous:play" in custom_ids
+
+
+def _poster_is_components_v2(message: discord.Message) -> bool:
+    return not bool(getattr(message, "embeds", [])) and bool(
+        getattr(message, "components", [])
+    )
+
+
+class MachineASousActionRow(discord.ui.ActionRow):
+    @discord.ui.button(
+        label="🎰 Machine à sous",
+        style=discord.ButtonStyle.success,
+        custom_id="machineasous:play",
+    )
+    async def play_button(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
+        view = self.view
+        if not isinstance(view, MachineASousView):
+            return await interaction.response.send_message(
+                "❌ Fonction Machine à sous indisponible.",
+                ephemeral=True,
+            )
+        await view.handle_play(interaction)
+
+
+class MachineASousView(discord.ui.LayoutView):
+    def __init__(self, *, enabled: bool = True):
         super().__init__(timeout=None)
+        self.enabled = enabled
+
+        if enabled:
+            state = f"✅ **Ouverte** de {CASINO_SCHEDULE_LABEL} (Europe/Paris)"
+            accent = discord.Colour.green()
+        else:
+            state = f"⛔ **Fermée** ({CASINO_SCHEDULE_LABEL})"
+            accent = discord.Colour.red()
+
+        container = discord.ui.Container(accent_colour=accent)
+        container.add_item(
+            discord.ui.TextDisplay(
+                "## 🎰 Machine à sous\n"
+                f"{state}"
+            )
+        )
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "### Gains possibles\n"
+                "0 / 5 / 20 / 50 / 100 / 500 / **1000 XP**\n"
+                "🎟️ Ticket gratuit · ⚡ Double XP (1h) · 🤝 XP partagé"
+            )
+        )
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                f"✨ Le rôle **{WINNER_ROLE_NAME}** est attribué pendant **24h** "
+                "si tu gagnes le **Super Jackpot**.\n"
+                "🗓️ **Une seule tentative par jour.**"
+            )
+        )
+        if enabled:
+            container.add_item(MachineASousActionRow())
+        self.add_item(container)
 
     async def _reward_ticket(
         self,
@@ -267,16 +360,7 @@ class MachineASousView(discord.ui.View):
         if gain == "ticket":
             await self._single_spin(interaction, cog, free=True)
 
-    @discord.ui.button(
-        label="🎰 Machine à sous",
-        style=discord.ButtonStyle.success,
-        custom_id="machineasous:play",
-    )
-    async def play_button(
-        self,
-        interaction: discord.Interaction,
-        button: discord.ui.Button,
-    ) -> None:
+    async def handle_play(self, interaction: discord.Interaction) -> None:
         cog: Optional["MachineASousCog"] = interaction.client.get_cog(
             "MachineASousCog",
         )  # type: ignore
@@ -333,27 +417,6 @@ class MachineASousCog(commands.Cog):
         self.current_view_enabled = _is_casino_open()
         self._last_announced_state: Optional[bool] = None
 
-    def _poster_embed(self) -> discord.Embed:
-        """Create the poster embed describing rewards and open state."""
-        if self.current_view_enabled:
-            desc_state = f"✅ **Ouverte** de {CASINO_SCHEDULE_LABEL} (Europe/Paris)"
-            color = 0x2ECC71
-        else:
-            desc_state = f"⛔ **Fermée** ({CASINO_SCHEDULE_LABEL})"
-            color = 0xED4245
-        return discord.Embed(
-            title="🎰 Machine à sous",
-            description=(
-                f"{desc_state}\n\n"
-                "0 / 5 / 20 / 50 / 100 / 500 / **1000** XP\n"
-                "🎟️ Ticket gratuit • ⚡ Double XP (1h) • 🤝 XP partagé\n"
-                f"✨ Le rôle **{WINNER_ROLE_NAME}** est attribué pendant "
-                "**24h** si tu gagnes le **Super Jackpot**.\n"
-                "🗓️ **Une seule tentative par jour.**"
-            ),
-            color=color,
-        )
-
     async def _delete_old_poster_message(self):
         """Delete the previously stored poster message if present."""
         poster = self.store.get_poster()
@@ -371,7 +434,7 @@ class MachineASousCog(commands.Cog):
         self.store.clear_poster()
 
     async def _replace_poster_message(self):
-        """Publish a fresh poster message in the slot machine channel."""
+        """Publish a fresh Components V2 poster in the slot machine channel."""
         await self.bot.wait_until_ready()
         await self._delete_old_poster_message()
         ch = self.bot.get_channel(CHANNEL_ID)
@@ -379,13 +442,9 @@ class MachineASousCog(commands.Cog):
             logger.warning("[MachineASous] Salon machine à sous introuvable.")
             return
         try:
-            if self.current_view_enabled:
-                msg = await ch.send(
-                    embed=self._poster_embed(),
-                    view=MachineASousView(),
-                )
-            else:
-                msg = await ch.send(embed=self._poster_embed())
+            msg = await ch.send(
+                view=MachineASousView(enabled=self.current_view_enabled),
+            )
             self.store.set_poster(
                 channel_id=str(ch.id),
                 message_id=str(msg.id),
@@ -402,14 +461,10 @@ class MachineASousCog(commands.Cog):
             return None
         try:
             async for msg in ch.history(limit=20):
-                if (
-                    msg.author.id == self.bot.user.id
-                    and msg.embeds
-                    and msg.embeds[0].title == "🎰 Machine à sous"
-                ):
+                if msg.author.id == self.bot.user.id and _is_machine_poster_message(msg):
                     return msg
         except Exception as e:
-            logger.debug("Failed to find existing poster: %s", e)
+            logger.debug("Failed to find existing poster message: %s", e)
         return None
 
     async def _ensure_poster_message(self):
@@ -417,22 +472,30 @@ class MachineASousCog(commands.Cog):
         if poster:
             stored_ch_id = int(poster.get("channel_id", 0))
             if stored_ch_id != CHANNEL_ID:
-                # L'ID configuré a changé : supprimer l'ancien message
+                # L'ID configuré a changé : supprimer l'ancien message.
                 await self._delete_old_poster_message()
             else:
                 ch = self.bot.get_channel(stored_ch_id)
                 if isinstance(ch, (discord.TextChannel, discord.Thread)):
                     try:
                         msg = await ch.fetch_message(int(poster.get("message_id", 0)))
-                        has_view = bool(msg.components)
-                        if has_view != self.current_view_enabled:
+                        has_button = _poster_has_play_button(msg)
+                        if (
+                            not _poster_is_components_v2(msg)
+                            or not _is_machine_poster_message(msg)
+                            or has_button != self.current_view_enabled
+                        ):
                             await self._replace_poster_message()
                         return
                     except discord.NotFound as e:
                         logger.debug("Poster message missing: %s", e)
         existing = await self._find_existing_poster()
         if existing:
-            if bool(existing.components) != self.current_view_enabled:
+            has_button = _poster_has_play_button(existing)
+            if (
+                not _poster_is_components_v2(existing)
+                or has_button != self.current_view_enabled
+            ):
                 await self._replace_poster_message()
             else:
                 self.store.set_poster(
@@ -652,7 +715,7 @@ class MachineASousCog(commands.Cog):
 
     async def cog_load(self):
         try:
-            self.bot.add_view(MachineASousView())
+            self.bot.add_view(MachineASousView(enabled=True))
         except Exception as e:
             logger.error("[MachineASous] add_view échoué: %s", e)
         asyncio.create_task(self._init_after_ready())

--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -496,6 +496,12 @@ class MachineASousCog(commands.Cog):
                 not _poster_is_components_v2(existing)
                 or has_button != self.current_view_enabled
             ):
+                # Persist the discovered legacy/stale poster first so the
+                # replacement path deletes that exact message before sending V2.
+                self.store.set_poster(
+                    channel_id=str(existing.channel.id),
+                    message_id=str(existing.id),
+                )
                 await self._replace_poster_message()
             else:
                 self.store.set_poster(

--- a/cogs/pari_xp.py
+++ b/cogs/pari_xp.py
@@ -22,6 +22,7 @@ from config import (
 )
 from storage.xp_store import xp_store
 from cogs.xp import award_xp
+from ui.casino_views import CasinoLeaderboardEntry, CasinoLeaderboardView
 from utils import xp_adapter
 from utils.timezones import PARIS_TZ
 from utils.persistence import atomic_write_json_async, read_json_safe
@@ -111,48 +112,146 @@ class NumberBetModal(discord.ui.Modal):
         await self.cog._handle_bet(interaction, "number", amt, num)
 
 
-class RouletteXPView(discord.ui.View):
+class RouletteXPActionRow(discord.ui.ActionRow):
     def __init__(self, cog: "PariXPCog", disabled: bool = False) -> None:
-        super().__init__(timeout=None)
         self.cog = cog
+        super().__init__()
         if disabled:
             for item in self.children:
                 item.disabled = True
 
-    @discord.ui.button(label="🔴 Rouge", style=discord.ButtonStyle.danger, custom_id="pari_xp:red")
-    async def bet_red(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # type: ignore[override]
+    @discord.ui.button(
+        label="🔴 Rouge",
+        style=discord.ButtonStyle.danger,
+        custom_id="pari_xp:red",
+    )
+    async def bet_red(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
         if self.cog.is_open:
             await interaction.response.send_modal(BetAmountModal(self.cog, "red"))
         else:
             await safe_respond(interaction, CASINO_CLOSED_MESSAGE, ephemeral=True)
 
-    @discord.ui.button(label="⚫ Noir", style=discord.ButtonStyle.secondary, custom_id="pari_xp:black")
-    async def bet_black(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # type: ignore[override]
+    @discord.ui.button(
+        label="⚫ Noir",
+        style=discord.ButtonStyle.secondary,
+        custom_id="pari_xp:black",
+    )
+    async def bet_black(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
         if self.cog.is_open:
             await interaction.response.send_modal(BetAmountModal(self.cog, "black"))
         else:
             await safe_respond(interaction, CASINO_CLOSED_MESSAGE, ephemeral=True)
 
-    @discord.ui.button(label="Pair", style=discord.ButtonStyle.primary, custom_id="pari_xp:even")
-    async def bet_even(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # type: ignore[override]
+    @discord.ui.button(
+        label="Pair",
+        style=discord.ButtonStyle.primary,
+        custom_id="pari_xp:even",
+    )
+    async def bet_even(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
         if self.cog.is_open:
             await interaction.response.send_modal(BetAmountModal(self.cog, "even"))
         else:
             await safe_respond(interaction, CASINO_CLOSED_MESSAGE, ephemeral=True)
 
-    @discord.ui.button(label="Impair", style=discord.ButtonStyle.primary, custom_id="pari_xp:odd")
-    async def bet_odd(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # type: ignore[override]
+    @discord.ui.button(
+        label="Impair",
+        style=discord.ButtonStyle.primary,
+        custom_id="pari_xp:odd",
+    )
+    async def bet_odd(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
         if self.cog.is_open:
             await interaction.response.send_modal(BetAmountModal(self.cog, "odd"))
         else:
             await safe_respond(interaction, CASINO_CLOSED_MESSAGE, ephemeral=True)
 
-    @discord.ui.button(label="Numéro", style=discord.ButtonStyle.success, custom_id="pari_xp:number")
-    async def bet_number(self, interaction: discord.Interaction, button: discord.ui.Button) -> None:  # type: ignore[override]
+    @discord.ui.button(
+        label="Numéro",
+        style=discord.ButtonStyle.success,
+        custom_id="pari_xp:number",
+    )
+    async def bet_number(
+        self,
+        interaction: discord.Interaction,
+        button: discord.ui.Button,
+    ) -> None:
         if self.cog.is_open:
             await interaction.response.send_modal(NumberBetModal(self.cog))
         else:
             await safe_respond(interaction, CASINO_CLOSED_MESSAGE, ephemeral=True)
+
+
+class RouletteXPView(discord.ui.LayoutView):
+    """Persistent mobile-first Components V2 roulette panel."""
+
+    def __init__(self, cog: "PariXPCog", disabled: bool = False) -> None:
+        super().__init__(timeout=None)
+        self.cog = cog
+
+        next_hour = (
+            f"{CASINO_CLOSE_HOUR:02d}:00"
+            if cog.is_open
+            else f"{CASINO_OPEN_HOUR:02d}:00"
+        )
+        status = "🟢 **Ouvert**" if cog.is_open else "🔴 **Fermé**"
+        action = "ferme" if cog.is_open else "ouvre"
+        accent = discord.Colour.green() if cog.is_open else discord.Colour.red()
+
+        container = discord.ui.Container(accent_colour=accent)
+        container.add_item(
+            discord.ui.TextDisplay(
+                "## 🎰 Pari XP\n"
+                f"{status} — {action} à **{next_hour}**\n"
+                f"Horaires : **{CASINO_SCHEDULE_LABEL}**"
+            )
+        )
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "### Mises & probabilités\n"
+                f"Mise : **{PARI_XP_MIN_BET} à {PARI_XP_MAX_BET} XP**\n"
+                "🔴 Rouge / ⚫ Noir : **45 % → x2**\n"
+                "🔢 Pair / Impair : **45 % → x2**\n"
+                "🎯 Numéro (1-36) : **5 % → x10**\n"
+                "🟢 Zéro Vert : **3 % → x0**"
+            )
+        )
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "### Activité du casino\n"
+                f"XP misés : **{int(cog.state.get('total_bets', 0))}**\n"
+                f"XP gagnés : **{int(cog.state.get('total_winnings', 0))}**"
+            )
+        )
+
+        last = cog.state.get("last_winner")
+        if isinstance(last, dict) and last.get("user_id") is not None:
+            container.add_item(discord.ui.Separator())
+            container.add_item(
+                discord.ui.TextDisplay(
+                    "### Dernier gagnant\n"
+                    f"<@{last.get('user_id')}> a gagné **{int(last.get('amount', 0))} XP**"
+                )
+            )
+
+        container.add_item(RouletteXPActionRow(cog, disabled=disabled))
+        self.add_item(container)
 
 
 class PariXPCog(commands.Cog):
@@ -167,6 +266,7 @@ class PariXPCog(commands.Cog):
         self.is_open: bool = bool(self.state.get("is_open"))
         self._message_id: Optional[int] = self.state.get("message_id")
         self._last_announced_state: Optional[bool] = None
+        self._last_panel_signature: tuple[object, ...] | None = None
         self.check_schedule.start()
 
     # ── Schedule handling ──
@@ -219,39 +319,17 @@ class PariXPCog(commands.Cog):
     async def _save_state(self) -> None:
         await atomic_write_json_async(STATE_FILE, self.state)
 
-    # ── Message & embed ──
-    def _build_embed(self) -> discord.Embed:
-        next_hour = (
-            f"{CASINO_CLOSE_HOUR:02d}:00"
-            if self.is_open
-            else f"{CASINO_OPEN_HOUR:02d}:00"
-        )
-        status = "🟢 Ouvert" if self.is_open else "🔴 Fermé"
-        desc = [
-            f"Mise min : {PARI_XP_MIN_BET} XP",
-            f"Mise max : {PARI_XP_MAX_BET} XP",
-            "",
-            "Probabilités :",
-            "• Rouge/Noir : 45% → x2",
-            "• Pair/Impair : 45% → x2",
-            "• Numéro (1-36) : 5% → x10",
-            "• Zéro Vert : 3% → 0x",
-            "",
-            f"État : {status} — {'ferme' if self.is_open else 'ouvre'} à ⏰ {next_hour}",
-            f"Horaires du casino : {CASINO_SCHEDULE_LABEL}",
-            "",
-            f"Total misés : {self.state.get('total_bets', 0)} XP",
-            f"Total gagnés : {self.state.get('total_winnings', 0)} XP",
-        ]
-        embed = discord.Embed(title="🎰 Pari XP", description="\n".join(desc))
+    def _roulette_panel_signature(self) -> tuple[object, ...]:
         last = self.state.get("last_winner")
-        if last:
-            embed.add_field(
-                name="Dernier gagnant",
-                value=f"<@{last.get('user_id')}> a gagné {last.get('amount')} XP",
-                inline=False,
-            )
-        return embed
+        if not isinstance(last, dict):
+            last = {}
+        return (
+            self.is_open,
+            int(self.state.get("total_bets", 0)),
+            int(self.state.get("total_winnings", 0)),
+            last.get("user_id"),
+            last.get("amount"),
+        )
 
     async def _ensure_roulette_message(self) -> None:
         channel = self.bot.get_channel(PARI_XP_CHANNEL_ID)
@@ -262,7 +340,8 @@ class PariXPCog(commands.Cog):
                 return
         if not isinstance(channel, discord.TextChannel):
             return
-        embed = self._build_embed()
+
+        signature = self._roulette_panel_signature()
         view = RouletteXPView(self, disabled=not self.is_open)
         message: Optional[discord.Message] = None
         if self._message_id:
@@ -270,16 +349,28 @@ class PariXPCog(commands.Cog):
                 message = await channel.fetch_message(self._message_id)
             except discord.NotFound:
                 message = None
+
         if message:
-            await safe_message_edit(message, embed=embed, view=view)
+            is_legacy = bool(getattr(message, "embeds", []))
+            if self._last_panel_signature == signature and not is_legacy:
+                return
+            await safe_message_edit(
+                message,
+                content=None,
+                embed=None,
+                attachments=[],
+                view=view,
+            )
         else:
             try:
-                sent = await channel.send(embed=embed, view=view)
+                sent = await channel.send(view=view)
             except discord.HTTPException:
                 return
             self._message_id = sent.id
             self.state["message_id"] = sent.id
             await self._save_state()
+
+        self._last_panel_signature = signature
 
     def _record_player_result(self, user_id: int, bet_amount: int, payout: int) -> None:
         players = self.state.setdefault("players", {})
@@ -437,18 +528,17 @@ class PariXPCog(commands.Cog):
             leaderboard.append((str(user_id), net, winnings, wagered, bets))
 
         if not leaderboard:
-            embed = discord.Embed(
-                title="🏆 Top Casino",
-                description="Aucune activité casino enregistrée pour le moment.",
+            await interaction.response.send_message(
+                view=CasinoLeaderboardView(()),
+                ephemeral=True,
             )
-            await interaction.response.send_message(embed=embed, ephemeral=True)
             return
 
         leaderboard.sort(
             key=lambda item: (item[1], item[2], -item[3]),
             reverse=True,
         )
-        lines = []
+        entries: list[CasinoLeaderboardEntry] = []
         for idx, (user_id, net, winnings, wagered, bets) in enumerate(
             leaderboard[:10],
             start=1,
@@ -473,20 +563,18 @@ class PariXPCog(commands.Cog):
             else:
                 display_name = f"Utilisateur {user_id}"
 
-            bet_label = "pari" if bets == 1 else "paris"
-            lines.append(
-                f"**#{idx}** {display_name} — **{net:+d} XP net** · "
-                f"{bets} {bet_label} · {wagered} misés · {winnings} gagnés"
+            entries.append(
+                CasinoLeaderboardEntry(
+                    rank=idx,
+                    display_name=display_name,
+                    net=net,
+                    winnings=winnings,
+                    wagered=wagered,
+                    bets=bets,
+                )
             )
 
-        embed = discord.Embed(
-            title="🏆 Top Casino",
-            description=(
-                "Classement par résultat net (gains - mises).\n\n"
-                + "\n".join(lines)
-            ),
-        )
-        await interaction.response.send_message(embed=embed)
+        await interaction.response.send_message(view=CasinoLeaderboardView(entries))
 
     async def cog_load(self) -> None:
         try:

--- a/tests/test_casino_components_v2.py
+++ b/tests/test_casino_components_v2.py
@@ -1,9 +1,13 @@
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import discord
+import pytest
 
 import cogs.pari_xp as pari_xp
+import cogs.machine_a_sous.machine_a_sous as machine_a_sous
 from cogs.machine_a_sous.machine_a_sous import (
+    MachineASousCog,
     MachineASousView,
     _is_machine_poster_message,
     _poster_has_play_button,
@@ -84,3 +88,54 @@ def test_slot_poster_detection_distinguishes_legacy_and_components_v2() -> None:
     assert _is_machine_poster_message(legacy_message)
     assert not _poster_is_components_v2(legacy_message)
     assert not _poster_has_play_button(legacy_message)
+
+
+@pytest.mark.asyncio
+async def test_discovered_legacy_slot_poster_is_registered_before_replacement(
+    monkeypatch,
+) -> None:
+    class FakeTextChannel:
+        id = machine_a_sous.CHANNEL_ID
+
+        async def history(self, *, limit: int):
+            assert limit == 20
+            yield legacy_message
+
+    class FakeThread:
+        pass
+
+    channel = FakeTextChannel()
+    legacy_message = SimpleNamespace(
+        id=321,
+        author=SimpleNamespace(id=999),
+        channel=channel,
+        embeds=[SimpleNamespace(title="🎰 Machine à sous")],
+        components=[],
+    )
+    bot = SimpleNamespace(
+        user=SimpleNamespace(id=999),
+        get_channel=lambda channel_id: channel,
+    )
+    store = SimpleNamespace(
+        get_poster=Mock(return_value=None),
+        set_poster=Mock(),
+    )
+    cog = object.__new__(MachineASousCog)
+    cog.bot = bot
+    cog.store = store
+    cog.current_view_enabled = True
+
+    async def replace_after_registration() -> None:
+        store.set_poster.assert_called_once_with(
+            channel_id=str(channel.id),
+            message_id=str(legacy_message.id),
+        )
+
+    cog._replace_poster_message = AsyncMock(side_effect=replace_after_registration)
+
+    monkeypatch.setattr(machine_a_sous.discord, "TextChannel", FakeTextChannel)
+    monkeypatch.setattr(machine_a_sous.discord, "Thread", FakeThread)
+
+    await MachineASousCog._ensure_poster_message(cog)
+
+    cog._replace_poster_message.assert_awaited_once()

--- a/tests/test_casino_components_v2.py
+++ b/tests/test_casino_components_v2.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+
+import discord
+
+import cogs.pari_xp as pari_xp
+from cogs.machine_a_sous.machine_a_sous import (
+    MachineASousView,
+    _is_machine_poster_message,
+    _poster_has_play_button,
+    _poster_is_components_v2,
+)
+
+
+def _text(view: discord.ui.LayoutView) -> str:
+    return "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+
+
+def _buttons(view: discord.ui.LayoutView) -> list[discord.ui.Button]:
+    return [
+        item
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.Button)
+    ]
+
+
+def _roulette_cog(*, is_open: bool) -> pari_xp.PariXPCog:
+    cog = object.__new__(pari_xp.PariXPCog)
+    cog.state = {
+        "is_open": is_open,
+        "total_bets": 120,
+        "total_winnings": 80,
+        "last_winner": {"user_id": 42, "amount": 40},
+    }
+    cog.is_open = is_open
+    return cog
+
+
+def test_roulette_v2_closed_state_disables_all_existing_bet_buttons() -> None:
+    view = pari_xp.RouletteXPView(_roulette_cog(is_open=False), disabled=True)
+
+    assert isinstance(view, discord.ui.LayoutView)
+    assert "🔴 **Fermé**" in _text(view)
+
+    buttons = _buttons(view)
+    assert [button.custom_id for button in buttons] == [
+        "pari_xp:red",
+        "pari_xp:black",
+        "pari_xp:even",
+        "pari_xp:odd",
+        "pari_xp:number",
+    ]
+    assert all(button.disabled for button in buttons)
+
+
+def test_slot_machine_v2_open_and_closed_posters_keep_same_play_contract() -> None:
+    opened = MachineASousView(enabled=True)
+    closed = MachineASousView(enabled=False)
+
+    assert isinstance(opened, discord.ui.LayoutView)
+    assert isinstance(closed, discord.ui.LayoutView)
+    assert "✅ **Ouverte**" in _text(opened)
+    assert "⛔ **Fermée**" in _text(closed)
+
+    assert [button.custom_id for button in _buttons(opened)] == ["machineasous:play"]
+    assert _buttons(closed) == []
+
+
+def test_slot_poster_detection_distinguishes_legacy_and_components_v2() -> None:
+    v2_view = MachineASousView(enabled=True)
+    v2_message = SimpleNamespace(embeds=[], components=v2_view.children)
+
+    assert _is_machine_poster_message(v2_message)
+    assert _poster_is_components_v2(v2_message)
+    assert _poster_has_play_button(v2_message)
+
+    legacy_message = SimpleNamespace(
+        embeds=[SimpleNamespace(title="🎰 Machine à sous")],
+        components=[],
+    )
+    assert _is_machine_poster_message(legacy_message)
+    assert not _poster_is_components_v2(legacy_message)
+    assert not _poster_has_play_button(legacy_message)

--- a/tests/test_machine_a_sous_free_ticket_priority.py
+++ b/tests/test_machine_a_sous_free_ticket_priority.py
@@ -2,6 +2,7 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import discord
 import pytest
 
 from cogs.machine_a_sous.machine_a_sous import MachineASousCog, MachineASousView
@@ -14,7 +15,7 @@ from utils.storage import load_json
 
 @pytest.mark.asyncio
 async def test_free_ticket_prioritized_over_store(tmp_path, monkeypatch):
-    monkeypatch.setattr("cogs.machine_a_sous.machine_a_sous.is_open_now", lambda *a, **k: True)
+    monkeypatch.setattr("cogs.machine_a_sous.machine_a_sous._is_casino_open", lambda *a, **k: True)
     monkeypatch.setattr("cogs.machine_a_sous.machine_a_sous.DATA_DIR", str(tmp_path))
 
     ticket_path = tmp_path / "tickets.json"
@@ -60,7 +61,12 @@ async def test_free_ticket_prioritized_over_store(tmp_path, monkeypatch):
         followup=DummyFollowup(),
     )
 
-    button = next(child for child in view.children if getattr(child, "custom_id", None) == "machineasous:play")
+    button = next(
+        child
+        for child in view.walk_children()
+        if isinstance(child, discord.ui.Button)
+        and child.custom_id == "machineasous:play"
+    )
     await button.callback(interaction)
     await asyncio.sleep(0)
 

--- a/tests/test_machine_a_sous_ticket_usage.py
+++ b/tests/test_machine_a_sous_ticket_usage.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from pathlib import Path
 import os
 
+import discord
 import pytest
 
 import sys
@@ -17,7 +18,7 @@ from storage.roulette_store import RouletteStore
 async def test_ticket_can_be_used_before_daily_spin(monkeypatch, tmp_path):
     # Ensure machine is considered open and use a temp data dir
     monkeypatch.setattr(
-        "cogs.machine_a_sous.machine_a_sous.is_open_now", lambda *a, **k: True
+        "cogs.machine_a_sous.machine_a_sous._is_casino_open", lambda *a, **k: True
     )
     monkeypatch.setattr(
         "cogs.machine_a_sous.machine_a_sous.DATA_DIR", str(tmp_path)
@@ -63,9 +64,12 @@ async def test_ticket_can_be_used_before_daily_spin(monkeypatch, tmp_path):
         followup=DummyFollowup(),
     )
 
-    # Trigger the button callback
+    # Trigger the same persistent button, now nested in the V2 container/action row.
     button = next(
-        child for child in view.children if getattr(child, "custom_id", None) == "machineasous:play"
+        child
+        for child in view.walk_children()
+        if isinstance(child, discord.ui.Button)
+        and child.custom_id == "machineasous:play"
     )
     await button.callback(interaction)
 

--- a/tests/test_pari_xp_active.py
+++ b/tests/test_pari_xp_active.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+import discord
 import pytest
 
 import cogs.pari_xp as pari_xp
@@ -14,7 +15,16 @@ def _make_cog(*, is_open: bool = True):
     cog.is_open = is_open
     cog._message_id = None
     cog._last_announced_state = None
+    cog._last_panel_signature = None
     return cog
+
+
+def _view_text(view: discord.ui.LayoutView) -> str:
+    return "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
 
 
 def test_is_open_now_respects_overnight_schedule(monkeypatch):
@@ -28,7 +38,7 @@ def test_is_open_now_respects_overnight_schedule(monkeypatch):
     assert not cog._is_open_now(pari_xp.datetime(2026, 8, 9, 2, 0, tzinfo=pari_xp.PARIS_TZ))
 
 
-def test_build_embed_reflects_active_state(monkeypatch):
+def test_roulette_v2_reflects_active_state(monkeypatch):
     monkeypatch.setattr(pari_xp, "CASINO_OPEN_HOUR", 10)
     monkeypatch.setattr(pari_xp, "CASINO_CLOSE_HOUR", 2)
     monkeypatch.setattr(pari_xp, "CASINO_SCHEDULE_LABEL", "10h00 - 02h00")
@@ -36,14 +46,28 @@ def test_build_embed_reflects_active_state(monkeypatch):
     cog.state["total_bets"] = 250
     cog.state["total_winnings"] = 100
 
-    embed = cog._build_embed()
-    description = embed.description or ""
+    view = pari_xp.RouletteXPView(cog)
+    text = _view_text(view)
 
-    assert embed.title == "🎰 Pari XP"
-    assert "🟢 Ouvert" in description
-    assert "ferme à ⏰ 02:00" in description
-    assert "Total misés : 250 XP" in description
-    assert "Total gagnés : 100 XP" in description
+    assert isinstance(view, discord.ui.LayoutView)
+    assert "🎰 Pari XP" in text
+    assert "🟢 **Ouvert**" in text
+    assert "ferme à **02:00**" in text
+    assert "XP misés : **250**" in text
+    assert "XP gagnés : **100**" in text
+
+    custom_ids = {
+        item.custom_id
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.Button)
+    }
+    assert custom_ids == {
+        "pari_xp:red",
+        "pari_xp:black",
+        "pari_xp:even",
+        "pari_xp:odd",
+        "pari_xp:number",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/test_pari_xp_leaderboard.py
+++ b/tests/test_pari_xp_leaderboard.py
@@ -1,9 +1,11 @@
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+import discord
 import pytest
 
 import cogs.pari_xp as pari_xp
+from ui.casino_views import CasinoLeaderboardView
 
 
 def _make_cog(state: dict):
@@ -14,7 +16,16 @@ def _make_cog(state: dict):
     cog.is_open = True
     cog._message_id = None
     cog._last_announced_state = None
+    cog._last_panel_signature = None
     return cog
+
+
+def _view_text(view: discord.ui.LayoutView) -> str:
+    return "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
 
 
 @pytest.mark.asyncio
@@ -115,11 +126,15 @@ async def test_top_casino_ranks_net_casino_result_not_global_xp(monkeypatch):
 
     await pari_xp.PariXPCog.top_casino.callback(cog, interaction)
 
-    embed = interaction.response.send_message.await_args.kwargs["embed"]
-    description = embed.description or ""
+    kwargs = interaction.response.send_message.await_args.kwargs
+    view = kwargs["view"]
+    assert isinstance(view, CasinoLeaderboardView)
+    assert "embed" not in kwargs
+
+    description = _view_text(view)
     assert description.index("Bob") < description.index("Charlie") < description.index("Alice")
     assert "**+90 XP net**" in description
-    assert "Classement par résultat net" in description
+    assert "Classement par **résultat net**" in description
 
 
 @pytest.mark.asyncio
@@ -137,7 +152,8 @@ async def test_top_casino_does_not_fallback_to_global_xp(monkeypatch):
 
     await pari_xp.PariXPCog.top_casino.callback(cog, interaction)
 
-    embed = interaction.response.send_message.await_args.kwargs["embed"]
-    assert embed.title == "🏆 Top Casino"
-    assert embed.description == "Aucune activité casino enregistrée pour le moment."
-    assert interaction.response.send_message.await_args.kwargs["ephemeral"] is True
+    kwargs = interaction.response.send_message.await_args.kwargs
+    view = kwargs["view"]
+    assert isinstance(view, CasinoLeaderboardView)
+    assert "Aucune activité casino enregistrée pour le moment." in _view_text(view)
+    assert kwargs["ephemeral"] is True

--- a/tests/test_safe_message_edit_remove_embed.py
+++ b/tests/test_safe_message_edit_remove_embed.py
@@ -28,3 +28,21 @@ async def test_safe_message_edit_removes_embed(monkeypatch):
 
     message.edit.assert_awaited_once_with(embed=None)
     limiter.acquire.assert_awaited_once_with(bucket="channel:123")
+
+
+@pytest.mark.asyncio
+async def test_safe_message_edit_forwards_view_only_change(monkeypatch):
+    view = object()
+    message = SimpleNamespace(
+        content="",
+        embeds=[],
+        edit=AsyncMock(),
+        channel=SimpleNamespace(id=456),
+    )
+    limiter = SimpleNamespace(acquire=AsyncMock())
+    monkeypatch.setattr("utils.discord_utils.limiter", limiter)
+
+    await safe_message_edit(message, view=view)
+
+    message.edit.assert_awaited_once_with(view=view)
+    limiter.acquire.assert_awaited_once_with(bucket="channel:456")

--- a/ui/casino_views.py
+++ b/ui/casino_views.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+import discord
+
+
+@dataclass(frozen=True, slots=True)
+class CasinoLeaderboardEntry:
+    rank: int
+    display_name: str
+    net: int
+    winnings: int
+    wagered: int
+    bets: int
+
+
+class CasinoLeaderboardView(discord.ui.LayoutView):
+    """Read-only Components V2 leaderboard for casino performance."""
+
+    def __init__(self, entries: Iterable[CasinoLeaderboardEntry]) -> None:
+        super().__init__(timeout=None)
+        rows = tuple(entries)
+
+        container = discord.ui.Container(accent_colour=discord.Colour.gold())
+        container.add_item(discord.ui.TextDisplay("## 🏆 Top Casino"))
+
+        if not rows:
+            container.add_item(
+                discord.ui.TextDisplay(
+                    "Aucune activité casino enregistrée pour le moment."
+                )
+            )
+        else:
+            container.add_item(
+                discord.ui.TextDisplay(
+                    "Classement par **résultat net** : gains - mises."
+                )
+            )
+            container.add_item(discord.ui.Separator())
+
+            for index, entry in enumerate(rows):
+                bet_label = "pari" if entry.bets == 1 else "paris"
+                container.add_item(
+                    discord.ui.TextDisplay(
+                        f"**#{entry.rank} · {entry.display_name}**\n"
+                        f"**{entry.net:+d} XP net** · {entry.bets} {bet_label}\n"
+                        f"{entry.wagered} XP misés · {entry.winnings} XP gagnés"
+                    )
+                )
+                if index < len(rows) - 1:
+                    container.add_item(discord.ui.Separator())
+
+        self.add_item(container)
+
+
+__all__ = ["CasinoLeaderboardEntry", "CasinoLeaderboardView"]

--- a/utils/discord_utils.py
+++ b/utils/discord_utils.py
@@ -56,9 +56,10 @@ async def safe_channel_edit(channel: discord.abc.GuildChannel, **kwargs) -> None
 async def safe_message_edit(message: discord.Message, **kwargs) -> discord.Message | None:
     """Safely edit a message.
 
-    Skips edits when content and embeds are unchanged and throttles requests
-    using the shared rate limiter.  Returns the original message when no update
-    is performed.
+    Skips edits when content and embeds are unchanged and no component view is
+    supplied, then throttles requests using the shared rate limiter.  A view
+    update is always forwarded because component state is not represented by
+    ``Message.content`` or ``Message.embeds``.
     """
     same_content = "content" not in kwargs or kwargs["content"] == getattr(message, "content", None)
 
@@ -82,10 +83,10 @@ async def safe_message_edit(message: discord.Message, **kwargs) -> discord.Messa
             m.to_dict() == n.to_dict() for m, n in zip(current_embeds, new_embeds)
         )
 
-    if same_content and same_embed:
+    same_view = "view" not in kwargs
+    if same_content and same_embed and same_view:
         return message
 
     channel_id = getattr(getattr(message, "channel", None), "id", 0)
     await limiter.acquire(bucket=f"channel:{channel_id}")
     return await message.edit(**kwargs)
-


### PR DESCRIPTION
## Objectif
Migrer les interfaces casino structurées vers Discord Components V2 sans modifier les règles de jeu ni l’économie XP.

## Interfaces migrées
- panneau permanent **Pari XP / roulette** ;
- panneau permanent **Machine à sous** ;
- commande `/top_casino`.

## Roulette XP
- `RouletteXPView` devient un `discord.ui.LayoutView` mobile-first ;
- conservation stricte des cinq boutons et de leurs `custom_id` : `pari_xp:red`, `pari_xp:black`, `pari_xp:even`, `pari_xp:odd`, `pari_xp:number` ;
- mêmes modales de mise et de numéro ;
- mêmes probabilités, multiplicateurs, débits/crédits XP et statistiques ;
- l’ancien message `Embed + View` est migré **en place** vers Components V2 en conservant son `message_id` ;
- une signature d’affichage évite les éditions inutiles à chaque passage de la boucle minute.

## Machine à sous
- le poster permanent devient un `LayoutView` avec `Container`, textes et `ActionRow` ;
- conservation du `custom_id="machineasous:play"` ;
- panneau ouvert : bouton de jeu présent ; panneau fermé : lecture seule ;
- l’ancien poster embed est détecté comme legacy puis remplacé proprement par le poster V2 ;
- les règles de tirage, tickets, essai quotidien, Double XP, XP partagé, jackpots et rôle temporaire restent inchangées.

## Top Casino
- `/top_casino` utilise désormais `CasinoLeaderboardView` ;
- classement toujours fondé sur `gains - mises` ;
- même tri et même top 10 ;
- état sans activité conservé en réponse éphémère.

## Notifications volontairement inchangées
Les animations de tirage, résultats individuels, annonces de jackpot et annonces d’ouverture/fermeture restent sous leur format court actuel. Elles ne sont pas des tableaux de bord et ne nécessitent pas Components V2.

## Infrastructure Components V2
`safe_message_edit()` transmet désormais toujours les modifications portant sur `view`. Avant cette correction, une édition uniquement composée de composants pouvait être considérée à tort comme inchangée.

## Tests ciblés ajoutés / adaptés
- rendu V2 roulette ouvert/fermé ;
- conservation des cinq `custom_id` et désactivation à la fermeture ;
- poster machine à sous ouvert/fermé et conservation du bouton persistant ;
- détection legacy vs Components V2 du poster machine ;
- tickets machine à sous et priorité des tickets existants ;
- classement `/top_casino` V2 et état vide ;
- édition `view=` via `safe_message_edit()` ;
- tests métier existants de gains/pertes roulette conservés.

La suite pytest complète ne peut pas être exécutée dans ce runtime car l’environnement local ne contient pas les dépendances Discord du dépôt.

## Diff
10 fichiers modifiés/ajoutés, tous liés à la présentation casino, ses tests ou au support d’édition des vues.

Après fusion et redéploiement, la validation Android portera sur le panneau roulette, les cinq boutons, le poster machine à sous et `/top_casino`.

Si tu valides, je fusionne #516.