### PR TITLE
feat: migrate seasonal leaderboard to Components V2

### DIFF
--- a/cogs/seasonal_leaderboards.py
+++ b/cogs/seasonal_leaderboards.py
@@ -11,6 +11,10 @@ from discord.ext import commands, tasks
 
 from config import DATA_DIR
 from storage.season_store import season_store
+from ui.season_leaderboard_view import (
+    SeasonLeaderboardEntry,
+    SeasonLeaderboardView,
+)
 from utils.persistence import read_json_safe
 from utils.seasons import (
     SEASON_METRICS,
@@ -200,33 +204,37 @@ class SeasonalLeaderboardsCog(commands.Cog):
             if len(visible_rows) >= 10:
                 break
 
-        lines: list[str] = []
-        for rank, (_user_id, value, display) in enumerate(visible_rows, start=1):
-            medal = {1: "🥇", 2: "🥈", 3: "🥉"}.get(rank, f"**#{rank}**")
-            lines.append(
-                f"{medal} {display} — **{format_metric_value(metric.key, value)}**"
+        entries = tuple(
+            SeasonLeaderboardEntry(
+                rank=rank,
+                display_name=display,
+                value=format_metric_value(metric.key, value),
             )
-
-        if not lines:
-            lines.append("Aucune activité enregistrée dans cette catégorie.")
+            for rank, (_user_id, value, display) in enumerate(
+                visible_rows,
+                start=1,
+            )
+        )
 
         started_at = payload.get("started_at")
-        tracking_note = ""
+        tracking_note: str | None = None
         if started_at:
             try:
                 started = datetime.fromisoformat(str(started_at))
-                tracking_note = f"\nSuivi de cette saison depuis <t:{int(started.timestamp())}:d>."
+                tracking_note = (
+                    f"Suivi de cette saison depuis <t:{int(started.timestamp())}:d>."
+                )
             except ValueError:
                 pass
 
-        embed = discord.Embed(
-            title=f"🏆 {metric.label} — {season_label(season_id)}",
-            description="\n".join(lines) + tracking_note,
+        await interaction.response.send_message(
+            view=SeasonLeaderboardView(
+                metric_label=metric.label,
+                season_label_text=season_label(season_id),
+                entries=entries,
+                tracking_note=tracking_note,
+            )
         )
-        embed.set_footer(
-            text="Saisons mensuelles · Europe/Paris · historique conservé"
-        )
-        await interaction.response.send_message(embed=embed)
 
 
 async def setup(bot: commands.Bot) -> None:

--- a/tests/test_season_leaderboard_view.py
+++ b/tests/test_season_leaderboard_view.py
@@ -1,0 +1,113 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+import cogs.seasonal_leaderboards as seasonal
+from ui.season_leaderboard_view import (
+    SeasonLeaderboardEntry,
+    SeasonLeaderboardView,
+)
+
+
+def _text(view: discord.ui.LayoutView) -> str:
+    return "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+
+
+def _buttons(view: discord.ui.LayoutView) -> list[discord.ui.Button]:
+    return [
+        item
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.Button)
+    ]
+
+
+def test_season_leaderboard_view_renders_mobile_read_only_top() -> None:
+    view = SeasonLeaderboardView(
+        metric_label="XP gagnée",
+        season_label_text="Août 2026",
+        entries=(
+            SeasonLeaderboardEntry(rank=1, display_name="Alice", value="120 XP"),
+            SeasonLeaderboardEntry(rank=2, display_name="Bob", value="90 XP"),
+            SeasonLeaderboardEntry(rank=4, display_name="Cara", value="40 XP"),
+        ),
+        tracking_note="Suivi de cette saison depuis <t:1785542400:d>.",
+    )
+
+    text = _text(view)
+    assert isinstance(view, discord.ui.LayoutView)
+    assert "🏆 CLASSEMENT SAISONNIER" in text
+    assert "**XP gagnée · Août 2026**" in text
+    assert "🥇 Alice — **120 XP**" in text
+    assert "🥈 Bob — **90 XP**" in text
+    assert "**#4** Cara — **40 XP**" in text
+    assert "Suivi de cette saison depuis <t:1785542400:d>." in text
+    assert "Saisons mensuelles · Europe/Paris · historique conservé" in text
+    assert _buttons(view) == []
+
+
+def test_season_leaderboard_view_handles_empty_category() -> None:
+    view = SeasonLeaderboardView(
+        metric_label="Messages",
+        season_label_text="Août 2026",
+        entries=(),
+    )
+
+    assert "Aucune activité enregistrée dans cette catégorie." in _text(view)
+
+
+@pytest.mark.asyncio
+async def test_classement_saison_keeps_ranking_filters_and_sends_v2(monkeypatch) -> None:
+    get_season = AsyncMock(
+        return_value={
+            "started_at": "2026-08-01T00:00:00+02:00",
+            "users": {
+                "99": {"xp_earned": 999},
+                "1": {"xp_earned": 120},
+                "2": {"xp_earned": 90},
+                "3": {"xp_earned": 40},
+            },
+        }
+    )
+    monkeypatch.setattr(seasonal.season_store, "get_season", get_season)
+
+    members = {
+        99: SimpleNamespace(display_name="RankingBot", bot=True),
+        1: SimpleNamespace(display_name="Alice", bot=False),
+        2: SimpleNamespace(display_name="Bob", bot=False),
+        3: SimpleNamespace(display_name="Cara", bot=False),
+    }
+    guild = SimpleNamespace(get_member=lambda user_id: members.get(user_id))
+    send_message = AsyncMock()
+    interaction = SimpleNamespace(
+        guild=guild,
+        response=SimpleNamespace(send_message=send_message),
+    )
+    categorie = SimpleNamespace(value="xp")
+    cog = object.__new__(seasonal.SeasonalLeaderboardsCog)
+
+    await seasonal.SeasonalLeaderboardsCog.classement_saison.callback(
+        cog,
+        interaction,
+        categorie,
+        "2026-08",
+    )
+
+    get_season.assert_awaited_once_with("2026-08")
+    send_message.assert_awaited_once()
+    kwargs = send_message.await_args.kwargs
+    assert "embed" not in kwargs
+    assert isinstance(kwargs["view"], SeasonLeaderboardView)
+
+    text = _text(kwargs["view"])
+    assert "**XP gagnée · Août 2026**" in text
+    assert "RankingBot" not in text
+    assert "🥇 Alice — **120 XP**" in text
+    assert "🥈 Bob — **90 XP**" in text
+    assert "🥉 Cara — **40 XP**" in text
+    assert "Suivi de cette saison depuis" in text

--- a/ui/season_leaderboard_view.py
+++ b/ui/season_leaderboard_view.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import discord
+
+
+SEASON_LEADERBOARD_ACCENT = discord.Colour.gold()
+
+
+@dataclass(frozen=True, slots=True)
+class SeasonLeaderboardEntry:
+    """Display-ready values for one seasonal leaderboard row."""
+
+    rank: int
+    display_name: str
+    value: str
+
+
+class SeasonLeaderboardView(discord.ui.LayoutView):
+    """Read-only mobile-first Components V2 seasonal leaderboard."""
+
+    def __init__(
+        self,
+        *,
+        metric_label: str,
+        season_label_text: str,
+        entries: tuple[SeasonLeaderboardEntry, ...],
+        tracking_note: str | None = None,
+    ) -> None:
+        super().__init__(timeout=None)
+
+        container = discord.ui.Container(accent_colour=SEASON_LEADERBOARD_ACCENT)
+        container.add_item(
+            discord.ui.TextDisplay(
+                "## 🏆 CLASSEMENT SAISONNIER\n"
+                f"**{metric_label} · {season_label_text}**"
+            )
+        )
+        container.add_item(discord.ui.Separator())
+
+        if entries:
+            lines: list[str] = []
+            for entry in entries:
+                rank_label = {
+                    1: "🥇",
+                    2: "🥈",
+                    3: "🥉",
+                }.get(entry.rank, f"**#{entry.rank}**")
+                lines.append(
+                    f"{rank_label} {entry.display_name} — **{entry.value}**"
+                )
+            container.add_item(discord.ui.TextDisplay("\n".join(lines)))
+        else:
+            container.add_item(
+                discord.ui.TextDisplay(
+                    "Aucune activité enregistrée dans cette catégorie."
+                )
+            )
+
+        if tracking_note:
+            container.add_item(discord.ui.Separator())
+            container.add_item(discord.ui.TextDisplay(f"-# {tracking_note}"))
+
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "-# Saisons mensuelles · Europe/Paris · historique conservé"
+            )
+        )
+        self.add_item(container)
+
+
+__all__ = [
+    "SEASON_LEADERBOARD_ACCENT",
+    "SeasonLeaderboardEntry",
+    "SeasonLeaderboardView",
+]


