### PR TITLE
refactor: remove Components V2 migration compatibility

### DIFF
--- a/cogs/machine_a_sous/machine_a_sous.py
+++ b/cogs/machine_a_sous/machine_a_sous.py
@@ -63,7 +63,7 @@ def _is_casino_open(now: Optional[datetime] = None) -> bool:
 
 
 def _poster_component_metadata(message: discord.Message) -> tuple[list[str], list[str]]:
-    """Extract text and custom IDs from legacy or V2 message components."""
+    """Extract text and custom IDs from Components V2 poster components."""
 
     texts: list[str] = []
     custom_ids: list[str] = []
@@ -81,9 +81,6 @@ def _poster_component_metadata(message: discord.Message) -> tuple[list[str], lis
 
 
 def _is_machine_poster_message(message: discord.Message) -> bool:
-    embeds = list(getattr(message, "embeds", []) or [])
-    if embeds and getattr(embeds[0], "title", None) == "🎰 Machine à sous":
-        return True
     texts, _ = _poster_component_metadata(message)
     return any("🎰 Machine à sous" in text for text in texts)
 
@@ -91,12 +88,6 @@ def _is_machine_poster_message(message: discord.Message) -> bool:
 def _poster_has_play_button(message: discord.Message) -> bool:
     _, custom_ids = _poster_component_metadata(message)
     return "machineasous:play" in custom_ids
-
-
-def _poster_is_components_v2(message: discord.Message) -> bool:
-    return not bool(getattr(message, "embeds", [])) and bool(
-        getattr(message, "components", [])
-    )
 
 
 class MachineASousActionRow(discord.ui.ActionRow):
@@ -481,8 +472,7 @@ class MachineASousCog(commands.Cog):
                         msg = await ch.fetch_message(int(poster.get("message_id", 0)))
                         has_button = _poster_has_play_button(msg)
                         if (
-                            not _poster_is_components_v2(msg)
-                            or not _is_machine_poster_message(msg)
+                            not _is_machine_poster_message(msg)
                             or has_button != self.current_view_enabled
                         ):
                             await self._replace_poster_message()
@@ -492,12 +482,7 @@ class MachineASousCog(commands.Cog):
         existing = await self._find_existing_poster()
         if existing:
             has_button = _poster_has_play_button(existing)
-            if (
-                not _poster_is_components_v2(existing)
-                or has_button != self.current_view_enabled
-            ):
-                # Persist the discovered legacy/stale poster first so the
-                # replacement path deletes that exact message before sending V2.
+            if has_button != self.current_view_enabled:
                 self.store.set_poster(
                     channel_id=str(existing.channel.id),
                     message_id=str(existing.id),

--- a/cogs/pari_xp.py
+++ b/cogs/pari_xp.py
@@ -353,8 +353,7 @@ class PariXPCog(commands.Cog):
                 message = None
 
         if message:
-            is_legacy = bool(getattr(message, "embeds", []))
-            if self._last_panel_signature == signature and not is_legacy:
+            if self._last_panel_signature == signature:
                 return
             await safe_message_edit(
                 message,

--- a/tests/test_casino_components_v2.py
+++ b/tests/test_casino_components_v2.py
@@ -11,7 +11,6 @@ from cogs.machine_a_sous.machine_a_sous import (
     MachineASousView,
     _is_machine_poster_message,
     _poster_has_play_button,
-    _poster_is_components_v2,
 )
 
 
@@ -64,25 +63,23 @@ def test_slot_machine_v2_open_and_closed_posters_keep_same_play_contract() -> No
     assert _buttons(closed) == []
 
 
-def test_slot_poster_detection_distinguishes_legacy_and_components_v2() -> None:
+def test_slot_poster_detection_uses_components_v2_contract() -> None:
     v2_view = MachineASousView(enabled=True)
     v2_message = SimpleNamespace(embeds=[], components=v2_view.children)
 
     assert _is_machine_poster_message(v2_message)
-    assert _poster_is_components_v2(v2_message)
     assert _poster_has_play_button(v2_message)
 
-    legacy_message = SimpleNamespace(
+    legacy_embed = SimpleNamespace(
         embeds=[SimpleNamespace(title="🎰 Machine à sous")],
         components=[],
     )
-    assert _is_machine_poster_message(legacy_message)
-    assert not _poster_is_components_v2(legacy_message)
-    assert not _poster_has_play_button(legacy_message)
+    assert not _is_machine_poster_message(legacy_embed)
+    assert not _poster_has_play_button(legacy_embed)
 
 
 @pytest.mark.asyncio
-async def test_discovered_legacy_slot_poster_is_registered_before_replacement(
+async def test_discovered_v2_slot_poster_is_registered_without_replacement(
     monkeypatch,
 ) -> None:
     class FakeTextChannel:
@@ -90,18 +87,19 @@ async def test_discovered_legacy_slot_poster_is_registered_before_replacement(
 
         async def history(self, *, limit: int):
             assert limit == 20
-            yield legacy_message
+            yield existing_message
 
     class FakeThread:
         pass
 
     channel = FakeTextChannel()
-    legacy_message = SimpleNamespace(
+    v2_view = MachineASousView(enabled=True)
+    existing_message = SimpleNamespace(
         id=321,
         author=SimpleNamespace(id=999),
         channel=channel,
-        embeds=[SimpleNamespace(title="🎰 Machine à sous")],
-        components=[],
+        embeds=[],
+        components=v2_view.children,
     )
     bot = SimpleNamespace(
         user=SimpleNamespace(id=999),
@@ -115,18 +113,15 @@ async def test_discovered_legacy_slot_poster_is_registered_before_replacement(
     cog.bot = bot
     cog.store = store
     cog.current_view_enabled = True
-
-    async def replace_after_registration() -> None:
-        store.set_poster.assert_called_once_with(
-            channel_id=str(channel.id),
-            message_id=str(legacy_message.id),
-        )
-
-    cog._replace_poster_message = AsyncMock(side_effect=replace_after_registration)
+    cog._replace_poster_message = AsyncMock()
 
     monkeypatch.setattr(machine_a_sous.discord, "TextChannel", FakeTextChannel)
     monkeypatch.setattr(machine_a_sous.discord, "Thread", FakeThread)
 
     await MachineASousCog._ensure_poster_message(cog)
 
-    cog._replace_poster_message.assert_awaited_once()
+    store.set_poster.assert_called_once_with(
+        channel_id=str(channel.id),
+        message_id=str(existing_message.id),
+    )
+    cog._replace_poster_message.assert_not_awaited()

--- a/tests/test_casino_components_v2.py
+++ b/tests/test_casino_components_v2.py
@@ -70,12 +70,12 @@ def test_slot_poster_detection_uses_components_v2_contract() -> None:
     assert _is_machine_poster_message(v2_message)
     assert _poster_has_play_button(v2_message)
 
-    legacy_embed = SimpleNamespace(
+    embed_only_message = SimpleNamespace(
         embeds=[SimpleNamespace(title="🎰 Machine à sous")],
         components=[],
     )
-    assert not _is_machine_poster_message(legacy_embed)
-    assert not _poster_has_play_button(legacy_embed)
+    assert not _is_machine_poster_message(embed_only_message)
+    assert not _poster_has_play_button(embed_only_message)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Objectif
Finaliser l’étape 10 de nettoyage après validation des migrations Components V2, sans supprimer de commande active et sans modifier la logique métier.

## Audit préalable
- `/profil`, `/succes`, `/objectif_communaute` et `/classement_saison` n’ont pas de doublon de commande détecté ; aucune commande n’est supprimée ;
- `RoleView` et `PlayerTypeView` sont encore référencées par le bot et restent intactes ;
- les embeds encore utilisés pour des notifications courtes ou des résultats transitoires ne sont pas considérés comme des interfaces legacy et restent en place ;
- le seul code explicitement transitoire restant concernait la détection/reprise d’anciens panneaux casino lors de la migration V2.

## Changements
- Roulette XP : suppression de l’inspection des embeds pour déterminer si le panneau permanent est legacy ; la mise à jour repose désormais uniquement sur la signature d’état V2 ;
- Machine à sous : la détection d’un poster existant ne reconnaît plus l’ancien embed `🎰 Machine à sous`, seulement le contrat Components V2 ;
- suppression du helper `_poster_is_components_v2`, devenu redondant ;
- conservation de la recherche d’un panneau V2 existant dans l’historique lorsque le stockage de son identifiant manque, afin d’éviter les doublons ;
- conservation du remplacement d’un poster stocké s’il ne correspond plus au panneau V2 attendu ou si l’état du bouton ouvert/fermé est incorrect ;
- adaptation des tests pour vérifier le contrat final V2 et la récupération d’un panneau V2 existant sans duplication.

## Hors périmètre
Aucune modification des probabilités, multiplicateurs, XP, tickets, jackpots, horaires, stockage, classement casino, profils, succès, objectifs communautaires ou saisons. Aucune commande n’est retirée.

## Diff
3 fichiers seulement :
- `cogs/pari_xp.py`
- `cogs/machine_a_sous/machine_a_sous.py`
- `tests/test_casino_components_v2.py`

Diff contrôlé contre `main` : 4 ajouts / 19 suppressions dans la machine à sous, 1 ajout / 2 suppressions dans la roulette, et adaptation ciblée des tests.

## Validation technique
Les patches des commits ont été inspectés individuellement et ne contiennent pas de modification métier parasite. Les tests pytest ne peuvent pas être exécutés dans le runtime ChatGPT car `discord.py` n’y est pas installé (`ModuleNotFoundError: No module named 'discord'`). Aucun succès de test n’est donc revendiqué. La PR reste en brouillon jusqu’à validation explicite de l’utilisateur.