### PR TITLE
feat: track Refuge community voice time

### DIFF
--- a/cogs/refuge_voice_activity.py
+++ b/cogs/refuge_voice_activity.py
@@ -29,9 +29,10 @@ class RefugeVoiceActivityCog(commands.Cog):
     def cog_unload(self) -> None:
         self.checkpoint_community_voice.cancel()
         try:
-            asyncio.create_task(self.tracker.checkpoint())
+            loop = asyncio.get_running_loop()
         except RuntimeError:
-            pass
+            return
+        loop.create_task(self.tracker.checkpoint())
 
     @commands.Cog.listener()
     async def on_ready(self) -> None:
@@ -50,6 +51,10 @@ class RefugeVoiceActivityCog(commands.Cog):
             channels,
             excluded_channel_ids=excluded_channel_ids,
             at=datetime.now(timezone.utc),
+        )
+        logger.info(
+            "[refuge] Suivi vocal communautaire prêt (%d salon(s) actif(s))",
+            len(self.tracker.active_channel_ids),
         )
 
     @commands.Cog.listener()
@@ -87,11 +92,25 @@ class RefugeVoiceActivityCog(commands.Cog):
 
         now = datetime.now(timezone.utc)
         for channel in affected.values():
+            was_active = channel.id in self.tracker.active_channel_ids
             await self.tracker.reconcile_channel(
                 channel.id,
                 tuple(channel.members),
                 at=now,
             )
+            is_active = channel.id in self.tracker.active_channel_ids
+            if not was_active and is_active:
+                logger.info(
+                    "[refuge] Temps vocal communautaire démarré dans #%s (%s)",
+                    channel.name,
+                    channel.id,
+                )
+            elif was_active and not is_active:
+                logger.info(
+                    "[refuge] Temps vocal communautaire arrêté dans #%s (%s)",
+                    channel.name,
+                    channel.id,
+                )
 
     @tasks.loop(seconds=CHECKPOINT_SECONDS)
     async def checkpoint_community_voice(self) -> None:

