### PR TITLE
feat: add the living Refuge Fire

### DIFF
--- a/rendering/__init__.py
+++ b/rendering/__init__.py
@@ -1,5 +1,11 @@
 """Deterministic visual rendering helpers for the Refuge world."""
 
+from .refuge_fire import (
+    REFUGE_FIRE_RENDERER_VERSION,
+    RefugeFireRenderer,
+    fire_scene_signature,
+    refuge_fire_renderer,
+)
 from .refuge_world import (
     REFUGE_CANVAS_SIZE,
     RefugeRenderContext,
@@ -12,9 +18,13 @@ from .refuge_world import (
 
 __all__ = [
     "REFUGE_CANVAS_SIZE",
+    "REFUGE_FIRE_RENDERER_VERSION",
+    "RefugeFireRenderer",
     "RefugeRenderContext",
     "RefugeWorldRenderer",
     "daypart_for_hour",
+    "fire_scene_signature",
+    "refuge_fire_renderer",
     "refuge_world_renderer",
     "scene_render_signature",
     "season_for_month",

--- a/rendering/refuge_fire.py
+++ b/rendering/refuge_fire.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import json
+from typing import Final
+
+from PIL import Image, ImageDraw
+
+from models.refuge_world import RefugeBuildingState, RefugeWorldState
+from rendering.refuge_world import (
+    REFUGE_CANVAS_SIZE,
+    RefugeRenderContext,
+    RefugeWorldRenderer,
+    refuge_world_renderer as base_world_renderer,
+    scene_render_signature,
+)
+from services.refuge_fire import (
+    FIRE_BUILDING_ID,
+    FIRE_MAX_LEVEL,
+    FIRE_SECRET_EVENTS,
+)
+
+
+REFUGE_FIRE_RENDERER_VERSION: Final[int] = 1
+FIRE_SITE_CENTER: Final[tuple[int, int]] = (644, 420)
+_VALID_INTENSITIES = frozenset({"low", "normal", "high"})
+
+
+def _mix(
+    left: tuple[int, int, int],
+    right: tuple[int, int, int],
+    ratio: float,
+) -> tuple[int, int, int]:
+    clamped = max(0.0, min(1.0, ratio))
+    return tuple(
+        int(round(a + (b - a) * clamped))
+        for a, b in zip(left, right)
+    )
+
+
+def _shade(
+    color: tuple[int, int, int],
+    factor: float,
+) -> tuple[int, int, int]:
+    return tuple(
+        max(0, min(255, int(round(channel * factor))))
+        for channel in color
+    )
+
+
+def _fire_building(state: RefugeWorldState) -> RefugeBuildingState | None:
+    return next(
+        (
+            building
+            for building in state.buildings
+            if building.building_id == FIRE_BUILDING_ID
+        ),
+        None,
+    )
+
+
+def _intensity(building: RefugeBuildingState) -> str:
+    value = str(building.state.get("intensity", "low")).strip().lower()
+    return value if value in _VALID_INTENSITIES else "low"
+
+
+def _secret_ids(building: RefugeBuildingState) -> frozenset[str]:
+    raw = building.state.get("secret_events", ())
+    if not isinstance(raw, (list, tuple, set, frozenset)):
+        return frozenset()
+    return frozenset(
+        str(value)
+        for value in raw
+        if str(value) in FIRE_SECRET_EVENTS
+    )
+
+
+def fire_scene_signature(
+    state: RefugeWorldState,
+    context: RefugeRenderContext,
+) -> str:
+    payload = {
+        "base": scene_render_signature(state, context),
+        "fire_renderer_version": REFUGE_FIRE_RENDERER_VERSION,
+    }
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _draw_glow(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    intensity: str,
+    daypart: str,
+    ground_color: tuple[int, int, int],
+) -> None:
+    x, y = center
+    base_radius = {"low": 25, "normal": 39, "high": 56}[intensity]
+    if daypart == "night":
+        base_radius += 15
+    elif daypart == "sunset":
+        base_radius += 7
+
+    ratios = (0.12, 0.19, 0.28)
+    radii = (base_radius + 20, base_radius + 10, base_radius)
+    for radius, ratio in zip(radii, ratios):
+        glow = _mix(ground_color, (247, 141, 57), ratio)
+        draw.ellipse(
+            (x - radius, y - radius // 2, x + radius, y + radius // 2),
+            fill=glow,
+        )
+
+
+def _draw_stone_ring(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    radius_x: int,
+    radius_y: int,
+    stone_color: tuple[int, int, int],
+    count: int = 10,
+) -> None:
+    x, y = center
+    positions = (
+        (-radius_x, 0),
+        (-int(radius_x * 0.78), -int(radius_y * 0.55)),
+        (-int(radius_x * 0.38), -radius_y),
+        (int(radius_x * 0.38), -radius_y),
+        (int(radius_x * 0.78), -int(radius_y * 0.55)),
+        (radius_x, 0),
+        (int(radius_x * 0.72), int(radius_y * 0.55)),
+        (int(radius_x * 0.30), radius_y),
+        (-int(radius_x * 0.30), radius_y),
+        (-int(radius_x * 0.72), int(radius_y * 0.55)),
+        (0, -radius_y - 2),
+        (0, radius_y + 2),
+    )
+    for dx, dy in positions[: max(1, min(len(positions), count))]:
+        width = 9
+        height = 5
+        draw.ellipse(
+            (x + dx - width, y + dy - height, x + dx + width, y + dy + height),
+            fill=stone_color,
+        )
+
+
+def _draw_flame(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    intensity: str,
+    level: int,
+) -> None:
+    x, y = center
+    scale = {"low": 0.78, "normal": 1.0, "high": 1.28}[intensity]
+    scale *= 1.0 + (max(1, level) - 1) * 0.06
+    height = int(49 * scale)
+    width = int(27 * scale)
+
+    outer = (224, 83, 35)
+    middle = (244, 139, 45)
+    inner = (255, 213, 91)
+    draw.polygon(
+        (
+            (x, y - height),
+            (x - width, y - int(height * 0.36)),
+            (x - int(width * 0.72), y + 4),
+            (x + int(width * 0.72), y + 4),
+            (x + width, y - int(height * 0.36)),
+        ),
+        fill=outer,
+    )
+    draw.polygon(
+        (
+            (x + int(width * 0.18), y - int(height * 0.76)),
+            (x - int(width * 0.58), y - int(height * 0.25)),
+            (x - int(width * 0.35), y + 1),
+            (x + int(width * 0.48), y + 1),
+        ),
+        fill=middle,
+    )
+    draw.polygon(
+        (
+            (x, y - int(height * 0.52)),
+            (x - int(width * 0.26), y - int(height * 0.14)),
+            (x, y),
+            (x + int(width * 0.28), y - int(height * 0.14)),
+        ),
+        fill=inner,
+    )
+
+
+def _draw_logs(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    scale: float = 1.0,
+) -> None:
+    x, y = center
+    half = int(31 * scale)
+    width = max(5, int(7 * scale))
+    wood = (92, 59, 36)
+    cut = (157, 112, 70)
+    draw.line((x - half, y + 8, x + half, y - 7), fill=wood, width=width)
+    draw.line((x - half, y - 7, x + half, y + 8), fill=wood, width=width)
+    draw.ellipse((x - half - 4, y + 4, x - half + 4, y + 12), fill=cut)
+    draw.ellipse((x + half - 4, y + 4, x + half + 4, y + 12), fill=cut)
+
+
+def _draw_bench(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    width: int,
+    winter: bool,
+) -> None:
+    x, y = center
+    wood = (91, 64, 42)
+    edge = (60, 48, 39)
+    draw.polygon(
+        (
+            (x - width, y - 5),
+            (x + width, y - 5),
+            (x + width - 7, y + 5),
+            (x - width + 7, y + 5),
+        ),
+        fill=wood,
+    )
+    draw.line((x - width + 10, y + 5, x - width + 6, y + 15), fill=edge, width=4)
+    draw.line((x + width - 10, y + 5, x + width - 6, y + 15), fill=edge, width=4)
+    if winter:
+        draw.line(
+            (x - width + 3, y - 6, x + width - 3, y - 6),
+            fill=(216, 223, 219),
+            width=3,
+        )
+
+
+def _draw_tent(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    winter: bool,
+) -> None:
+    x, y = center
+    canvas = (116, 83, 56)
+    dark = _shade(canvas, 0.72)
+    draw.polygon(((x, y - 43), (x - 34, y + 10), (x + 34, y + 10)), fill=canvas)
+    draw.polygon(((x, y - 43), (x, y + 10), (x + 34, y + 10)), fill=dark)
+    draw.line((x, y - 43, x, y + 10), fill=(72, 54, 39), width=3)
+    if winter:
+        draw.line((x - 19, y - 13, x, y - 43, x + 19, y - 13), fill=(220, 226, 221), width=4)
+
+
+def _draw_lantern(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    lit: bool,
+) -> None:
+    x, y = center
+    draw.line((x, y, x, y - 42), fill=(62, 54, 46), width=4)
+    lamp = (244, 191, 92) if lit else (139, 122, 84)
+    draw.rectangle((x - 7, y - 43, x + 7, y - 29), fill=lamp)
+    draw.rectangle((x - 9, y - 46, x + 9, y - 42), fill=(66, 58, 48))
+
+
+def _draw_secret_details(
+    draw: ImageDraw.ImageDraw,
+    *,
+    secrets: frozenset[str],
+    daypart: str,
+) -> None:
+    if "night_of_stars" in secrets:
+        star_color = (190, 210, 218) if daypart != "night" else (232, 231, 191)
+        for x, y in ((584, 438), (608, 452), (680, 452), (704, 438), (644, 464)):
+            draw.polygon(
+                ((x, y - 5), (x + 3, y), (x, y + 5), (x - 3, y)),
+                fill=star_color,
+            )
+
+    if "first_visitor" in secrets:
+        orange = (174, 91, 43)
+        dark = (69, 55, 43)
+        x, y = 742, 420
+        draw.ellipse((x - 18, y - 10, x + 14, y + 8), fill=orange)
+        draw.polygon(((x + 8, y - 7), (x + 23, y - 16), (x + 19, y + 1)), fill=orange)
+        draw.polygon(((x - 14, y - 4), (x - 32, y - 15), (x - 25, y + 3)), fill=orange)
+        draw.polygon(((x + 14, y - 12), (x + 17, y - 23), (x + 21, y - 11)), fill=orange)
+        draw.ellipse((x + 18, y - 8, x + 21, y - 5), fill=dark)
+
+    if "full_circle" in secrets:
+        stone = (115, 112, 103)
+        _draw_stone_ring(
+            draw,
+            center=(644, 421),
+            radius_x=76,
+            radius_y=27,
+            stone_color=stone,
+            count=12,
+        )
+
+
+def draw_refuge_fire(
+    draw: ImageDraw.ImageDraw,
+    state: RefugeWorldState,
+    *,
+    context: RefugeRenderContext,
+) -> None:
+    building = _fire_building(state)
+    if building is None or int(building.level) <= 0:
+        return
+
+    level = max(1, min(FIRE_MAX_LEVEL, int(building.level)))
+    intensity = _intensity(building)
+    secrets = _secret_ids(building)
+    x, y = FIRE_SITE_CENTER
+    winter = context.season == "winter"
+    dark_time = context.daypart in {"night", "sunset"}
+
+    ground = {
+        "winter": (139, 145, 134),
+        "spring": (91, 126, 76),
+        "summer": (77, 111, 66),
+        "autumn": (116, 101, 65),
+    }[context.season]
+    if context.daypart == "night":
+        ground = _shade(ground, 0.55)
+
+    _draw_glow(
+        draw,
+        center=(x, y - 4),
+        intensity=intensity,
+        daypart=context.daypart,
+        ground_color=ground,
+    )
+
+    if level >= 4:
+        plaza = _mix(ground, (144, 132, 113), 0.66)
+        draw.ellipse((x - 87, y - 36, x + 87, y + 35), fill=plaza)
+        draw.ellipse(
+            (x - 75, y - 29, x + 75, y + 29),
+            outline=_shade(plaza, 0.72),
+            width=3,
+        )
+
+    if level >= 2:
+        _draw_tent(draw, center=(x - 79, y - 13), winter=winter)
+        _draw_bench(draw, center=(x - 70, y + 28), width=28, winter=winter)
+        _draw_bench(draw, center=(x + 70, y + 28), width=28, winter=winter)
+
+    if level >= 3:
+        _draw_bench(draw, center=(x, y + 48), width=31, winter=winter)
+        _draw_lantern(draw, center=(x - 55, y - 25), lit=dark_time)
+        _draw_lantern(draw, center=(x + 55, y - 25), lit=dark_time)
+
+    if level >= 4:
+        stone = (108, 105, 96)
+        for px in (x - 91, x + 91):
+            draw.rectangle((px - 7, y - 44, px + 7, y + 8), fill=stone)
+            banner = (112, 57, 43) if context.season != "winter" else (84, 91, 96)
+            draw.polygon(
+                ((px + 8, y - 40), (px + 31, y - 33), (px + 8, y - 24)),
+                fill=banner,
+            )
+
+    if level >= 5:
+        stone = (101, 101, 96)
+        draw.rectangle((x - 43, y - 78, x - 28, y - 6), fill=stone)
+        draw.rectangle((x + 28, y - 78, x + 43, y - 6), fill=stone)
+        draw.arc((x - 43, y - 103, x + 43, y - 31), 180, 360, fill=stone, width=10)
+        draw.ellipse((x - 50, y + 6, x + 50, y + 31), fill=(106, 101, 91))
+
+    _draw_secret_details(draw, secrets=secrets, daypart=context.daypart)
+
+    ring_scale = 1.0 + (level - 1) * 0.08
+    _draw_stone_ring(
+        draw,
+        center=(x, y + 5),
+        radius_x=int(34 * ring_scale),
+        radius_y=int(13 * ring_scale),
+        stone_color=(111, 105, 96) if not winter else (151, 155, 150),
+    )
+    _draw_logs(draw, center=(x, y + 5), scale=ring_scale)
+    _draw_flame(
+        draw,
+        center=(x, y - 2),
+        intensity=intensity,
+        level=level,
+    )
+
+    if winter:
+        draw.arc(
+            (x - 42, y - 11, x + 42, y + 22),
+            190,
+            342,
+            fill=(218, 224, 220),
+            width=3,
+        )
+
+
+class RefugeFireRenderer:
+    """Compose the REFUGE-004 terrain with the living Fire layer."""
+
+    def __init__(
+        self,
+        base_renderer: RefugeWorldRenderer = base_world_renderer,
+    ) -> None:
+        self.base_renderer = base_renderer
+
+    def render_png(
+        self,
+        state: RefugeWorldState,
+        *,
+        context: RefugeRenderContext | None = None,
+    ) -> bytes:
+        render_context = context or RefugeRenderContext.from_datetime()
+        base_png = self.base_renderer.render_png(state, context=render_context)
+        image = Image.open(io.BytesIO(base_png)).convert("RGB")
+        draw = ImageDraw.Draw(image)
+        draw_refuge_fire(draw, state, context=render_context)
+
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG", optimize=False, compress_level=9)
+        return buffer.getvalue()
+
+    async def render_png_async(
+        self,
+        state: RefugeWorldState,
+        *,
+        context: RefugeRenderContext | None = None,
+    ) -> bytes:
+        return await asyncio.to_thread(self.render_png, state, context=context)
+
+
+refuge_fire_renderer = RefugeFireRenderer()
+
+
+__all__ = [
+    "FIRE_SITE_CENTER",
+    "REFUGE_FIRE_RENDERER_VERSION",
+    "RefugeFireRenderer",
+    "draw_refuge_fire",
+    "fire_scene_signature",
+    "refuge_fire_renderer",
+]

--- a/services/refuge_fire.py
+++ b/services/refuge_fire.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Final, Mapping
+
+from models.refuge_world import (
+    RefugeBuildingState,
+    RefugeHistoricalEvent,
+    RefugeWorldState,
+)
+from services.refuge_world import (
+    BuildingProgressionRule,
+    RefugeWorldService,
+    refuge_world_service,
+    world_render_signature,
+)
+from storage.refuge_activity_store import (
+    RefugeActivityStore,
+    refuge_activity_store,
+)
+
+
+FIRE_BUILDING_ID: Final[str] = "fire"
+FIRE_METRIC_KEY: Final[str] = "community_voice_seconds"
+FIRE_MAX_LEVEL: Final[int] = 5
+FIRE_RECENT_WINDOW_SECONDS: Final[int] = 24 * 60 * 60
+
+FIRE_LEVEL_NAMES: Final[Mapping[int, str]] = {
+    1: "L’Étincelle",
+    2: "Le Campement",
+    3: "Le Grand Foyer",
+    4: "La Place du Refuge",
+    5: "Le Cœur du Refuge",
+}
+
+FIRE_SECRET_EVENTS: Final[Mapping[str, str]] = {
+    "night_of_stars": "La Nuit des Étoiles",
+    "first_visitor": "Le Premier Visiteur",
+    "full_circle": "Le Cercle complet",
+}
+
+_VALID_INTENSITIES = frozenset({"low", "normal", "high"})
+
+
+def _utc_iso(at: datetime | None = None) -> str:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).isoformat()
+
+
+def _parse_thresholds_env(name: str) -> tuple[int, ...]:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return ()
+    values: list[int] = []
+    for item in raw.split(","):
+        token = item.strip()
+        if not token:
+            raise ValueError(f"{name} contains an empty threshold")
+        try:
+            value = int(token)
+        except ValueError as exc:
+            raise ValueError(f"{name} must contain integer seconds") from exc
+        values.append(value)
+    return tuple(values)
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeFireConfig:
+    """Configurable thresholds; no production thresholds are hard-coded."""
+
+    level_thresholds_seconds: tuple[int, ...] = ()
+    intensity_thresholds_seconds: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.level_thresholds_seconds and len(self.level_thresholds_seconds) != 4:
+            raise ValueError(
+                "fire level thresholds must contain exactly 4 values "
+                "to define levels II to V"
+            )
+        if self.intensity_thresholds_seconds and len(
+            self.intensity_thresholds_seconds
+        ) != 2:
+            raise ValueError(
+                "fire intensity thresholds must contain exactly 2 values"
+            )
+        self._validate_increasing(
+            self.level_thresholds_seconds,
+            name="fire level thresholds",
+            positive=True,
+        )
+        self._validate_increasing(
+            self.intensity_thresholds_seconds,
+            name="fire intensity thresholds",
+            positive=False,
+        )
+
+    @staticmethod
+    def _validate_increasing(
+        values: tuple[int, ...],
+        *,
+        name: str,
+        positive: bool,
+    ) -> None:
+        previous: int | None = None
+        for raw in values:
+            value = int(raw)
+            if positive and value <= 0:
+                raise ValueError(f"{name} must be > 0")
+            if not positive and value < 0:
+                raise ValueError(f"{name} must be >= 0")
+            if previous is not None and value <= previous:
+                raise ValueError(f"{name} must be strictly increasing")
+            previous = value
+
+    @classmethod
+    def from_env(cls) -> "RefugeFireConfig":
+        return cls(
+            level_thresholds_seconds=_parse_thresholds_env(
+                "REFUGE_FIRE_LEVEL_THRESHOLDS_SECONDS"
+            ),
+            intensity_thresholds_seconds=_parse_thresholds_env(
+                "REFUGE_FIRE_INTENSITY_THRESHOLDS_SECONDS"
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeFireStatus:
+    state: RefugeWorldState
+    level: int
+    level_name: str
+    intensity: str
+    lifetime_voice_seconds: int
+    recent_voice_seconds: int
+    changed: bool
+    render_signature: str
+
+
+def fire_level_name(level: int) -> str:
+    normalized = max(1, min(FIRE_MAX_LEVEL, int(level)))
+    return FIRE_LEVEL_NAMES[normalized]
+
+
+def fire_intensity_for_recent(
+    recent_seconds: int,
+    *,
+    thresholds: tuple[int, ...] = (),
+) -> str:
+    recent = max(0, int(recent_seconds))
+    if thresholds:
+        if len(thresholds) != 2:
+            raise ValueError("fire intensity thresholds must contain 2 values")
+        low_to_normal, normal_to_high = (int(value) for value in thresholds)
+        if recent < low_to_normal:
+            return "low"
+        if recent < normal_to_high:
+            return "normal"
+        return "high"
+
+    # Without calibrated production thresholds, zero activity is quiet and
+    # any observed community voice activity is shown as normal. "high" stays
+    # unavailable until the two explicit thresholds are configured.
+    return "low" if recent == 0 else "normal"
+
+
+def _fire_building(state: RefugeWorldState) -> RefugeBuildingState | None:
+    return next(
+        (
+            building
+            for building in state.buildings
+            if building.building_id == FIRE_BUILDING_ID
+        ),
+        None,
+    )
+
+
+def _replace_building(
+    state: RefugeWorldState,
+    building: RefugeBuildingState,
+) -> RefugeWorldState:
+    buildings = {
+        current.building_id: current
+        for current in state.buildings
+    }
+    buildings[building.building_id] = building
+    return replace(
+        state,
+        buildings=tuple(
+            sorted(buildings.values(), key=lambda item: item.building_id)
+        ),
+    )
+
+
+class RefugeFireService:
+    """Bridge real community voice activity to the permanent Refuge Fire."""
+
+    def __init__(
+        self,
+        *,
+        activity_store: RefugeActivityStore = refuge_activity_store,
+        world_service: RefugeWorldService = refuge_world_service,
+    ) -> None:
+        self.activity_store = activity_store
+        self.world_service = world_service
+        self.world_store = world_service.store
+        self._lock = asyncio.Lock()
+
+    async def evaluate(
+        self,
+        *,
+        config: RefugeFireConfig | None = None,
+        at: datetime | None = None,
+    ) -> RefugeFireStatus:
+        fire_config = config or RefugeFireConfig.from_env()
+        async with self._lock:
+            return await self._evaluate_locked(config=fire_config, at=at)
+
+    async def _evaluate_locked(
+        self,
+        *,
+        config: RefugeFireConfig,
+        at: datetime | None,
+    ) -> RefugeFireStatus:
+        lifetime_seconds = await self.activity_store.get_total_seconds()
+        recent_seconds = await self.activity_store.get_recent_seconds(
+            window_seconds=FIRE_RECENT_WINDOW_SECONDS,
+            at=at,
+        )
+        progression = await self.world_service.evaluate(
+            metrics={FIRE_METRIC_KEY: lifetime_seconds},
+            rules=(
+                BuildingProgressionRule(
+                    building_id=FIRE_BUILDING_ID,
+                    metric_key=FIRE_METRIC_KEY,
+                    thresholds=config.level_thresholds_seconds,
+                    minimum_level=1,
+                    event_from_level=2,
+                ),
+            ),
+            at=at,
+        )
+
+        state = progression.state
+        building = _fire_building(state)
+        if building is None:
+            raise RuntimeError("Refuge Fire progression did not create a building")
+
+        intensity = fire_intensity_for_recent(
+            recent_seconds,
+            thresholds=config.intensity_thresholds_seconds,
+        )
+        if intensity not in _VALID_INTENSITIES:
+            raise RuntimeError(f"unsupported Fire intensity: {intensity}")
+
+        state_changed = progression.changed
+        if building.state.get("intensity") != intensity:
+            building_state = dict(building.state)
+            building_state["intensity"] = intensity
+            building = replace(building, state=building_state)
+            state = _replace_building(state, building)
+            state = await self.world_store.save_state(state)
+            state_changed = True
+
+        return RefugeFireStatus(
+            state=state,
+            level=max(1, min(FIRE_MAX_LEVEL, int(building.level))),
+            level_name=fire_level_name(building.level),
+            intensity=intensity,
+            lifetime_voice_seconds=lifetime_seconds,
+            recent_voice_seconds=recent_seconds,
+            changed=state_changed,
+            render_signature=world_render_signature(state),
+        )
+
+    async def unlock_secret(
+        self,
+        secret_id: str,
+        *,
+        at: datetime | None = None,
+        config: RefugeFireConfig | None = None,
+    ) -> RefugeWorldState:
+        """Persist one supported Fire secret; trigger conditions live in REFUGE-012."""
+
+        normalized = str(secret_id).strip()
+        if normalized not in FIRE_SECRET_EVENTS:
+            raise ValueError(f"unsupported Fire secret: {normalized}")
+
+        fire_config = config or RefugeFireConfig.from_env()
+        async with self._lock:
+            status = await self._evaluate_locked(config=fire_config, at=at)
+            state = status.state
+            building = _fire_building(state)
+            if building is None:
+                raise RuntimeError("Refuge Fire building is missing")
+
+            event_id = f"fire:secret:{normalized}"
+            if any(event.event_id == event_id for event in state.events):
+                return state
+
+            existing_secrets = building.state.get("secret_events", ())
+            secrets = {
+                str(value)
+                for value in existing_secrets
+                if str(value) in FIRE_SECRET_EVENTS
+            } if isinstance(existing_secrets, (list, tuple, set, frozenset)) else set()
+            secrets.add(normalized)
+
+            building_state = dict(building.state)
+            building_state["secret_events"] = sorted(secrets)
+            updated = _replace_building(
+                state,
+                replace(building, state=building_state),
+            )
+
+            event = RefugeHistoricalEvent(
+                event_id=event_id,
+                event_type="fire_secret_discovered",
+                occurred_at=_utc_iso(at),
+                data={
+                    "building_id": FIRE_BUILDING_ID,
+                    "secret_id": normalized,
+                    "name": FIRE_SECRET_EVENTS[normalized],
+                },
+            )
+            updated = replace(updated, events=updated.events + (event,))
+            return await self.world_store.save_state(updated)
+
+
+refuge_fire_service = RefugeFireService()
+
+
+__all__ = [
+    "FIRE_BUILDING_ID",
+    "FIRE_LEVEL_NAMES",
+    "FIRE_MAX_LEVEL",
+    "FIRE_RECENT_WINDOW_SECONDS",
+    "FIRE_SECRET_EVENTS",
+    "RefugeFireConfig",
+    "RefugeFireService",
+    "RefugeFireStatus",
+    "fire_intensity_for_recent",
+    "fire_level_name",
+    "refuge_fire_service",
+]

--- a/storage/refuge_activity_store.py
+++ b/storage/refuge_activity_store.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import weakref
 from copy import deepcopy
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping
 
@@ -12,19 +12,75 @@ from utils.persistence import atomic_write_json_async, read_json_safe
 from utils.seasons import split_interval_by_season
 
 
-REFUGE_ACTIVITY_SCHEMA_VERSION = 1
+REFUGE_ACTIVITY_SCHEMA_VERSION = 2
 REFUGE_ACTIVITY_FILE = Path(DATA_DIR) / "refuge_activity.json"
+RECENT_BUCKET_SECONDS = 60
+RECENT_RETENTION_SECONDS = 48 * 60 * 60
 
 
 class RefugeActivitySchemaError(ValueError):
     """Raised when persisted Refuge activity uses an unsupported schema."""
 
 
-def _utc_iso(at: datetime | None = None) -> str:
+def _aware_utc(at: datetime | None = None) -> datetime:
     moment = at or datetime.now(timezone.utc)
     if moment.tzinfo is None:
         moment = moment.replace(tzinfo=timezone.utc)
-    return moment.astimezone(timezone.utc).isoformat()
+    return moment.astimezone(timezone.utc)
+
+
+def _utc_iso(at: datetime | None = None) -> str:
+    return _aware_utc(at).isoformat()
+
+
+def _bucket_start(at: datetime) -> datetime:
+    current = _aware_utc(at)
+    return current.replace(second=0, microsecond=0)
+
+
+def _split_recent_buckets(
+    started_at: datetime,
+    recorded_seconds: int,
+) -> tuple[tuple[str, int], ...]:
+    remaining = max(0, int(recorded_seconds))
+    if remaining <= 0:
+        return ()
+
+    current = _aware_utc(started_at)
+    parts: list[tuple[str, int]] = []
+    while remaining > 0:
+        bucket = _bucket_start(current)
+        next_bucket = bucket + timedelta(seconds=RECENT_BUCKET_SECONDS)
+        room = max(1, int((next_bucket - current).total_seconds()))
+        seconds = min(remaining, room)
+        parts.append((bucket.isoformat(), seconds))
+        current += timedelta(seconds=seconds)
+        remaining -= seconds
+    return tuple(parts)
+
+
+def _parse_bucket_key(value: object) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return _bucket_start(parsed)
+
+
+def _prune_recent_buckets(
+    buckets: dict[str, int],
+    *,
+    at: datetime,
+) -> None:
+    cutoff = _aware_utc(at) - timedelta(seconds=RECENT_RETENTION_SECONDS)
+    for raw_key in list(buckets):
+        bucket = _parse_bucket_key(raw_key)
+        if bucket is None or bucket + timedelta(seconds=RECENT_BUCKET_SECONDS) <= cutoff:
+            buckets.pop(raw_key, None)
 
 
 class RefugeActivityStore:
@@ -46,6 +102,7 @@ class RefugeActivityStore:
             "tracking_started_at": None,
             "community_voice_seconds": 0,
             "seasons": {},
+            "recent_voice_buckets": {},
         }
 
     def _get_lock(self) -> asyncio.Lock:
@@ -74,11 +131,12 @@ class RefugeActivityStore:
             version = int(raw.get("schema_version", 0))
         except (TypeError, ValueError):
             version = 0
-        if version != REFUGE_ACTIVITY_SCHEMA_VERSION:
+        if version not in {1, REFUGE_ACTIVITY_SCHEMA_VERSION}:
             raise RefugeActivitySchemaError(
                 "unsupported refuge activity schema "
-                f"{version}; expected {REFUGE_ACTIVITY_SCHEMA_VERSION}"
+                f"{version}; expected 1 or {REFUGE_ACTIVITY_SCHEMA_VERSION}"
             )
+        migrated = version == 1
 
         try:
             total_seconds = max(0, int(raw.get("community_voice_seconds", 0)))
@@ -102,6 +160,24 @@ class RefugeActivityStore:
                     "community_voice_seconds": seconds,
                 }
 
+        recent_voice_buckets: dict[str, int] = {}
+        raw_buckets = raw.get("recent_voice_buckets", {})
+        if isinstance(raw_buckets, Mapping):
+            for raw_key, raw_seconds in raw_buckets.items():
+                bucket = _parse_bucket_key(raw_key)
+                if bucket is None:
+                    continue
+                try:
+                    seconds = max(0, int(raw_seconds))
+                except (TypeError, ValueError):
+                    continue
+                if seconds <= 0:
+                    continue
+                key = bucket.isoformat()
+                recent_voice_buckets[key] = (
+                    recent_voice_buckets.get(key, 0) + seconds
+                )
+
         tracking_started_at = raw.get("tracking_started_at")
         self._data = {
             "schema_version": REFUGE_ACTIVITY_SCHEMA_VERSION,
@@ -110,8 +186,11 @@ class RefugeActivityStore:
             ),
             "community_voice_seconds": total_seconds,
             "seasons": seasons,
+            "recent_voice_buckets": recent_voice_buckets,
         }
         self._loaded = True
+        if migrated:
+            await atomic_write_json_async(self.path, self._data)
 
     async def initialize(
         self,
@@ -143,6 +222,7 @@ class RefugeActivityStore:
                 int(self._data.get("community_voice_seconds", 0))
                 + recorded_seconds
             )
+
             seasons = self._data.setdefault("seasons", {})
             for season_id, seconds in parts:
                 season = seasons.setdefault(
@@ -153,6 +233,17 @@ class RefugeActivityStore:
                     int(season.get("community_voice_seconds", 0))
                     + seconds
                 )
+
+            recent = self._data.setdefault("recent_voice_buckets", {})
+            for bucket_key, seconds in _split_recent_buckets(
+                started_at,
+                recorded_seconds,
+            ):
+                recent[bucket_key] = int(recent.get(bucket_key, 0)) + seconds
+            _prune_recent_buckets(
+                recent,
+                at=_aware_utc(started_at) + timedelta(seconds=recorded_seconds),
+            )
             self._dirty = True
         return recorded_seconds
 
@@ -175,6 +266,37 @@ class RefugeActivityStore:
         except (TypeError, ValueError):
             return 0
 
+    async def get_recent_seconds(
+        self,
+        *,
+        window_seconds: int = 24 * 60 * 60,
+        at: datetime | None = None,
+    ) -> int:
+        window = int(window_seconds)
+        if window <= 0:
+            raise ValueError("window_seconds must be > 0")
+
+        now = _aware_utc(at)
+        cutoff = now - timedelta(seconds=window)
+        snapshot = await self.get_snapshot()
+        raw_buckets = snapshot.get("recent_voice_buckets", {})
+        if not isinstance(raw_buckets, Mapping):
+            return 0
+
+        total = 0
+        for raw_key, raw_seconds in raw_buckets.items():
+            bucket = _parse_bucket_key(raw_key)
+            if bucket is None:
+                continue
+            bucket_end = bucket + timedelta(seconds=RECENT_BUCKET_SECONDS)
+            if bucket_end <= cutoff or bucket > now:
+                continue
+            try:
+                total += max(0, int(raw_seconds))
+            except (TypeError, ValueError):
+                continue
+        return total
+
     async def flush(self) -> None:
         async with self._get_lock():
             await self._load_locked()
@@ -188,6 +310,8 @@ refuge_activity_store = RefugeActivityStore()
 
 
 __all__ = [
+    "RECENT_BUCKET_SECONDS",
+    "RECENT_RETENTION_SECONDS",
     "REFUGE_ACTIVITY_FILE",
     "REFUGE_ACTIVITY_SCHEMA_VERSION",
     "RefugeActivitySchemaError",

--- a/tests/test_refuge_fire.py
+++ b/tests/test_refuge_fire.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services.refuge_fire import (
+    FIRE_LEVEL_NAMES,
+    FIRE_SECRET_EVENTS,
+    RefugeFireConfig,
+    RefugeFireService,
+    fire_intensity_for_recent,
+)
+from services.refuge_world import RefugeWorldService
+from storage.refuge_activity_store import (
+    REFUGE_ACTIVITY_SCHEMA_VERSION,
+    RefugeActivityStore,
+)
+from storage.refuge_world_store import RefugeWorldStore
+
+
+def _fire_building(state):
+    return next(
+        building
+        for building in state.buildings
+        if building.building_id == "fire"
+    )
+
+
+def _service(tmp_path):
+    activity = RefugeActivityStore(tmp_path / "refuge_activity.json")
+    world_store = RefugeWorldStore(tmp_path / "refuge_world.json")
+    world_service = RefugeWorldService(world_store)
+    fire = RefugeFireService(
+        activity_store=activity,
+        world_service=world_service,
+    )
+    return activity, world_store, fire
+
+
+def test_fire_level_names_are_the_five_validated_names():
+    assert FIRE_LEVEL_NAMES == {
+        1: "L’Étincelle",
+        2: "Le Campement",
+        3: "Le Grand Foyer",
+        4: "La Place du Refuge",
+        5: "Le Cœur du Refuge",
+    }
+
+
+def test_fire_config_accepts_unconfigured_or_four_level_thresholds():
+    assert RefugeFireConfig().level_thresholds_seconds == ()
+    assert RefugeFireConfig(
+        level_thresholds_seconds=(100, 500, 1000, 5000),
+        intensity_thresholds_seconds=(120, 900),
+    ).level_thresholds_seconds[-1] == 5000
+
+    with pytest.raises(ValueError):
+        RefugeFireConfig(level_thresholds_seconds=(100, 500))
+    with pytest.raises(ValueError):
+        RefugeFireConfig(
+            level_thresholds_seconds=(100, 100, 1000, 5000)
+        )
+    with pytest.raises(ValueError):
+        RefugeFireConfig(intensity_thresholds_seconds=(60,))
+
+
+def test_fire_config_reads_explicit_environment_thresholds(monkeypatch):
+    monkeypatch.setenv(
+        "REFUGE_FIRE_LEVEL_THRESHOLDS_SECONDS",
+        "3600,14400,36000,72000",
+    )
+    monkeypatch.setenv(
+        "REFUGE_FIRE_INTENSITY_THRESHOLDS_SECONDS",
+        "1800,10800",
+    )
+
+    config = RefugeFireConfig.from_env()
+
+    assert config.level_thresholds_seconds == (3600, 14400, 36000, 72000)
+    assert config.intensity_thresholds_seconds == (1800, 10800)
+
+
+@pytest.mark.parametrize(
+    ("recent", "thresholds", "expected"),
+    [
+        (0, (), "low"),
+        (1, (), "normal"),
+        (59, (60, 180), "low"),
+        (60, (60, 180), "normal"),
+        (179, (60, 180), "normal"),
+        (180, (60, 180), "high"),
+    ],
+)
+def test_fire_intensity_is_configurable(recent, thresholds, expected):
+    assert fire_intensity_for_recent(
+        recent,
+        thresholds=thresholds,
+    ) == expected
+
+
+@pytest.mark.asyncio
+async def test_activity_schema_v1_migrates_without_losing_totals(tmp_path):
+    path = tmp_path / "refuge_activity.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "tracking_started_at": "2026-08-09T05:00:00+00:00",
+                "community_voice_seconds": 4321,
+                "seasons": {
+                    "2026-08": {"community_voice_seconds": 4321}
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    store = RefugeActivityStore(path)
+    snapshot = await store.get_snapshot()
+
+    assert snapshot["schema_version"] == REFUGE_ACTIVITY_SCHEMA_VERSION
+    assert snapshot["community_voice_seconds"] == 4321
+    assert snapshot["seasons"]["2026-08"]["community_voice_seconds"] == 4321
+    assert snapshot["recent_voice_buckets"] == {}
+
+    persisted = json.loads(path.read_text(encoding="utf-8"))
+    assert persisted["schema_version"] == REFUGE_ACTIVITY_SCHEMA_VERSION
+
+
+@pytest.mark.asyncio
+async def test_recent_voice_window_accumulates_independent_room_time(tmp_path):
+    store = RefugeActivityStore(tmp_path / "refuge_activity.json")
+    start = datetime(2026, 8, 9, 4, 0, tzinfo=timezone.utc)
+    end = start + timedelta(minutes=10)
+
+    await store.record_interval(start, end)
+    await store.record_interval(start, end)
+
+    assert await store.get_total_seconds() == 20 * 60
+    assert await store.get_recent_seconds(
+        at=end,
+        window_seconds=24 * 60 * 60,
+    ) == 20 * 60
+
+
+@pytest.mark.asyncio
+async def test_recent_voice_window_does_not_backfill_old_activity(tmp_path):
+    store = RefugeActivityStore(tmp_path / "refuge_activity.json")
+    old = datetime(2026, 8, 7, 4, 0, tzinfo=timezone.utc)
+    now = datetime(2026, 8, 9, 4, 0, tzinfo=timezone.utc)
+
+    await store.record_interval(old, old + timedelta(minutes=20))
+    await store.record_interval(now, now + timedelta(minutes=5))
+
+    assert await store.get_total_seconds() == 25 * 60
+    assert await store.get_recent_seconds(
+        at=now + timedelta(minutes=5),
+    ) == 5 * 60
+
+
+@pytest.mark.asyncio
+async def test_fire_starts_at_level_one_without_arbitrary_thresholds(tmp_path):
+    activity, _world_store, fire = _service(tmp_path)
+    start = datetime(2026, 8, 9, 4, 0, tzinfo=timezone.utc)
+    await activity.record_interval(start, start + timedelta(minutes=2))
+
+    status = await fire.evaluate(
+        config=RefugeFireConfig(),
+        at=start + timedelta(minutes=2),
+    )
+
+    assert status.level == 1
+    assert status.level_name == "L’Étincelle"
+    assert status.intensity == "normal"
+    assert status.lifetime_voice_seconds == 120
+    assert _fire_building(status.state).state["intensity"] == "normal"
+
+
+@pytest.mark.asyncio
+async def test_fire_reaches_level_five_and_never_regresses(tmp_path):
+    activity, _world_store, fire = _service(tmp_path)
+    start = datetime(2026, 8, 9, 4, 0, tzinfo=timezone.utc)
+    config = RefugeFireConfig(
+        level_thresholds_seconds=(60, 120, 180, 240),
+        intensity_thresholds_seconds=(60, 180),
+    )
+    await activity.record_interval(start, start + timedelta(seconds=250))
+
+    first = await fire.evaluate(
+        config=config,
+        at=start + timedelta(seconds=250),
+    )
+    later = await fire.evaluate(
+        config=config,
+        at=start + timedelta(days=2),
+    )
+
+    assert first.level == 5
+    assert first.intensity == "high"
+    assert later.level == 5
+    assert later.intensity == "low"
+
+    level_events = [
+        event
+        for event in later.state.events
+        if event.event_type == "building_level_reached"
+        and event.data.get("building_id") == "fire"
+    ]
+    assert [event.data["level"] for event in level_events] == [2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_fire_secret_unlock_is_persistent_and_idempotent(tmp_path):
+    _activity, world_store, fire = _service(tmp_path)
+    at = datetime(2026, 8, 9, 4, 0, tzinfo=timezone.utc)
+    config = RefugeFireConfig()
+
+    first = await fire.unlock_secret(
+        "first_visitor",
+        at=at,
+        config=config,
+    )
+    second = await fire.unlock_secret(
+        "first_visitor",
+        at=at + timedelta(hours=1),
+        config=config,
+    )
+    restarted = await world_store.get_state()
+
+    assert _fire_building(first).state["secret_events"] == ["first_visitor"]
+    assert _fire_building(second).state["secret_events"] == ["first_visitor"]
+    assert _fire_building(restarted).state["secret_events"] == ["first_visitor"]
+
+    matching = [
+        event
+        for event in restarted.events
+        if event.event_id == "fire:secret:first_visitor"
+    ]
+    assert len(matching) == 1
+    assert matching[0].data["name"] == FIRE_SECRET_EVENTS["first_visitor"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_fire_secret_is_rejected(tmp_path):
+    _activity, _world_store, fire = _service(tmp_path)
+
+    with pytest.raises(ValueError):
+        await fire.unlock_secret("not-a-secret")

--- a/tests/test_refuge_fire_renderer.py
+++ b/tests/test_refuge_fire_renderer.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import hashlib
+import io
+
+import pytest
+from PIL import Image
+
+from models.refuge_world import RefugeBuildingState, RefugeWorldState
+from rendering.refuge_fire import (
+    RefugeFireRenderer,
+    fire_scene_signature,
+)
+from rendering.refuge_world import REFUGE_CANVAS_SIZE, RefugeRenderContext
+
+
+CONTEXT = RefugeRenderContext(season="summer", daypart="night")
+
+
+def _state(
+    *,
+    level: int,
+    intensity: str = "normal",
+    secrets: tuple[str, ...] = (),
+) -> RefugeWorldState:
+    return RefugeWorldState(
+        buildings=(
+            RefugeBuildingState(
+                building_id="fire",
+                level=level,
+                unlocked_at="2026-08-09T05:00:00+00:00",
+                state={
+                    "intensity": intensity,
+                    "secret_events": list(secrets),
+                },
+            ),
+        ),
+    )
+
+
+def _digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def test_fire_renderer_produces_expected_png_dimensions():
+    payload = RefugeFireRenderer().render_png(
+        _state(level=1),
+        context=CONTEXT,
+    )
+
+    image = Image.open(io.BytesIO(payload))
+    assert image.size == REFUGE_CANVAS_SIZE
+    assert image.mode == "RGB"
+
+
+def test_all_five_fire_levels_have_distinct_silhouettes():
+    renderer = RefugeFireRenderer()
+
+    digests = {
+        _digest(renderer.render_png(_state(level=level), context=CONTEXT))
+        for level in range(1, 6)
+    }
+
+    assert len(digests) == 5
+
+
+def test_fire_intensity_changes_the_visual_without_changing_level():
+    renderer = RefugeFireRenderer()
+    low = renderer.render_png(
+        _state(level=3, intensity="low"),
+        context=CONTEXT,
+    )
+    normal = renderer.render_png(
+        _state(level=3, intensity="normal"),
+        context=CONTEXT,
+    )
+    high = renderer.render_png(
+        _state(level=3, intensity="high"),
+        context=CONTEXT,
+    )
+
+    assert len({_digest(low), _digest(normal), _digest(high)}) == 3
+
+
+def test_fire_season_and_daypart_change_the_visual():
+    renderer = RefugeFireRenderer()
+    state = _state(level=4, intensity="high")
+
+    summer_day = renderer.render_png(
+        state,
+        context=RefugeRenderContext(season="summer", daypart="day"),
+    )
+    winter_night = renderer.render_png(
+        state,
+        context=RefugeRenderContext(season="winter", daypart="night"),
+    )
+
+    assert summer_day != winter_night
+
+
+@pytest.mark.parametrize(
+    "secret_id",
+    ["night_of_stars", "first_visitor", "full_circle"],
+)
+def test_each_fire_secret_adds_a_permanent_visual_trace(secret_id):
+    renderer = RefugeFireRenderer()
+    base = renderer.render_png(
+        _state(level=3),
+        context=CONTEXT,
+    )
+    discovered = renderer.render_png(
+        _state(level=3, secrets=(secret_id,)),
+        context=CONTEXT,
+    )
+
+    assert discovered != base
+
+
+def test_fire_renderer_is_byte_deterministic():
+    renderer = RefugeFireRenderer()
+    state = _state(
+        level=5,
+        intensity="high",
+        secrets=("night_of_stars", "first_visitor", "full_circle"),
+    )
+
+    first = renderer.render_png(state, context=CONTEXT)
+    second = renderer.render_png(state, context=CONTEXT)
+
+    assert first == second
+
+
+def test_fire_scene_signature_tracks_level_intensity_and_secrets():
+    base = fire_scene_signature(
+        _state(level=2, intensity="normal"),
+        CONTEXT,
+    )
+    level = fire_scene_signature(
+        _state(level=3, intensity="normal"),
+        CONTEXT,
+    )
+    intensity = fire_scene_signature(
+        _state(level=2, intensity="high"),
+        CONTEXT,
+    )
+    secret = fire_scene_signature(
+        _state(level=2, intensity="normal", secrets=("full_circle",)),
+        CONTEXT,
+    )
+
+    assert len({base, level, intensity, secret}) == 4
+
+
+@pytest.mark.asyncio
+async def test_fire_async_renderer_matches_sync_renderer():
+    renderer = RefugeFireRenderer()
+    state = _state(level=3, intensity="normal")
+
+    expected = renderer.render_png(state, context=CONTEXT)
+    actual = await renderer.render_png_async(state, context=CONTEXT)
+
+    assert actual == expected


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-005 — Feu de camp complet** : relier le temps vocal communautaire de REFUGE-002 au moteur REFUGE-003 et ajouter la première couche bâtiment au renderer REFUGE-004.

## Progression permanente
Le Feu possède exactement 5 niveaux validés :
1. **L’Étincelle**
2. **Le Campement**
3. **Le Grand Foyer**
4. **La Place du Refuge**
5. **Le Cœur du Refuge**

La progression utilise le cumul `community_voice_seconds` et reste strictement monotone grâce au moteur REFUGE-003 : un niveau atteint ne redescend jamais.

### Aucun seuil arbitraire
Aucun seuil de production II→V n’est codé en dur.
- `REFUGE_FIRE_LEVEL_THRESHOLDS_SECONDS` accepte exactement 4 seuils croissants lorsqu’ils seront calibrés ;
- sans configuration, le Feu reste volontairement au niveau I `L’Étincelle` ;
- les valeurs présentes dans les tests sont uniquement des fixtures.

## Intensité récente — 24 h
Le rendu du Feu possède trois intensités visuelles : `low`, `normal`, `high`.

Pour rendre réellement possible une fenêtre des **24 dernières heures**, `refuge_activity.json` passe du schéma 1 au schéma 2 :
- conservation intégrale de `tracking_started_at`, du cumul historique et des cumuls mensuels ;
- migration automatique v1 → v2 ;
- ajout de `recent_voice_buckets` par minute UTC ;
- rétention bornée à 48 h pour empêcher une croissance infinie du fichier ;
- les salles vocales qualifiées simultanées continuent à s’additionner indépendamment.

La donnée 24 h ne peut pas être reconstruite rétroactivement depuis le schéma v1. Elle commence donc **prospectivement après déploiement de REFUGE-005**, sans inventer d’activité passée.

`REFUGE_FIRE_INTENSITY_THRESHOLDS_SECONDS` permettra de calibrer les deux seuils `low→normal` et `normal→high`. Tant qu’ils ne sont pas définis :
- 0 seconde récente → `low` ;
- activité communautaire récente > 0 → `normal` ;
- `high` n’est jamais attribué arbitrairement.

Seule la catégorie d’intensité est persistée dans le `RefugeBuildingState`, pas le compteur brut 24 h, afin d’éviter de provoquer une régénération d’image à chaque minute.

## Rendu du Feu
Nouveau `RefugeFireRenderer` en composition avec le terrain REFUGE-004 :
- 1280×720 conservé ;
- niveau I : petit foyer ;
- niveau II : campement, tente et bancs ;
- niveau III : grand foyer, assises supplémentaires et lanternes ;
- niveau IV : place structurée, pavage et bannières ;
- niveau V : foyer monumental / cœur du Refuge ;
- taille de flamme et halo dépendants de `low / normal / high` ;
- variantes hiver et lumière jour/coucher/nuit ;
- rendu déterministe et wrapper async hors event loop ;
- `fire_scene_signature()` versionne explicitement la couche graphique Fire.

## Événements secrets du Feu
Les trois secrets validés sont supportés et possèdent une trace visuelle permanente :
- `La Nuit des Étoiles` ;
- `Le Premier Visiteur` ;
- `Le Cercle complet`.

`RefugeFireService.unlock_secret()` assure une persistance idempotente dans l’historique et dans l’état visuel du Feu.

**Les conditions cachées qui déclencheront automatiquement ces secrets ne sont volontairement pas définies ici** : conformément à la roadmap, leur moteur de détection reste dans **REFUGE-012 — événements secrets**. REFUGE-005 fournit seulement les identifiants, la persistance et leurs conséquences visuelles.

## Fichiers
- `services/refuge_fire.py` — nouveau ;
- `rendering/refuge_fire.py` — nouveau ;
- `rendering/__init__.py` — export du renderer Fire ;
- `storage/refuge_activity_store.py` — migration v2 + fenêtre récente ;
- `tests/test_refuge_fire.py` — nouveau ;
- `tests/test_refuge_fire_renderer.py` — nouveau.

## Hors périmètre
Aucune modification de :
- calcul XP vocal ;
- règle des 2 humains de REFUGE-002 ;
- salon AFK ;
- checkpoints Discord ;
- Hall ;
- Casino ;
- Chantier ;
- Components V2 ;
- panneau public ;
- commandes Discord ;
- probabilités ou économie casino ;
- seuils réels de progression.

## Validation effectuée
- compilation syntaxique des nouveaux modules ;
- validation isolée de la migration activité v1→v2 ;
- validation du cumul récent ;
- validation du passage I→V avec seuils de test et de la non-régression ;
- validation de l’unlock secret idempotent ;
- validation graphique locale : 5 niveaux = 5 rendus distincts ;
- `low / normal / high` produisent trois rendus distincts au même niveau ;
- PNG 1280×720 déterministe dans le même environnement.

La suite pytest complète du dépôt n’a pas été exécutée dans le runtime ChatGPT. La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.