### PR TITLE
feat: add Refuge world persistence foundation

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,1 @@
+"""Domain models used by bot services and persistence layers."""

--- a/models/refuge_world.py
+++ b/models/refuge_world.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Mapping
+
+REFUGE_WORLD_SCHEMA_VERSION = 1
+
+
+def _string_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _dict_copy(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): item for key, item in value.items()}
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeBuildingState:
+    building_id: str
+    level: int = 0
+    unlocked_at: str | None = None
+    state: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "building_id": self.building_id,
+            "level": max(0, int(self.level)),
+            "unlocked_at": self.unlocked_at,
+            "state": dict(self.state),
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        fallback_id: str | None = None,
+    ) -> "RefugeBuildingState":
+        building_id = _string_or_none(payload.get("building_id")) or fallback_id
+        if not building_id:
+            raise ValueError("building_id is required")
+        try:
+            level = max(0, int(payload.get("level", 0)))
+        except (TypeError, ValueError):
+            level = 0
+        return cls(
+            building_id=building_id,
+            level=level,
+            unlocked_at=_string_or_none(payload.get("unlocked_at")),
+            state=_dict_copy(payload.get("state")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeHistoricalEvent:
+    event_id: str
+    event_type: str
+    occurred_at: str
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "event_id": self.event_id,
+            "event_type": self.event_type,
+            "occurred_at": self.occurred_at,
+            "data": dict(self.data),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "RefugeHistoricalEvent":
+        event_id = _string_or_none(payload.get("event_id"))
+        event_type = _string_or_none(payload.get("event_type"))
+        occurred_at = _string_or_none(payload.get("occurred_at"))
+        if not event_id or not event_type or not occurred_at:
+            raise ValueError("historical event requires id, type and occurred_at")
+        return cls(
+            event_id=event_id,
+            event_type=event_type,
+            occurred_at=occurred_at,
+            data=_dict_copy(payload.get("data")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RefugePanelState:
+    channel_id: int | None = None
+    message_id: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "channel_id": self.channel_id,
+            "message_id": self.message_id,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "RefugePanelState":
+        def _positive_int_or_none(value: Any) -> int | None:
+            try:
+                normalized = int(value)
+            except (TypeError, ValueError):
+                return None
+            return normalized if normalized > 0 else None
+
+        return cls(
+            channel_id=_positive_int_or_none(payload.get("channel_id")),
+            message_id=_positive_int_or_none(payload.get("message_id")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeConstructionState:
+    construction_id: str
+    status: str
+    project_id: str | None = None
+    opened_at: str | None = None
+    closes_at: str | None = None
+    started_at: str | None = None
+    completes_at: str | None = None
+    data: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "construction_id": self.construction_id,
+            "status": self.status,
+            "project_id": self.project_id,
+            "opened_at": self.opened_at,
+            "closes_at": self.closes_at,
+            "started_at": self.started_at,
+            "completes_at": self.completes_at,
+            "data": dict(self.data),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "RefugeConstructionState":
+        construction_id = _string_or_none(payload.get("construction_id"))
+        status = _string_or_none(payload.get("status"))
+        if not construction_id or not status:
+            raise ValueError("construction requires construction_id and status")
+        return cls(
+            construction_id=construction_id,
+            status=status,
+            project_id=_string_or_none(payload.get("project_id")),
+            opened_at=_string_or_none(payload.get("opened_at")),
+            closes_at=_string_or_none(payload.get("closes_at")),
+            started_at=_string_or_none(payload.get("started_at")),
+            completes_at=_string_or_none(payload.get("completes_at")),
+            data=_dict_copy(payload.get("data")),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeWorldSnapshot:
+    season_id: str
+    captured_at: str
+    buildings: tuple[RefugeBuildingState, ...] = ()
+    event_ids: tuple[str, ...] = ()
+    active_construction: RefugeConstructionState | None = None
+    state: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "season_id": self.season_id,
+            "captured_at": self.captured_at,
+            "buildings": {
+                building.building_id: building.to_dict()
+                for building in self.buildings
+            },
+            "event_ids": list(self.event_ids),
+            "active_construction": (
+                self.active_construction.to_dict()
+                if self.active_construction is not None
+                else None
+            ),
+            "state": dict(self.state),
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        payload: Mapping[str, Any],
+        *,
+        fallback_season_id: str | None = None,
+    ) -> "RefugeWorldSnapshot":
+        season_id = _string_or_none(payload.get("season_id")) or fallback_season_id
+        captured_at = _string_or_none(payload.get("captured_at"))
+        if not season_id or not captured_at:
+            raise ValueError("snapshot requires season_id and captured_at")
+        buildings = _parse_buildings(payload.get("buildings"))
+        raw_event_ids = payload.get("event_ids", [])
+        event_ids = (
+            tuple(
+                event_id
+                for raw in raw_event_ids
+                if (event_id := _string_or_none(raw))
+            )
+            if isinstance(raw_event_ids, list)
+            else ()
+        )
+        raw_construction = payload.get("active_construction")
+        active_construction = (
+            RefugeConstructionState.from_dict(raw_construction)
+            if isinstance(raw_construction, Mapping)
+            else None
+        )
+        return cls(
+            season_id=season_id,
+            captured_at=captured_at,
+            buildings=buildings,
+            event_ids=event_ids,
+            active_construction=active_construction,
+            state=_dict_copy(payload.get("state")),
+        )
+
+
+def _parse_buildings(value: Any) -> tuple[RefugeBuildingState, ...]:
+    if not isinstance(value, Mapping):
+        return ()
+    buildings: list[RefugeBuildingState] = []
+    for raw_id, raw_payload in value.items():
+        if not isinstance(raw_payload, Mapping):
+            continue
+        try:
+            buildings.append(
+                RefugeBuildingState.from_dict(
+                    raw_payload,
+                    fallback_id=str(raw_id),
+                )
+            )
+        except ValueError:
+            continue
+    return tuple(sorted(buildings, key=lambda building: building.building_id))
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeWorldState:
+    schema_version: int = REFUGE_WORLD_SCHEMA_VERSION
+    created_at: str | None = None
+    buildings: tuple[RefugeBuildingState, ...] = ()
+    events: tuple[RefugeHistoricalEvent, ...] = ()
+    snapshots: tuple[RefugeWorldSnapshot, ...] = ()
+    panel: RefugePanelState = field(default_factory=RefugePanelState)
+    active_construction: RefugeConstructionState | None = None
+    state: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "created_at": self.created_at,
+            "buildings": {
+                building.building_id: building.to_dict()
+                for building in self.buildings
+            },
+            "events": [event.to_dict() for event in self.events],
+            "snapshots": {
+                snapshot.season_id: snapshot.to_dict()
+                for snapshot in self.snapshots
+            },
+            "panel": self.panel.to_dict(),
+            "active_construction": (
+                self.active_construction.to_dict()
+                if self.active_construction is not None
+                else None
+            ),
+            "state": dict(self.state),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "RefugeWorldState":
+        try:
+            schema_version = int(payload.get("schema_version", 0))
+        except (TypeError, ValueError):
+            schema_version = 0
+        if schema_version != REFUGE_WORLD_SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported refuge world schema version: {schema_version}"
+            )
+
+        events: list[RefugeHistoricalEvent] = []
+        raw_events = payload.get("events", [])
+        if isinstance(raw_events, list):
+            for raw_event in raw_events:
+                if not isinstance(raw_event, Mapping):
+                    continue
+                try:
+                    events.append(RefugeHistoricalEvent.from_dict(raw_event))
+                except ValueError:
+                    continue
+
+        snapshots: list[RefugeWorldSnapshot] = []
+        raw_snapshots = payload.get("snapshots", {})
+        if isinstance(raw_snapshots, Mapping):
+            for raw_season_id, raw_snapshot in raw_snapshots.items():
+                if not isinstance(raw_snapshot, Mapping):
+                    continue
+                try:
+                    snapshots.append(
+                        RefugeWorldSnapshot.from_dict(
+                            raw_snapshot,
+                            fallback_season_id=str(raw_season_id),
+                        )
+                    )
+                except ValueError:
+                    continue
+
+        raw_panel = payload.get("panel")
+        panel = (
+            RefugePanelState.from_dict(raw_panel)
+            if isinstance(raw_panel, Mapping)
+            else RefugePanelState()
+        )
+        raw_construction = payload.get("active_construction")
+        active_construction = (
+            RefugeConstructionState.from_dict(raw_construction)
+            if isinstance(raw_construction, Mapping)
+            else None
+        )
+
+        return cls(
+            schema_version=schema_version,
+            created_at=_string_or_none(payload.get("created_at")),
+            buildings=_parse_buildings(payload.get("buildings")),
+            events=tuple(events),
+            snapshots=tuple(
+                sorted(snapshots, key=lambda snapshot: snapshot.season_id)
+            ),
+            panel=panel,
+            active_construction=active_construction,
+            state=_dict_copy(payload.get("state")),
+        )

--- a/storage/refuge_world_store.py
+++ b/storage/refuge_world_store.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import asyncio
+import weakref
+from copy import deepcopy
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from config import DATA_DIR
+from models.refuge_world import (
+    REFUGE_WORLD_SCHEMA_VERSION,
+    RefugeWorldState,
+)
+from utils.persistence import atomic_write_json_async, read_json_safe
+
+
+REFUGE_WORLD_FILE = Path(DATA_DIR) / "refuge_world.json"
+
+
+class RefugeWorldSchemaError(ValueError):
+    """Raised when persisted Refuge data uses an unsupported schema."""
+
+
+def _migrate_payload(raw: Any) -> tuple[dict[str, Any], bool]:
+    if not isinstance(raw, Mapping):
+        return RefugeWorldState().to_dict(), False
+
+    payload = {str(key): value for key, value in raw.items()}
+    try:
+        version = int(payload.get("schema_version", 0))
+    except (TypeError, ValueError):
+        version = 0
+
+    if version > REFUGE_WORLD_SCHEMA_VERSION:
+        raise RefugeWorldSchemaError(
+            "refuge world schema is newer than this bot "
+            f"({version} > {REFUGE_WORLD_SCHEMA_VERSION})"
+        )
+
+    migrated = False
+    while version < REFUGE_WORLD_SCHEMA_VERSION:
+        if version == 0:
+            payload = {
+                "schema_version": 1,
+                "created_at": payload.get("created_at"),
+                "buildings": payload.get("buildings", {}),
+                "events": payload.get(
+                    "events",
+                    payload.get("historical_events", []),
+                ),
+                "snapshots": payload.get("snapshots", {}),
+                "panel": payload.get("panel", {}),
+                "active_construction": payload.get("active_construction"),
+                "state": payload.get("state", {}),
+            }
+            version = 1
+            migrated = True
+            continue
+        raise RefugeWorldSchemaError(
+            f"no refuge world migration path from schema {version}"
+        )
+
+    return payload, migrated
+
+
+def _utc_iso(at: datetime | None = None) -> str:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).isoformat()
+
+
+class RefugeWorldStore:
+    """Persist the Refuge world state without owning progression rules."""
+
+    def __init__(self, path: str | Path = REFUGE_WORLD_FILE) -> None:
+        self.path = Path(path)
+        self._loaded = False
+        self._state = RefugeWorldState()
+        self._locks: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Lock
+        ] = weakref.WeakKeyDictionary()
+
+    def _get_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[loop] = lock
+        return lock
+
+    async def _load_locked(self) -> None:
+        if self._loaded:
+            return
+
+        raw = await asyncio.to_thread(read_json_safe, self.path, None)
+        if raw is None:
+            self._state = RefugeWorldState()
+            self._loaded = True
+            return
+
+        payload, migrated = _migrate_payload(raw)
+        try:
+            state = RefugeWorldState.from_dict(payload)
+        except ValueError as exc:
+            raise RefugeWorldSchemaError(str(exc)) from exc
+
+        self._state = state
+        self._loaded = True
+        if migrated:
+            await atomic_write_json_async(self.path, state.to_dict())
+
+    async def load(self) -> RefugeWorldState:
+        async with self._get_lock():
+            await self._load_locked()
+            return deepcopy(self._state)
+
+    async def initialize(
+        self,
+        *,
+        created_at: datetime | None = None,
+    ) -> RefugeWorldState:
+        async with self._get_lock():
+            await self._load_locked()
+            if self._state.created_at is None:
+                self._state = replace(
+                    self._state,
+                    created_at=_utc_iso(created_at),
+                )
+                await atomic_write_json_async(self.path, self._state.to_dict())
+            return deepcopy(self._state)
+
+    async def get_state(self) -> RefugeWorldState:
+        async with self._get_lock():
+            await self._load_locked()
+            return deepcopy(self._state)
+
+    async def save_state(self, state: RefugeWorldState) -> RefugeWorldState:
+        if state.schema_version != REFUGE_WORLD_SCHEMA_VERSION:
+            raise RefugeWorldSchemaError(
+                "cannot persist refuge world schema "
+                f"{state.schema_version}; expected {REFUGE_WORLD_SCHEMA_VERSION}"
+            )
+        async with self._get_lock():
+            self._state = deepcopy(state)
+            self._loaded = True
+            await atomic_write_json_async(self.path, self._state.to_dict())
+            return deepcopy(self._state)
+
+
+refuge_world_store = RefugeWorldStore()
+
+
+__all__ = [
+    "REFUGE_WORLD_FILE",
+    "RefugeWorldSchemaError",
+    "RefugeWorldStore",
+    "refuge_world_store",
+]

--- a/tests/test_refuge_world_store.py
+++ b/tests/test_refuge_world_store.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from models.refuge_world import (
+    REFUGE_WORLD_SCHEMA_VERSION,
+    RefugeBuildingState,
+    RefugeConstructionState,
+    RefugeHistoricalEvent,
+    RefugePanelState,
+    RefugeWorldSnapshot,
+    RefugeWorldState,
+)
+from storage.refuge_world_store import RefugeWorldSchemaError, RefugeWorldStore
+from utils.persistence import read_json_safe
+
+
+@pytest.mark.asyncio
+async def test_initialize_is_stable_across_restart(tmp_path):
+    path = tmp_path / "refuge_world.json"
+    created = datetime(2026, 8, 9, 4, 0, tzinfo=timezone.utc)
+
+    first = RefugeWorldStore(path)
+    initialized = await first.initialize(created_at=created)
+
+    assert initialized.schema_version == REFUGE_WORLD_SCHEMA_VERSION
+    assert initialized.created_at == created.isoformat()
+
+    restarted = RefugeWorldStore(path)
+    later = await restarted.initialize(created_at=created + timedelta(days=1))
+
+    assert later == initialized
+    assert read_json_safe(path, {})["created_at"] == created.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_round_trip_preserves_world_foundation_state(tmp_path):
+    path = tmp_path / "refuge_world.json"
+    construction = RefugeConstructionState(
+        construction_id="construction-1",
+        status="voting",
+        project_id="observatory",
+        opened_at="2026-08-09T04:00:00+00:00",
+        closes_at="2026-08-12T04:00:00+00:00",
+        data={"eligible": True},
+    )
+    buildings = (
+        RefugeBuildingState(
+            building_id="fire",
+            level=2,
+            unlocked_at="2026-08-09T04:00:00+00:00",
+            state={"intensity": "normal"},
+        ),
+        RefugeBuildingState(building_id="hall", level=1),
+    )
+    event = RefugeHistoricalEvent(
+        event_id="event-1",
+        event_type="world_created",
+        occurred_at="2026-08-09T04:00:00+00:00",
+        data={"source": "refuge-001"},
+    )
+    snapshot = RefugeWorldSnapshot(
+        season_id="2026-08",
+        captured_at="2026-09-01T00:00:00+00:00",
+        buildings=buildings,
+        event_ids=(event.event_id,),
+        active_construction=construction,
+        state={"daypart": "night"},
+    )
+    expected = RefugeWorldState(
+        created_at="2026-08-09T04:00:00+00:00",
+        buildings=buildings,
+        events=(event,),
+        snapshots=(snapshot,),
+        panel=RefugePanelState(channel_id=123, message_id=456),
+        active_construction=construction,
+        state={"renderer_revision": 1},
+    )
+
+    await RefugeWorldStore(path).save_state(expected)
+    restored = await RefugeWorldStore(path).get_state()
+
+    assert restored == expected
+
+
+@pytest.mark.asyncio
+async def test_corrupt_primary_recovers_from_atomic_backup(tmp_path):
+    path = tmp_path / "refuge_world.json"
+    first_state = RefugeWorldState(created_at="2026-08-09T04:00:00+00:00")
+    second_state = RefugeWorldState(
+        created_at="2026-08-09T04:00:00+00:00",
+        panel=RefugePanelState(channel_id=10, message_id=20),
+    )
+    store = RefugeWorldStore(path)
+    await store.save_state(first_state)
+    await store.save_state(second_state)
+
+    path.write_text("{broken", encoding="utf-8")
+
+    recovered = await RefugeWorldStore(path).get_state()
+
+    assert recovered == first_state
+
+
+@pytest.mark.asyncio
+async def test_corrupt_primary_without_backup_falls_back_to_empty_world(tmp_path):
+    path = tmp_path / "refuge_world.json"
+    path.write_text("{broken", encoding="utf-8")
+
+    recovered = await RefugeWorldStore(path).get_state()
+
+    assert recovered == RefugeWorldState()
+
+
+@pytest.mark.asyncio
+async def test_unversioned_payload_migrates_to_schema_v1(tmp_path):
+    path = tmp_path / "refuge_world.json"
+    path.write_text(
+        json.dumps(
+            {
+                "created_at": "2026-08-09T04:00:00+00:00",
+                "buildings": {"fire": {"level": 2}},
+                "historical_events": [
+                    {
+                        "event_id": "event-1",
+                        "event_type": "world_created",
+                        "occurred_at": "2026-08-09T04:00:00+00:00",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    migrated = await RefugeWorldStore(path).get_state()
+    persisted = read_json_safe(path, {})
+
+    assert migrated.schema_version == REFUGE_WORLD_SCHEMA_VERSION
+    assert migrated.buildings[0].building_id == "fire"
+    assert migrated.buildings[0].level == 2
+    assert migrated.events[0].event_id == "event-1"
+    assert persisted["schema_version"] == REFUGE_WORLD_SCHEMA_VERSION
+    assert "events" in persisted
+    assert "historical_events" not in persisted
+
+
+@pytest.mark.asyncio
+async def test_future_schema_is_rejected_without_overwrite(tmp_path):
+    path = tmp_path / "refuge_world.json"
+    payload = {
+        "schema_version": REFUGE_WORLD_SCHEMA_VERSION + 1,
+        "created_at": "future",
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(RefugeWorldSchemaError):
+        await RefugeWorldStore(path).get_state()
+
+    assert json.loads(path.read_text(encoding="utf-8")) == payload


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-001 — Fondation du monde** pour le Refuge Vivant, sans interface Discord, sans rendu graphique et sans règle de progression.

## Changements
- nouveau package `models` pour les modèles de domaine du Refuge ;
- `RefugeWorldState` versionné (`schema_version = 1`) ;
- modèles dédiés aux bâtiments, événements historiques, panneau permanent, chantier courant et snapshots saisonniers ;
- sérialisation/désérialisation déterministe vers JSON ;
- nouveau `RefugeWorldStore` dans `storage/refuge_world_store.py` ;
- persistance dans `DATA_DIR/refuge_world.json` via les utilitaires atomiques existants ;
- initialisation idempotente de la date de naissance du Refuge ;
- copies défensives à la lecture/écriture pour éviter de muter l’état interne du store depuis l’extérieur ;
- migration explicite d’un payload non versionné (schéma 0) vers le schéma 1 ;
- rejet d’un schéma futur inconnu sans réécrire le fichier ;
- récupération d’un JSON principal corrompu via le mécanisme `.bak` déjà fourni par `utils.persistence`.

## Hors périmètre
Aucune modification de :
- XP ou calcul vocal ;
- `SeasonStore` ;
- succès ;
- casino ;
- objectifs communautaires ;
- Components V2 ;
- commandes Discord ;
- rendu Pillow ;
- seuils ou règles de progression du Refuge.

## Fichiers
- `models/__init__.py`
- `models/refuge_world.py`
- `storage/refuge_world_store.py`
- `tests/test_refuge_world_store.py`

## Validation
Un test ciblé isolé reproduisant les utilitaires de persistance du dépôt a exécuté les 6 scénarios de `tests/test_refuge_world_store.py` : **6 passed**.

Ce contrôle couvre :
- initialisation stable après restart ;
- round-trip de tout l’état de fondation ;
- fallback sur backup atomique ;
- fallback sûr si primaire et backup sont indisponibles ;
- migration schéma 0 → 1 ;
- rejet d’un schéma futur sans overwrite.

La suite pytest complète du dépôt n’a pas été exécutée dans le runtime ChatGPT. La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.