### PR TITLE
feat: add Refuge world progression engine

### DIFF
--- a/services/refuge_world.py
+++ b/services/refuge_world.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Mapping, Sequence
+
+from models.refuge_world import RefugeBuildingState, RefugeHistoricalEvent, RefugeWorldState
+from storage.refuge_world_store import RefugeWorldStore, refuge_world_store
+
+
+def _utc_iso(at: datetime | None = None) -> str:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).isoformat()
+
+
+@dataclass(frozen=True, slots=True)
+class BuildingProgressionRule:
+    building_id: str
+    metric_key: str
+    thresholds: tuple[int, ...] = ()
+    minimum_level: int = 0
+    event_from_level: int = 2
+
+    def __post_init__(self) -> None:
+        if not self.building_id.strip():
+            raise ValueError("building_id is required")
+        if not self.metric_key.strip():
+            raise ValueError("metric_key is required")
+        if self.minimum_level < 0:
+            raise ValueError("minimum_level must be >= 0")
+        if self.event_from_level < 1:
+            raise ValueError("event_from_level must be >= 1")
+        previous = -1
+        for threshold in self.thresholds:
+            if threshold < 0:
+                raise ValueError("thresholds must be >= 0")
+            if threshold <= previous:
+                raise ValueError("thresholds must be strictly increasing")
+            previous = threshold
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeWorldEvaluation:
+    state: RefugeWorldState
+    changed: bool
+    changed_buildings: tuple[str, ...]
+    render_signature: str
+
+
+def level_for_metric(
+    value: int,
+    *,
+    thresholds: Sequence[int],
+    minimum_level: int = 0,
+) -> int:
+    normalized = max(0, int(value))
+    level = max(0, int(minimum_level))
+    for threshold in thresholds:
+        if normalized < int(threshold):
+            break
+        level += 1
+    return level
+
+
+def world_render_signature(state: RefugeWorldState) -> str:
+    """Hash only fields that can affect the rendered current world."""
+
+    payload = {
+        "buildings": [
+            {
+                "building_id": building.building_id,
+                "level": int(building.level),
+                "state": building.state,
+            }
+            for building in sorted(
+                state.buildings,
+                key=lambda item: item.building_id,
+            )
+        ],
+        "active_construction": (
+            state.active_construction.to_dict()
+            if state.active_construction is not None
+            else None
+        ),
+        "state": state.state,
+    }
+    canonical = json.dumps(
+        payload,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _event_id(building_id: str, level: int) -> str:
+    return f"building:{building_id}:level:{level}"
+
+
+class RefugeWorldService:
+    """Apply configured progression rules to the persisted Refuge world."""
+
+    def __init__(self, store: RefugeWorldStore = refuge_world_store) -> None:
+        self.store = store
+
+    async def evaluate(
+        self,
+        *,
+        metrics: Mapping[str, int],
+        rules: Sequence[BuildingProgressionRule],
+        at: datetime | None = None,
+    ) -> RefugeWorldEvaluation:
+        now_iso = _utc_iso(at)
+        current = await self.store.initialize(created_at=at)
+        buildings = {
+            building.building_id: building
+            for building in current.buildings
+        }
+        events = list(current.events)
+        existing_event_ids = {event.event_id for event in events}
+        changed_buildings: list[str] = []
+        rule_building_ids = [rule.building_id for rule in rules]
+        if len(set(rule_building_ids)) != len(rule_building_ids):
+            raise ValueError("only one progression rule is allowed per building")
+
+        for rule in rules:
+            metric_value = max(0, int(metrics.get(rule.metric_key, 0)))
+            target_level = level_for_metric(
+                metric_value,
+                thresholds=rule.thresholds,
+                minimum_level=rule.minimum_level,
+            )
+            existing = buildings.get(rule.building_id)
+            current_level = existing.level if existing is not None else 0
+            if target_level <= current_level:
+                continue
+
+            unlocked_at = (
+                (existing.unlocked_at or current.created_at or now_iso)
+                if existing is not None
+                else (current.created_at or now_iso)
+            )
+            building_state = dict(existing.state) if existing is not None else {}
+            buildings[rule.building_id] = RefugeBuildingState(
+                building_id=rule.building_id,
+                level=target_level,
+                unlocked_at=unlocked_at,
+                state=building_state,
+            )
+            changed_buildings.append(rule.building_id)
+
+            for reached_level in range(current_level + 1, target_level + 1):
+                if reached_level < rule.event_from_level:
+                    continue
+                event_id = _event_id(rule.building_id, reached_level)
+                if event_id in existing_event_ids:
+                    continue
+                events.append(
+                    RefugeHistoricalEvent(
+                        event_id=event_id,
+                        event_type="building_level_reached",
+                        occurred_at=now_iso,
+                        data={
+                            "building_id": rule.building_id,
+                            "level": reached_level,
+                            "metric_key": rule.metric_key,
+                        },
+                    )
+                )
+                existing_event_ids.add(event_id)
+
+        changed = bool(changed_buildings)
+        if changed:
+            current = replace(
+                current,
+                buildings=tuple(
+                    sorted(
+                        buildings.values(),
+                        key=lambda item: item.building_id,
+                    )
+                ),
+                events=tuple(events),
+            )
+            current = await self.store.save_state(current)
+
+        return RefugeWorldEvaluation(
+            state=current,
+            changed=changed,
+            changed_buildings=tuple(sorted(changed_buildings)),
+            render_signature=world_render_signature(current),
+        )
+
+
+refuge_world_service = RefugeWorldService()
+
+
+__all__ = [
+    "BuildingProgressionRule",
+    "RefugeWorldEvaluation",
+    "RefugeWorldService",
+    "level_for_metric",
+    "refuge_world_service",
+    "world_render_signature",
+]

--- a/tests/test_refuge_world_service.py
+++ b/tests/test_refuge_world_service.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from models.refuge_world import (
+    RefugeBuildingState,
+    RefugeHistoricalEvent,
+    RefugePanelState,
+    RefugeWorldState,
+)
+from services.refuge_world import (
+    BuildingProgressionRule,
+    RefugeWorldService,
+    level_for_metric,
+    world_render_signature,
+)
+from storage.refuge_world_store import RefugeWorldStore
+
+
+def test_level_for_metric_uses_injected_thresholds_only():
+    thresholds = (100, 500, 1_000, 5_000)
+
+    assert level_for_metric(0, thresholds=thresholds, minimum_level=1) == 1
+    assert level_for_metric(99, thresholds=thresholds, minimum_level=1) == 1
+    assert level_for_metric(100, thresholds=thresholds, minimum_level=1) == 2
+    assert level_for_metric(999, thresholds=thresholds, minimum_level=1) == 3
+    assert level_for_metric(5_000, thresholds=thresholds, minimum_level=1) == 5
+    assert level_for_metric(999_999, thresholds=thresholds, minimum_level=1) == 5
+
+
+@pytest.mark.parametrize(
+    "thresholds",
+    [
+        (-1,),
+        (100, 100),
+        (500, 100),
+    ],
+)
+def test_progression_rule_rejects_invalid_thresholds(thresholds):
+    with pytest.raises(ValueError):
+        BuildingProgressionRule(
+            building_id="fire",
+            metric_key="community_voice_seconds",
+            thresholds=thresholds,
+            minimum_level=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_service_creates_initial_building_without_fake_milestone(tmp_path):
+    store = RefugeWorldStore(tmp_path / "refuge_world.json")
+    service = RefugeWorldService(store)
+    started = datetime(2026, 8, 9, 4, 45, tzinfo=timezone.utc)
+    rule = BuildingProgressionRule(
+        building_id="fire",
+        metric_key="community_voice_seconds",
+        thresholds=(100, 500, 1_000, 5_000),
+        minimum_level=1,
+    )
+
+    result = await service.evaluate(
+        metrics={"community_voice_seconds": 0},
+        rules=[rule],
+        at=started,
+    )
+
+    assert result.changed is True
+    assert result.changed_buildings == ("fire",)
+    assert len(result.state.buildings) == 1
+    fire = result.state.buildings[0]
+    assert fire.level == 1
+    assert fire.unlocked_at == started.isoformat()
+    assert result.state.events == ()
+
+
+@pytest.mark.asyncio
+async def test_service_progression_is_monotonic_and_records_crossed_levels_once(tmp_path):
+    store = RefugeWorldStore(tmp_path / "refuge_world.json")
+    service = RefugeWorldService(store)
+    started = datetime(2026, 8, 9, 4, 45, tzinfo=timezone.utc)
+    rule = BuildingProgressionRule(
+        building_id="fire",
+        metric_key="community_voice_seconds",
+        thresholds=(100, 500, 1_000, 5_000),
+        minimum_level=1,
+    )
+
+    await service.evaluate(
+        metrics={"community_voice_seconds": 0},
+        rules=[rule],
+        at=started,
+    )
+    upgraded = await service.evaluate(
+        metrics={"community_voice_seconds": 600},
+        rules=[rule],
+        at=started + timedelta(days=1),
+    )
+
+    assert upgraded.state.buildings[0].level == 3
+    assert [event.data["level"] for event in upgraded.state.events] == [2, 3]
+    assert all(
+        event.event_type == "building_level_reached"
+        for event in upgraded.state.events
+    )
+
+    lower_metric = await service.evaluate(
+        metrics={"community_voice_seconds": 50},
+        rules=[rule],
+        at=started + timedelta(days=2),
+    )
+
+    assert lower_metric.changed is False
+    assert lower_metric.state.buildings[0].level == 3
+    assert [event.data["level"] for event in lower_metric.state.events] == [2, 3]
+
+
+@pytest.mark.asyncio
+async def test_service_preserves_existing_building_state_when_level_changes(tmp_path):
+    store = RefugeWorldStore(tmp_path / "refuge_world.json")
+    started = datetime(2026, 8, 9, 4, 45, tzinfo=timezone.utc)
+    state = await store.initialize(created_at=started)
+    existing = RefugeBuildingState(
+        building_id="fire",
+        level=2,
+        unlocked_at=started.isoformat(),
+        state={"decoration": "fox"},
+    )
+    await store.save_state(replace(state, buildings=(existing,)))
+
+    service = RefugeWorldService(store)
+    result = await service.evaluate(
+        metrics={"voice": 1_500},
+        rules=[
+            BuildingProgressionRule(
+                building_id="fire",
+                metric_key="voice",
+                thresholds=(100, 500, 1_000, 5_000),
+                minimum_level=1,
+            )
+        ],
+        at=started + timedelta(days=10),
+    )
+
+    assert result.state.buildings[0].level == 4
+    assert result.state.buildings[0].state == {"decoration": "fox"}
+
+
+@pytest.mark.asyncio
+async def test_service_keeps_unrelated_buildings_and_world_state(tmp_path):
+    store = RefugeWorldStore(tmp_path / "refuge_world.json")
+    started = datetime(2026, 8, 9, 4, 45, tzinfo=timezone.utc)
+    state = await store.initialize(created_at=started)
+    hall = RefugeBuildingState(
+        building_id="hall",
+        level=2,
+        unlocked_at=started.isoformat(),
+        state={"lights": "gold"},
+    )
+    seeded = replace(
+        state,
+        buildings=(hall,),
+        state={"season_visual": "summer"},
+    )
+    await store.save_state(seeded)
+
+    service = RefugeWorldService(store)
+    result = await service.evaluate(
+        metrics={"voice": 0},
+        rules=[
+            BuildingProgressionRule(
+                building_id="fire",
+                metric_key="voice",
+                minimum_level=1,
+            )
+        ],
+        at=started,
+    )
+
+    buildings = {building.building_id: building for building in result.state.buildings}
+    assert buildings["hall"] == hall
+    assert buildings["fire"].level == 1
+    assert result.state.state == {"season_visual": "summer"}
+
+
+def test_render_signature_ignores_history_and_panel_but_tracks_visual_state():
+    started = "2026-08-09T04:45:00+00:00"
+    fire = RefugeBuildingState(
+        building_id="fire",
+        level=2,
+        unlocked_at=started,
+        state={"intensity": "normal"},
+    )
+    state = RefugeWorldState(
+        created_at=started,
+        buildings=(fire,),
+        events=(),
+        panel=RefugePanelState(),
+        state={"season_visual": "summer"},
+    )
+    signature = world_render_signature(state)
+
+    metadata_only = replace(
+        state,
+        panel=RefugePanelState(channel_id=123, message_id=456),
+        events=(
+            RefugeHistoricalEvent(
+                event_id="history",
+                event_type="note",
+                occurred_at=started,
+                data={},
+            ),
+        ),
+    )
+    assert world_render_signature(metadata_only) == signature
+
+    visual_change = replace(state, state={"season_visual": "autumn"})
+    assert world_render_signature(visual_change) != signature
+
+
+@pytest.mark.asyncio
+async def test_service_rejects_multiple_rules_for_same_building(tmp_path):
+    service = RefugeWorldService(
+        RefugeWorldStore(tmp_path / "refuge_world.json")
+    )
+
+    with pytest.raises(ValueError, match="one progression rule"):
+        await service.evaluate(
+            metrics={"a": 10, "b": 20},
+            rules=[
+                BuildingProgressionRule("fire", "a"),
+                BuildingProgressionRule("fire", "b"),
+            ],
+        )


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-003 — Moteur du monde** : une couche métier générique qui transforme des métriques fournies en progression persistante du `RefugeWorldState`, sans Discord, sans Pillow et sans encore implémenter les règles détaillées du Feu, du Hall ou du Casino.

## Changements
- nouveau `services/refuge_world.py` ;
- `BuildingProgressionRule` : bâtiment, clé de métrique, seuils injectés, niveau minimum et niveau à partir duquel l’historique est enregistré ;
- `level_for_metric()` pour résoudre un niveau à partir de seuils fournis par la configuration appelante ;
- progression **strictement monotone** : une baisse ultérieure de métrique ne fait jamais régresser un bâtiment ;
- création automatique des événements `building_level_reached` pour chaque palier réellement franchi ;
- absence de faux événement pour le niveau initial par défaut (`event_from_level = 2`) ;
- conservation de `unlocked_at` et du `state` spécifique d’un bâtiment lors d’un changement de niveau ;
- conservation des bâtiments et états du monde non concernés par une règle ;
- rejet de plusieurs règles concurrentes pour le même bâtiment ;
- `world_render_signature()` : SHA-256 déterministe basé uniquement sur l’état visuel courant (bâtiments, chantier actif, état visuel global), en excluant panneau Discord, historique et snapshots ;
- `RefugeWorldEvaluation` expose l’état, les bâtiments modifiés et la signature de rendu ;
- sauvegarde du `RefugeWorldState` uniquement lorsqu’une progression persistante a réellement eu lieu.

## Seuils
**Aucun seuil de progression réel n’est introduit dans cette PR.**
Le moteur reçoit les seuils via `BuildingProgressionRule`. Les valeurs 100/500/etc. présentes dans les tests sont exclusivement des fixtures de test et ne seront pas utilisées en production.

## Hors périmètre
Aucune modification de :
- `RefugeWorldState` / schéma de persistance REFUGE-001 ;
- suivi vocal REFUGE-002 ;
- XP ou calcul vocal existant ;
- `SeasonStore` ;
- succès ;
- casino ;
- objectifs communautaires ;
- Components V2 ;
- commandes/cogs Discord ;
- rendu Pillow ;
- seuils réels du Feu, Hall ou Casino.

## Fichiers
- `services/refuge_world.py`
- `tests/test_refuge_world_service.py`

## Validation
Le cœur du moteur a été exécuté dans un environnement isolé avec des doubles fidèles du modèle/store :
- création du niveau initial ;
- saut niveau 1 → 3 avec événements 2 et 3 ;
- absence de régression quand la métrique redescend ;
- absence de doublons d’événements ;
- rejet de deux règles pour le même bâtiment ;
- stabilité de la signature hors changements visuels.

Le fichier de tests du dépôt ajoute **10 cas pytest collectés** (dont 3 variantes paramétrées) couvrant aussi la conservation d’état et des bâtiments non concernés. La suite pytest complète du dépôt n’a pas été exécutée dans le runtime ChatGPT.

La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.