### PR DESCRIPTION
## Objectif
Migrer `/classement_saison` vers Discord Components V2 pour l’étape 9, sans modifier les règles de saison, le stockage, le calcul des métriques ni l’ordre du classement.

## Changements
- `/classement_saison` conserve les mêmes paramètres `categorie` et `saison` ;
- les erreurs de catégorie inconnue, format `AAAA-MM` invalide et saison absente restent inchangées et éphémères ;
- la récupération `season_store.get_season()`, `rank_rows()`, le filtrage des bots, la limite Top 10 et `format_metric_value()` restent dans le cog ;
- remplacement de l’ancien `discord.Embed` final par une `SeasonLeaderboardView` basée sur `discord.ui.LayoutView` ;
- panneau mobile-first en lecture seule avec titre, métrique, mois, Top 10, médailles/rangs, note de début de suivi et rappel `Europe/Paris · historique conservé` ;
- état vide conservé : `Aucune activité enregistrée dans cette catégorie.`

## Tests ciblés ajoutés
- rendu Components V2 mobile et absence de boutons ;
- rendu d’une catégorie vide ;
- conservation de la récupération de saison, du filtrage des bots, du classement et du format XP ;
- vérification que `/classement_saison` envoie une `SeasonLeaderboardView` et non un embed.

## Hors périmètre
Aucun changement dans `storage/season_store.py`, `utils/seasons.py`, le suivi XP/messages/vocal/casino, les saisons mensuelles Europe/Paris, l’historique, les règles de classement ou les données persistées.

## Validation technique
Le diff a été contrôlé contre `main` : 3 fichiers seulement. Les tests pytest ne sont pas annoncés comme exécutés dans le runtime ChatGPT, qui ne dispose pas de l’environnement Discord complet. La PR reste en brouillon jusqu’à validation explicite de l’utilisateur.