### PR TITLE
feat: migrate achievements display to Components V2

### DIFF
--- a/cogs/achievements.py
+++ b/cogs/achievements.py
@@ -12,6 +12,11 @@ from discord.ext import commands, tasks
 from config import DATA_DIR
 from storage.achievement_store import achievement_store
 from storage.xp_store import xp_store
+from ui.achievements_view import (
+    AchievementCategoryDisplay,
+    AchievementDisplay,
+    AchievementsView,
+)
 from utils.achievements import (
     ACHIEVEMENTS,
     CATEGORY_LABELS,
@@ -175,39 +180,48 @@ class AchievementsCog(commands.Cog):
         metrics, newly_unlocked = await self._sync_member(target)
         unlocked = await achievement_store.get_user_achievements(target.id)
 
-        embed = discord.Embed(
-            title=f"🏅 Succès de {target.display_name}",
-            description=(
-                f"**{len(unlocked)}/{len(ACHIEVEMENTS)}** badges débloqués."
-            ),
-        )
-        if newly_unlocked:
-            embed.description += (
-                f"\n✨ **{len(newly_unlocked)} nouveau(x) succès** reconnu(s) maintenant."
-            )
-
+        categories: list[AchievementCategoryDisplay] = []
         for category, label in CATEGORY_LABELS.items():
-            lines: list[str] = []
+            achievements: list[AchievementDisplay] = []
             for achievement in ACHIEVEMENTS:
                 if achievement.category != category:
                     continue
                 if achievement.id in unlocked:
-                    lines.append(
-                        f"✅ {achievement.emoji} **{achievement.name}** — {achievement.description}"
-                    )
+                    detail = achievement.description
+                    status = "✅"
                 else:
                     current, target_value = achievement_progress(achievement, metrics)
-                    progress = _format_progress(
+                    detail = _format_progress(
                         achievement.metric,
                         current,
                         target_value,
                     )
-                    lines.append(
-                        f"🔒 {achievement.emoji} **{achievement.name}** — {progress}"
+                    status = "🔒"
+                achievements.append(
+                    AchievementDisplay(
+                        status=status,
+                        emoji=achievement.emoji,
+                        name=achievement.name,
+                        detail=detail,
                     )
-            embed.add_field(name=label, value="\n".join(lines), inline=False)
+                )
+            if achievements:
+                categories.append(
+                    AchievementCategoryDisplay(
+                        label=label,
+                        achievements=tuple(achievements),
+                    )
+                )
 
-        await interaction.response.send_message(embed=embed)
+        await interaction.response.send_message(
+            view=AchievementsView(
+                display_name=target.display_name,
+                unlocked_count=len(unlocked),
+                total_count=len(ACHIEVEMENTS),
+                categories=tuple(categories),
+                newly_unlocked_count=len(newly_unlocked),
+            )
+        )
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/tests/test_achievements_view.py
+++ b/tests/test_achievements_view.py
@@ -1,0 +1,119 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+import cogs.achievements as achievements
+from ui.achievements_view import (
+    AchievementCategoryDisplay,
+    AchievementDisplay,
+    AchievementsView,
+)
+
+
+def _text(view: discord.ui.LayoutView) -> str:
+    return "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+
+
+def _buttons(view: discord.ui.LayoutView) -> list[discord.ui.Button]:
+    return [
+        item
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.Button)
+    ]
+
+
+def test_achievements_view_renders_read_only_components_v2_panel() -> None:
+    view = AchievementsView(
+        display_name="Kevin",
+        unlocked_count=2,
+        total_count=9,
+        newly_unlocked_count=1,
+        categories=(
+            AchievementCategoryDisplay(
+                label="Progression XP",
+                achievements=(
+                    AchievementDisplay(
+                        status="✅",
+                        emoji="🥉",
+                        name="Membre Bronze",
+                        detail="Atteindre le niveau 5.",
+                    ),
+                    AchievementDisplay(
+                        status="🔒",
+                        emoji="🥈",
+                        name="Membre Argent",
+                        detail="niveau 7/10",
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    text = _text(view)
+    assert isinstance(view, discord.ui.LayoutView)
+    assert "🏅 SUCCÈS DU REFUGE" in text
+    assert "**Kevin**" in text
+    assert "**2/9** badges débloqués." in text
+    assert "**1 nouveau(x) succès**" in text
+    assert "### Progression XP" in text
+    assert "✅ 🥉 **Membre Bronze** — Atteindre le niveau 5." in text
+    assert "🔒 🥈 **Membre Argent** — niveau 7/10" in text
+    assert _buttons(view) == []
+
+
+@pytest.mark.asyncio
+async def test_succes_command_keeps_existing_sync_and_sends_v2_view(monkeypatch) -> None:
+    cog = object.__new__(achievements.AchievementsCog)
+    cog._sync_member = AsyncMock(
+        return_value=(
+            {
+                "level": 7,
+                "casino_bets": 0,
+                "tenure_days": 40,
+            },
+            ["level_5"],
+        )
+    )
+    get_user_achievements = AsyncMock(
+        return_value={
+            "level_5": "2026-08-09T02:00:00+00:00",
+            "tenure_30_days": "2026-08-09T02:00:00+00:00",
+        }
+    )
+    monkeypatch.setattr(
+        achievements.achievement_store,
+        "get_user_achievements",
+        get_user_achievements,
+    )
+
+    target = SimpleNamespace(id=42, display_name="Kevin")
+    send_message = AsyncMock()
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(send_message=send_message),
+    )
+
+    await achievements.AchievementsCog.succes.callback(
+        cog,
+        interaction,
+        target,
+    )
+
+    cog._sync_member.assert_awaited_once_with(target)
+    get_user_achievements.assert_awaited_once_with(42)
+    send_message.assert_awaited_once()
+
+    kwargs = send_message.await_args.kwargs
+    assert "embed" not in kwargs
+    assert isinstance(kwargs["view"], AchievementsView)
+
+    text = _text(kwargs["view"])
+    assert "**2/9** badges débloqués." in text
+    assert "✅ 🥉 **Membre Bronze** — Atteindre le niveau 5." in text
+    assert "🔒 🥈 **Membre Argent** — niveau 7/10" in text
+    assert "✅ 🌱 **Un mois au Refuge** — Être membre du Refuge depuis 30 jours." in text

--- a/ui/achievements_view.py
+++ b/ui/achievements_view.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import discord
+
+
+ACHIEVEMENTS_ACCENT = discord.Colour.gold()
+
+
+@dataclass(frozen=True, slots=True)
+class AchievementDisplay:
+    """Display-ready values for one achievement entry."""
+
+    status: str
+    emoji: str
+    name: str
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class AchievementCategoryDisplay:
+    """Display-ready values for one achievement category."""
+
+    label: str
+    achievements: tuple[AchievementDisplay, ...]
+
+
+class AchievementsView(discord.ui.LayoutView):
+    """Read-only mobile-first Components V2 achievements panel."""
+
+    def __init__(
+        self,
+        *,
+        display_name: str,
+        unlocked_count: int,
+        total_count: int,
+        categories: tuple[AchievementCategoryDisplay, ...],
+        newly_unlocked_count: int = 0,
+    ) -> None:
+        super().__init__(timeout=None)
+
+        container = discord.ui.Container(accent_colour=ACHIEVEMENTS_ACCENT)
+        container.add_item(
+            discord.ui.TextDisplay(
+                "## 🏅 SUCCÈS DU REFUGE\n"
+                f"**{display_name}**"
+            )
+        )
+
+        container.add_item(discord.ui.Separator())
+        summary = f"**{unlocked_count}/{total_count}** badges débloqués."
+        if newly_unlocked_count:
+            summary += (
+                "\n"
+                f"✨ **{newly_unlocked_count} nouveau(x) succès** reconnu(s) maintenant."
+            )
+        container.add_item(discord.ui.TextDisplay(summary))
+
+        for category in categories:
+            if not category.achievements:
+                continue
+            lines = [f"### {category.label}"]
+            lines.extend(
+                f"{achievement.status} {achievement.emoji} "
+                f"**{achievement.name}** — {achievement.detail}"
+                for achievement in category.achievements
+            )
+            container.add_item(discord.ui.Separator())
+            container.add_item(discord.ui.TextDisplay("\n".join(lines)))
+
+        self.add_item(container)
+
+
+__all__ = [
+    "ACHIEVEMENTS_ACCENT",
+    "AchievementCategoryDisplay",
+    "AchievementDisplay",
+    "AchievementsView",
+]


### PR DESCRIPTION
## Objectif
Migrer l’affichage des succès / badges vers Discord Components V2 pour terminer l’étape 8, sans modifier les règles de déblocage, la progression ni le stockage.

## Changements
- `/succes` conserve exactement le même flux métier : résolution du membre, `_sync_member()`, lecture de `achievement_store`, calcul des progressions et reconnaissance des nouveaux succès ;
- remplacement de l’ancien `discord.Embed` par une `AchievementsView` basée sur `discord.ui.LayoutView` ;
- panneau mobile-first en lecture seule avec : nom du membre, compteur de badges, nouveaux succès reconnus, puis catégories Progression XP / Casino XP / Ancienneté ;
- succès débloqués : même description qu’avant ;
- succès verrouillés : même progression qu’avant (`niveau x/y`, `x/y paris`, `x/y jours`) ;
- aucune logique de qualification ou de persistance dans la classe UI.

## Tests ciblés ajoutés
- rendu Components V2 du panneau et absence de boutons ;
- conservation de l’appel `_sync_member()` et de la lecture `achievement_store` ;
- vérification que `/succes` envoie une `AchievementsView` et non un embed ;
- vérification des lignes débloquées / verrouillées et de la progression affichée.

## Hors périmètre
Aucun changement dans `utils/achievements.py`, `storage/achievement_store.py`, XP, casino, ancienneté, seuils, catalogue des 9 succès ou tâche de synchronisation périodique.

## Validation technique
Le diff a été contrôlé par rapport à `main` : 3 fichiers seulement. Les tests pytest n’ont pas pu être exécutés dans le runtime ChatGPT : `discord.py` n’y est pas installé et le checkout réseau GitHub n’est pas accessible depuis le conteneur. La PR reste en brouillon jusqu’à validation explicite de l’utilisateur.