### PR TITLE
fix: extend casino hours and hide closed roulette controls

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -46,7 +46,7 @@ REWARDS = [
 WEIGHTS = [250, 230, 150, 80, 40, 15, 5, 80, 80, 70]
 SPIN_GIF_URL = "https://media.tenor.com/2roX3zvclxkAAAAC/slot-machine.gif"
 WIN_GIF_URL = "https://media.tenor.com/XwI-iYdkfVIAAAAi/lottery-winner.gif"
-CASINO_CLOSED_MESSAGE = "🌙 Le Casino est fermé. Horaires : 10h00 - 02h00."
+CASINO_CLOSED_MESSAGE = f"🌙 Le Casino est fermé. Horaires : {CASINO_SCHEDULE_LABEL}."
 
 
 def _fmt(dt: datetime) -> str:

--- a/cogs/pari_xp.py
+++ b/cogs/pari_xp.py
@@ -38,7 +38,7 @@ PARI_XP_MAX_BET = int(os.getenv("PARI_XP_MAX_BET", "500"))
 SPINNING_GIF_URL = (
     "https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExcGpxaXd6ZDZhaGlvbXhjOTJtdDA5MTl5cGo2N2oxbHB2aXZpNjJtZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26uflBhaGt5lQsaCA/giphy.gif"
 )
-CASINO_CLOSED_MESSAGE = "🌙 Le Casino est fermé. Horaires : 10h00 - 02h00."
+CASINO_CLOSED_MESSAGE = f"🌙 Le Casino est fermé. Horaires : {CASINO_SCHEDULE_LABEL}."
 
 
 def _draw_number_for_roll(selected_number: int, roll: float) -> int:
@@ -203,14 +203,16 @@ class RouletteXPView(discord.ui.LayoutView):
         super().__init__(timeout=None)
         self.cog = cog
 
-        next_hour = (
-            f"{CASINO_CLOSE_HOUR:02d}:00"
-            if cog.is_open
-            else f"{CASINO_OPEN_HOUR:02d}:00"
-        )
-        status = "🟢 **Ouvert**" if cog.is_open else "🔴 **Fermé**"
-        action = "ferme" if cog.is_open else "ouvre"
-        accent = discord.Colour.green() if cog.is_open else discord.Colour.red()
+        if not cog.is_open:
+            container = discord.ui.Container(accent_colour=discord.Colour.red())
+            container.add_item(discord.ui.TextDisplay("🔴 **Casino fermé**"))
+            self.add_item(container)
+            return
+
+        next_hour = f"{CASINO_CLOSE_HOUR:02d}:00"
+        status = "🟢 **Ouvert**"
+        action = "ferme"
+        accent = discord.Colour.green()
 
         container = discord.ui.Container(accent_colour=accent)
         container.add_item(

--- a/config.py
+++ b/config.py
@@ -53,7 +53,7 @@ except AttributeError:
 
 # ── Horaires du casino ────────────────────────────────────────
 CASINO_OPEN_HOUR: int = int(os.getenv("CASINO_OPEN_HOUR", "10"))
-CASINO_CLOSE_HOUR: int = int(os.getenv("CASINO_CLOSE_HOUR", "2"))
+CASINO_CLOSE_HOUR: int = int(os.getenv("CASINO_CLOSE_HOUR", "6"))
 CASINO_SCHEDULE_LABEL = f"{CASINO_OPEN_HOUR:02d}h00 - {CASINO_CLOSE_HOUR:02d}h00"
 
 
@@ -138,9 +138,9 @@ ROCK_RADIO_STREAM_URL = os.getenv(
 
 
 # ── Divers ────────────────────────────────────────────────────
-XP_VIEWER_ROLE_ID = 1403510368340410550
+XP_VIEWER_ROLE_ID = 1403510366340410550
 TOP_MSG_ROLE_ID = 1406412171965104208
-TOP_VC_ROLE_ID = 1406412383878119485
+TOP_VC_ROLE_ID = 1406412383878111985
 MVP_ROLE_ID = 1406412507433795595
 
 ANNOUNCE_CHANNEL_ID: int = int(os.getenv("ANNOUNCE_CHANNEL_ID", "0"))

--- a/config.py
+++ b/config.py
@@ -138,9 +138,9 @@ ROCK_RADIO_STREAM_URL = os.getenv(
 
 
 # ── Divers ────────────────────────────────────────────────────
-XP_VIEWER_ROLE_ID = 1403510366340410550
+XP_VIEWER_ROLE_ID = 1403510368340410550
 TOP_MSG_ROLE_ID = 1406412171965104208
-TOP_VC_ROLE_ID = 1406412383878111985
+TOP_VC_ROLE_ID = 1406412383878119485
 MVP_ROLE_ID = 1406412507433795595
 
 ANNOUNCE_CHANNEL_ID: int = int(os.getenv("ANNOUNCE_CHANNEL_ID", "0"))
@@ -277,7 +277,7 @@ CHANNEL_RENAME_MIN_INTERVAL_PER_CHANNEL: int = int(
 CHANNEL_RENAME_MIN_INTERVAL_GLOBAL: int = int(
     os.getenv("CHANNEL_RENAME_MIN_INTERVAL_GLOBAL", "2")
 )
-"""Intervalle minimal global entre les renommages de salons."""
+"""Intervalle minimal global entre les éditions de salons."""
 
 CHANNEL_RENAME_DEBOUNCE_SECONDS: int = int(
     os.getenv("CHANNEL_RENAME_DEBOUNCE_SECONDS", "2")

--- a/config.py
+++ b/config.py
@@ -277,7 +277,7 @@ CHANNEL_RENAME_MIN_INTERVAL_PER_CHANNEL: int = int(
 CHANNEL_RENAME_MIN_INTERVAL_GLOBAL: int = int(
     os.getenv("CHANNEL_RENAME_MIN_INTERVAL_GLOBAL", "2")
 )
-"""Intervalle minimal global entre les éditions de salons."""
+"""Intervalle minimal global entre les renommages de salons."""
 
 CHANNEL_RENAME_DEBOUNCE_SECONDS: int = int(
     os.getenv("CHANNEL_RENAME_DEBOUNCE_SECONDS", "2")

--- a/tests/test_casino_components_v2.py
+++ b/tests/test_casino_components_v2.py
@@ -43,21 +43,12 @@ def _roulette_cog(*, is_open: bool) -> pari_xp.PariXPCog:
     return cog
 
 
-def test_roulette_v2_closed_state_disables_all_existing_bet_buttons() -> None:
+def test_roulette_v2_closed_state_hides_all_bet_buttons() -> None:
     view = pari_xp.RouletteXPView(_roulette_cog(is_open=False), disabled=True)
 
     assert isinstance(view, discord.ui.LayoutView)
-    assert "🔴 **Fermé**" in _text(view)
-
-    buttons = _buttons(view)
-    assert [button.custom_id for button in buttons] == [
-        "pari_xp:red",
-        "pari_xp:black",
-        "pari_xp:even",
-        "pari_xp:odd",
-        "pari_xp:number",
-    ]
-    assert all(button.disabled for button in buttons)
+    assert _text(view) == "🔴 **Casino fermé**"
+    assert _buttons(view) == []
 
 
 def test_slot_machine_v2_open_and_closed_posters_keep_same_play_contract() -> None:

--- a/tests/test_pari_xp_active.py
+++ b/tests/test_pari_xp_active.py
@@ -29,19 +29,19 @@ def _view_text(view: discord.ui.LayoutView) -> str:
 
 def test_is_open_now_respects_overnight_schedule(monkeypatch):
     monkeypatch.setattr(pari_xp, "CASINO_OPEN_HOUR", 10)
-    monkeypatch.setattr(pari_xp, "CASINO_CLOSE_HOUR", 2)
+    monkeypatch.setattr(pari_xp, "CASINO_CLOSE_HOUR", 6)
     cog = _make_cog()
 
     assert cog._is_open_now(pari_xp.datetime(2026, 8, 8, 10, 0, tzinfo=pari_xp.PARIS_TZ))
-    assert cog._is_open_now(pari_xp.datetime(2026, 8, 9, 1, 59, tzinfo=pari_xp.PARIS_TZ))
+    assert cog._is_open_now(pari_xp.datetime(2026, 8, 9, 5, 59, tzinfo=pari_xp.PARIS_TZ))
     assert not cog._is_open_now(pari_xp.datetime(2026, 8, 8, 9, 59, tzinfo=pari_xp.PARIS_TZ))
-    assert not cog._is_open_now(pari_xp.datetime(2026, 8, 9, 2, 0, tzinfo=pari_xp.PARIS_TZ))
+    assert not cog._is_open_now(pari_xp.datetime(2026, 8, 9, 6, 0, tzinfo=pari_xp.PARIS_TZ))
 
 
 def test_roulette_v2_reflects_active_state(monkeypatch):
     monkeypatch.setattr(pari_xp, "CASINO_OPEN_HOUR", 10)
-    monkeypatch.setattr(pari_xp, "CASINO_CLOSE_HOUR", 2)
-    monkeypatch.setattr(pari_xp, "CASINO_SCHEDULE_LABEL", "10h00 - 02h00")
+    monkeypatch.setattr(pari_xp, "CASINO_CLOSE_HOUR", 6)
+    monkeypatch.setattr(pari_xp, "CASINO_SCHEDULE_LABEL", "10h00 - 06h00")
     cog = _make_cog(is_open=True)
     cog.state["total_bets"] = 250
     cog.state["total_winnings"] = 100
@@ -52,7 +52,7 @@ def test_roulette_v2_reflects_active_state(monkeypatch):
     assert isinstance(view, discord.ui.LayoutView)
     assert "🎰 Pari XP" in text
     assert "🟢 **Ouvert**" in text
-    assert "ferme à **02:00**" in text
+    assert "ferme à **06:00**" in text
     assert "XP misés : **250**" in text
     assert "XP gagnés : **100**" in text
 


### PR DESCRIPTION
## Objectif
Appliquer les deux corrections relevées pendant la validation Android de l’étape 7, sans modifier la logique métier du casino.

## Changements
- heure de fermeture par défaut du casino : **02h00 → 06h00** ;
- plage affichée : **10h00 - 06h00** ;
- les messages de fermeture Roulette XP et Machine à sous utilisent désormais le libellé d’horaire centralisé, afin d’éviter un texte obsolète ;
- lorsque la Roulette XP est fermée, son panneau Components V2 affiche uniquement **« 🔴 Casino fermé »** ;
- les cinq boutons Rouge / Noir / Pair / Impair / Numéro ne sont plus rendus lorsque le casino est fermé ;
- lorsque la Roulette XP est ouverte, les cinq boutons, leurs `custom_id`, les modales et toute la logique de pari restent inchangés.

## Tests ciblés adaptés
- frontière horaire vérifiée à **05:59 ouvert / 06:00 fermé** ;
- panneau Roulette ouvert attendu avec fermeture affichée à **06:00** ;
- panneau Roulette fermé attendu sans aucun bouton.

## Hors périmètre
Aucun changement des probabilités, multiplicateurs, XP, tickets, jackpots, essai quotidien, classement casino ou stockage.

## Validation
La suite pytest n’a pas été exécutée dans le runtime ChatGPT : `discord.py` n’y est pas installé (`ModuleNotFoundError: discord`). La PR reste en brouillon jusqu’à validation explicite.