--- a/cogs/refuge_voice_activity.py
+++ b/cogs/refuge_voice_activity.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+import discord
+from discord.ext import commands, tasks
+
+from services.refuge_voice_activity import CommunityVoiceTracker
+from storage.refuge_activity_store import refuge_activity_store
+
+
+logger = logging.getLogger(__name__)
+CHECKPOINT_SECONDS = 30
+
+
+class RefugeVoiceActivityCog(commands.Cog):
+    """Track shared human voice-channel time for the Refuge world."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.tracker = CommunityVoiceTracker(refuge_activity_store)
+
+    async def cog_load(self) -> None:
+        await refuge_activity_store.initialize()
+        self.checkpoint_community_voice.start()
+
+    def cog_unload(self) -> None:
+        self.checkpoint_community_voice.cancel()
+        try:
+            asyncio.create_task(self.tracker.checkpoint())
+        except RuntimeError:
+            pass
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        channels: list[tuple[int, tuple[discord.Member, ...]]] = []
+        excluded_channel_ids: set[int] = set()
+
+        for guild in self.bot.guilds:
+            if guild.afk_channel is not None:
+                excluded_channel_ids.add(guild.afk_channel.id)
+            channels.extend(
+                (channel.id, tuple(channel.members))
+                for channel in guild.voice_channels
+            )
+
+        await self.tracker.reconcile_snapshot(
+            channels,
+            excluded_channel_ids=excluded_channel_ids,
+            at=datetime.now(timezone.utc),
+        )
+
+    @commands.Cog.listener()
+    async def on_disconnect(self) -> None:
+        try:
+            await self.tracker.stop_all(at=datetime.now(timezone.utc))
+        except Exception:
+            logger.exception(
+                "[refuge] Impossible de finaliser le temps vocal communautaire "
+                "pendant la déconnexion"
+            )
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(
+        self,
+        member: discord.Member,
+        before: discord.VoiceState,
+        after: discord.VoiceState,
+    ) -> None:
+        if member.bot or before.channel == after.channel:
+            return
+
+        afk_channel_id = (
+            member.guild.afk_channel.id
+            if member.guild.afk_channel is not None
+            else None
+        )
+        affected: dict[int, discord.VoiceChannel] = {}
+        for channel in (before.channel, after.channel):
+            if not isinstance(channel, discord.VoiceChannel):
+                continue
+            if afk_channel_id is not None and channel.id == afk_channel_id:
+                continue
+            affected[channel.id] = channel
+
+        now = datetime.now(timezone.utc)
+        for channel in affected.values():
+            await self.tracker.reconcile_channel(
+                channel.id,
+                tuple(channel.members),
+                at=now,
+            )
+
+    @tasks.loop(seconds=CHECKPOINT_SECONDS)
+    async def checkpoint_community_voice(self) -> None:
+        try:
+            await self.tracker.checkpoint(at=datetime.now(timezone.utc))
+        except Exception:
+            logger.exception(
+                "[refuge] Impossible de sauvegarder le temps vocal communautaire"
+            )
+
+    @checkpoint_community_voice.before_loop
+    async def before_checkpoint_community_voice(self) -> None:
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RefugeVoiceActivityCog(bot))

--- a/cogs/refuge_voice_activity.py
+++ b/cogs/refuge_voice_activity.py
@@ -12,7 +12,7 @@ from storage.refuge_activity_store import refuge_activity_store
 
 
 logger = logging.getLogger(__name__)
-CHECKPOINT_SECONDS = 30
+CHECKPOINT_SECONDS = 60
 
 
 class RefugeVoiceActivityCog(commands.Cog):

--- a/services/refuge_voice_activity.py
+++ b/services/refuge_voice_activity.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+from storage.refuge_activity_store import RefugeActivityStore
+
+
+MIN_COMMUNITY_HUMANS = 2
+
+
+def human_member_count(members: Iterable[object]) -> int:
+    return sum(1 for member in members if not bool(getattr(member, "bot", False)))
+
+
+def _aware_utc(at: datetime | None = None) -> datetime:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
+
+
+class CommunityVoiceTracker:
+    """Track channel-time where at least two humans share a voice channel."""
+
+    def __init__(self, store: RefugeActivityStore) -> None:
+        self.store = store
+        self._active_channels: dict[int, datetime] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def active_channel_ids(self) -> frozenset[int]:
+        return frozenset(self._active_channels)
+
+    async def reconcile_channel(
+        self,
+        channel_id: int,
+        members: Iterable[object],
+        *,
+        at: datetime | None = None,
+    ) -> None:
+        now = _aware_utc(at)
+        qualifies = human_member_count(members) >= MIN_COMMUNITY_HUMANS
+
+        async with self._lock:
+            started_at = self._active_channels.get(int(channel_id))
+            if qualifies:
+                if started_at is None:
+                    self._active_channels[int(channel_id)] = now
+                return
+
+            if started_at is None:
+                return
+            self._active_channels.pop(int(channel_id), None)
+            await self.store.record_interval(started_at, now)
+
+    async def reconcile_snapshot(
+        self,
+        channels: Iterable[tuple[int, Iterable[object]]],
+        *,
+        excluded_channel_ids: Iterable[int] = (),
+        at: datetime | None = None,
+    ) -> None:
+        now = _aware_utc(at)
+        excluded = {int(channel_id) for channel_id in excluded_channel_ids}
+        qualifying = {
+            int(channel_id)
+            for channel_id, members in channels
+            if int(channel_id) not in excluded
+            and human_member_count(members) >= MIN_COMMUNITY_HUMANS
+        }
+
+        async with self._lock:
+            for channel_id in list(self._active_channels):
+                if channel_id in qualifying:
+                    continue
+                started_at = self._active_channels.pop(channel_id)
+                await self.store.record_interval(started_at, now)
+
+            for channel_id in qualifying:
+                self._active_channels.setdefault(channel_id, now)
+
+    async def checkpoint(
+        self,
+        *,
+        at: datetime | None = None,
+    ) -> None:
+        now = _aware_utc(at)
+        async with self._lock:
+            for channel_id, started_at in list(self._active_channels.items()):
+                recorded = await self.store.record_interval(started_at, now)
+                if recorded > 0:
+                    self._active_channels[channel_id] = started_at + timedelta(
+                        seconds=recorded
+                    )
+            await self.store.flush()
+
+    async def stop_all(
+        self,
+        *,
+        at: datetime | None = None,
+    ) -> None:
+        now = _aware_utc(at)
+        async with self._lock:
+            for channel_id, started_at in list(self._active_channels.items()):
+                await self.store.record_interval(started_at, now)
+                self._active_channels.pop(channel_id, None)
+            await self.store.flush()
+
+
+__all__ = [
+    "MIN_COMMUNITY_HUMANS",
+    "CommunityVoiceTracker",
+    "human_member_count",
+]

--- a/storage/refuge_activity_store.py
+++ b/storage/refuge_activity_store.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import asyncio
+import weakref
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from config import DATA_DIR
+from utils.persistence import atomic_write_json_async, read_json_safe
+from utils.seasons import split_interval_by_season
+
+
+REFUGE_ACTIVITY_SCHEMA_VERSION = 1
+REFUGE_ACTIVITY_FILE = Path(DATA_DIR) / "refuge_activity.json"
+
+
+class RefugeActivitySchemaError(ValueError):
+    """Raised when persisted Refuge activity uses an unsupported schema."""
+
+
+def _utc_iso(at: datetime | None = None) -> str:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).isoformat()
+
+
+class RefugeActivityStore:
+    """Persist derived Refuge activity without changing XP or season metrics."""
+
+    def __init__(self, path: str | Path = REFUGE_ACTIVITY_FILE) -> None:
+        self.path = Path(path)
+        self._loaded = False
+        self._dirty = False
+        self._data: dict[str, Any] = self._empty_data()
+        self._locks: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Lock
+        ] = weakref.WeakKeyDictionary()
+
+    @staticmethod
+    def _empty_data() -> dict[str, Any]:
+        return {
+            "schema_version": REFUGE_ACTIVITY_SCHEMA_VERSION,
+            "tracking_started_at": None,
+            "community_voice_seconds": 0,
+            "seasons": {},
+        }
+
+    def _get_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[loop] = lock
+        return lock
+
+    async def _load_locked(self) -> None:
+        if self._loaded:
+            return
+
+        raw = await asyncio.to_thread(read_json_safe, self.path, None)
+        if raw is None:
+            self._data = self._empty_data()
+            self._loaded = True
+            return
+        if not isinstance(raw, Mapping):
+            self._data = self._empty_data()
+            self._loaded = True
+            return
+
+        try:
+            version = int(raw.get("schema_version", 0))
+        except (TypeError, ValueError):
+            version = 0
+        if version != REFUGE_ACTIVITY_SCHEMA_VERSION:
+            raise RefugeActivitySchemaError(
+                "unsupported refuge activity schema "
+                f"{version}; expected {REFUGE_ACTIVITY_SCHEMA_VERSION}"
+            )
+
+        try:
+            total_seconds = max(0, int(raw.get("community_voice_seconds", 0)))
+        except (TypeError, ValueError):
+            total_seconds = 0
+
+        seasons: dict[str, dict[str, int]] = {}
+        raw_seasons = raw.get("seasons", {})
+        if isinstance(raw_seasons, Mapping):
+            for raw_season_id, raw_payload in raw_seasons.items():
+                if not isinstance(raw_payload, Mapping):
+                    continue
+                try:
+                    seconds = max(
+                        0,
+                        int(raw_payload.get("community_voice_seconds", 0)),
+                    )
+                except (TypeError, ValueError):
+                    seconds = 0
+                seasons[str(raw_season_id)] = {
+                    "community_voice_seconds": seconds,
+                }
+
+        tracking_started_at = raw.get("tracking_started_at")
+        self._data = {
+            "schema_version": REFUGE_ACTIVITY_SCHEMA_VERSION,
+            "tracking_started_at": (
+                str(tracking_started_at) if tracking_started_at else None
+            ),
+            "community_voice_seconds": total_seconds,
+            "seasons": seasons,
+        }
+        self._loaded = True
+
+    async def initialize(
+        self,
+        *,
+        at: datetime | None = None,
+    ) -> dict[str, Any]:
+        async with self._get_lock():
+            await self._load_locked()
+            if not self._data.get("tracking_started_at"):
+                self._data["tracking_started_at"] = _utc_iso(at)
+                await atomic_write_json_async(self.path, self._data)
+            return deepcopy(self._data)
+
+    async def record_interval(
+        self,
+        started_at: datetime,
+        ended_at: datetime,
+    ) -> int:
+        parts = split_interval_by_season(started_at, ended_at)
+        recorded_seconds = sum(seconds for _season_id, seconds in parts)
+        if recorded_seconds <= 0:
+            return 0
+
+        async with self._get_lock():
+            await self._load_locked()
+            if not self._data.get("tracking_started_at"):
+                self._data["tracking_started_at"] = _utc_iso(started_at)
+            self._data["community_voice_seconds"] = (
+                int(self._data.get("community_voice_seconds", 0))
+                + recorded_seconds
+            )
+            seasons = self._data.setdefault("seasons", {})
+            for season_id, seconds in parts:
+                season = seasons.setdefault(
+                    season_id,
+                    {"community_voice_seconds": 0},
+                )
+                season["community_voice_seconds"] = (
+                    int(season.get("community_voice_seconds", 0))
+                    + seconds
+                )
+            self._dirty = True
+        return recorded_seconds
+
+    async def get_snapshot(self) -> dict[str, Any]:
+        async with self._get_lock():
+            await self._load_locked()
+            return deepcopy(self._data)
+
+    async def get_total_seconds(self) -> int:
+        snapshot = await self.get_snapshot()
+        return int(snapshot.get("community_voice_seconds", 0))
+
+    async def get_season_seconds(self, season_id: str) -> int:
+        snapshot = await self.get_snapshot()
+        season = snapshot.get("seasons", {}).get(season_id, {})
+        if not isinstance(season, Mapping):
+            return 0
+        try:
+            return max(0, int(season.get("community_voice_seconds", 0)))
+        except (TypeError, ValueError):
+            return 0
+
+    async def flush(self) -> None:
+        async with self._get_lock():
+            await self._load_locked()
+            if not self._dirty:
+                return
+            await atomic_write_json_async(self.path, self._data)
+            self._dirty = False
+
+
+refuge_activity_store = RefugeActivityStore()
+
+
+__all__ = [
+    "REFUGE_ACTIVITY_FILE",
+    "REFUGE_ACTIVITY_SCHEMA_VERSION",
+    "RefugeActivitySchemaError",
+    "RefugeActivityStore",
+    "refuge_activity_store",
+]

--- a/tests/test_refuge_voice_activity.py
+++ b/tests/test_refuge_voice_activity.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from services.refuge_voice_activity import CommunityVoiceTracker, human_member_count
+from storage.refuge_activity_store import RefugeActivitySchemaError, RefugeActivityStore
+
+
+def member(*, bot: bool = False):
+    return SimpleNamespace(bot=bot)
+
+
+def test_human_member_count_excludes_bots():
+    assert human_member_count([member(), member(bot=True), member()]) == 2
+
+
+@pytest.mark.asyncio
+async def test_activity_tracking_start_is_stable_after_restart(tmp_path):
+    path = tmp_path / "refuge_activity.json"
+    first = RefugeActivityStore(path)
+    started = datetime(2026, 8, 9, 10, 0, tzinfo=timezone.utc)
+    first_state = await first.initialize(at=started)
+
+    restarted = RefugeActivityStore(path)
+    second_state = await restarted.initialize(
+        at=started + timedelta(days=1),
+    )
+
+    assert first_state["tracking_started_at"] == started.isoformat()
+    assert second_state["tracking_started_at"] == started.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_store_splits_community_voice_across_paris_months(tmp_path):
+    store = RefugeActivityStore(tmp_path / "refuge_activity.json")
+    start = datetime(2026, 8, 31, 21, 59, 30, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=2)
+
+    recorded = await store.record_interval(start, end)
+
+    assert recorded == 120
+    assert await store.get_total_seconds() == 120
+    assert await store.get_season_seconds("2026-08") == 30
+    assert await store.get_season_seconds("2026-09") == 90
+
+
+@pytest.mark.asyncio
+async def test_tracker_starts_only_with_two_humans_and_preserves_session(tmp_path):
+    store = RefugeActivityStore(tmp_path / "refuge_activity.json")
+    tracker = CommunityVoiceTracker(store)
+    start = datetime(2026, 8, 9, 10, 0, tzinfo=timezone.utc)
+
+    await tracker.reconcile_channel(100, [member()], at=start)
+    assert tracker.active_channel_ids == frozenset()
+
+    await tracker.reconcile_channel(
+        100,
+        [member(), member()],
+        at=start + timedelta(minutes=1),
+    )
+    assert tracker.active_channel_ids == frozenset({100})
+
+    # A third human joining does not restart the qualifying interval.
+    await tracker.reconcile_channel(
+        100,
+        [member(), member(), member()],
+        at=start + timedelta(minutes=2),
+    )
+    await tracker.reconcile_channel(
+        100,
+        [member()],
+        at=start + timedelta(minutes=6),
+    )
+
+    assert await store.get_total_seconds() == 5 * 60
+
+
+@pytest.mark.asyncio
+async def test_two_qualifying_channels_accumulate_independently(tmp_path):
+    store = RefugeActivityStore(tmp_path / "refuge_activity.json")
+    tracker = CommunityVoiceTracker(store)
+    start = datetime(2026, 8, 9, 10, 0, tzinfo=timezone.utc)
+
+    await tracker.reconcile_snapshot(
+        [
+            (100, [member(), member()]),
+            (200, [member(), member(), member()]),
+        ],
+        at=start,
+    )
+    await tracker.stop_all(at=start + timedelta(minutes=10))
+
+    assert await store.get_total_seconds() == 20 * 60
+
+
+@pytest.mark.asyncio
+async def test_snapshot_excludes_configured_channels(tmp_path):
+    store = RefugeActivityStore(tmp_path / "refuge_activity.json")
+    tracker = CommunityVoiceTracker(store)
+    start = datetime(2026, 8, 9, 10, 0, tzinfo=timezone.utc)
+
+    await tracker.reconcile_snapshot(
+        [
+            (100, [member(), member()]),
+            (999, [member(), member()]),
+        ],
+        excluded_channel_ids={999},
+        at=start,
+    )
+
+    assert tracker.active_channel_ids == frozenset({100})
+
+
+@pytest.mark.asyncio
+async def test_checkpoint_persists_without_resetting_fractional_time(tmp_path):
+    store = RefugeActivityStore(tmp_path / "refuge_activity.json")
+    tracker = CommunityVoiceTracker(store)
+    start = datetime(2026, 8, 9, 10, 0, 0, 500000, tzinfo=timezone.utc)
+
+    await tracker.reconcile_channel(100, [member(), member()], at=start)
+    await tracker.checkpoint(at=start + timedelta(seconds=30.7))
+    assert await store.get_total_seconds() == 30
+
+    await tracker.stop_all(at=start + timedelta(seconds=61.2))
+    # Fractional remainder from the first checkpoint carries into the second.
+    assert await store.get_total_seconds() == 61
+
+    restarted = RefugeActivityStore(tmp_path / "refuge_activity.json")
+    assert await restarted.get_total_seconds() == 61
+
+
+@pytest.mark.asyncio
+async def test_reconcile_snapshot_preserves_existing_qualified_session(tmp_path):
+    store = RefugeActivityStore(tmp_path / "refuge_activity.json")
+    tracker = CommunityVoiceTracker(store)
+    start = datetime(2026, 8, 9, 10, 0, tzinfo=timezone.utc)
+
+    await tracker.reconcile_snapshot([(100, [member(), member()])], at=start)
+    await tracker.reconcile_snapshot(
+        [(100, [member(), member(), member()])],
+        at=start + timedelta(minutes=5),
+    )
+    await tracker.stop_all(at=start + timedelta(minutes=10))
+
+    assert await store.get_total_seconds() == 10 * 60
+
+
+@pytest.mark.asyncio
+async def test_store_rejects_unknown_schema(tmp_path):
+    path = tmp_path / "refuge_activity.json"
+    path.write_text('{"schema_version": 99}', encoding="utf-8")
+
+    store = RefugeActivityStore(path)
+    with pytest.raises(RefugeActivitySchemaError):
+        await store.get_snapshot()

--- a/tests/test_refuge_voice_activity.py
+++ b/tests/test_refuge_voice_activity.py
@@ -121,15 +121,15 @@ async def test_checkpoint_persists_without_resetting_fractional_time(tmp_path):
     start = datetime(2026, 8, 9, 10, 0, 0, 500000, tzinfo=timezone.utc)
 
     await tracker.reconcile_channel(100, [member(), member()], at=start)
-    await tracker.checkpoint(at=start + timedelta(seconds=30.7))
-    assert await store.get_total_seconds() == 30
+    await tracker.checkpoint(at=start + timedelta(seconds=60.7))
+    assert await store.get_total_seconds() == 60
 
-    await tracker.stop_all(at=start + timedelta(seconds=61.2))
+    await tracker.stop_all(at=start + timedelta(seconds=121.2))
     # Fractional remainder from the first checkpoint carries into the second.
-    assert await store.get_total_seconds() == 61
+    assert await store.get_total_seconds() == 121
 
     restarted = RefugeActivityStore(tmp_path / "refuge_activity.json")
-    assert await restarted.get_total_seconds() == 61
+    assert await restarted.get_total_seconds() == 121
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-002 — Temps vocal communautaire** pour alimenter le futur Feu de camp du Refuge Vivant, sans modifier le calcul XP vocal existant.

## Règle de comptage
- une salle vocale contribue uniquement lorsqu’elle contient **au moins 2 membres humains** ;
- les bots ne comptent jamais dans le seuil ;
- 5 humains dans une même salle comptent comme **1 unité de temps de salle**, pas 5 ;
- 2 salles qualifiées simultanément accumulent chacune leur temps ;
- le salon AFK du serveur est exclu ;
- le suivi est prospectif : après un restart/reconnect, une session repart à partir de l’état effectivement observé, sans inventer de temps pendant l’arrêt du bot.

## Changements
- nouveau `storage/refuge_activity_store.py` avec `schema_version = 1` ;
- stockage dans `DATA_DIR/refuge_activity.json` ;
- total cumulatif `community_voice_seconds` + ventilation par saison `AAAA-MM` ;
- écriture atomique via les utilitaires de persistance existants ;
- nouveau `services/refuge_voice_activity.py` avec un tracker indépendant de Discord et du moteur XP ;
- checkpoint toutes les **60 secondes** pendant les sessions actives ;
- ce checkpoint n’effectue aucun appel HTTP à l’API Discord : il ne fait que calculer le temps écoulé et persister localement l’état ;
- conservation du reliquat sous-seconde entre checkpoints afin d’éviter une dérive cumulative ;
- nouveau `cogs/refuge_voice_activity.py`, auto-chargé par le chargeur actuel des cogs ;
- reconstruction des salles déjà qualifiées au `on_ready` ;
- finalisation des sessions au `on_disconnect` ;
- logs uniquement lors du démarrage/arrêt d’une salle communautaire et à l’initialisation du tracker.

## Hors périmètre
Aucune modification de :
- `cogs/xp.py` ;
- `SeasonStore` et ses métriques ;
- gains XP, multiplicateurs ou bonus vocaux ;
- casino ;
- succès ;
- Components V2 ;
- `RefugeWorldState` ;
- niveaux ou seuils du Feu de camp ;
- rendu graphique.

## Fichiers
- `cogs/refuge_voice_activity.py`
- `services/refuge_voice_activity.py`
- `storage/refuge_activity_store.py`
- `tests/test_refuge_voice_activity.py`

## Validation
Les **9 tests ciblés** du tracker/store ont été exécutés dans un environnement isolé reproduisant les utilitaires de persistance et de saisons du dépôt : **9 passed** avant l’ajustement de cadence. Le changement 30 s → 60 s ne modifie pas le moteur de calcul ; le test de checkpoint a été aligné sur la cadence d’une minute.

Ils couvrent :
- exclusion des bots ;
- date de début stable après restart ;
- découpage du temps au changement de mois Europe/Paris ;
- seuil de 2 humains ;
- absence de multiplication par le nombre de membres d’une même salle ;
- accumulation indépendante de deux salles simultanées ;
- exclusion d’un salon configuré (utilisé pour l’AFK) ;
- checkpoint/persistance sans perte cumulative des fractions de seconde ;
- reconstruction répétée d’un snapshot sans redémarrer une session déjà qualifiée ;
- rejet d’un schéma inconnu.

La suite pytest complète du dépôt n’a pas été exécutée dans le runtime ChatGPT car `discord.py` n’y est pas disponible. La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.