### PR TITLE
feat: add the living Refuge Hall

### DIFF
--- a/rendering/__init__.py
+++ b/rendering/__init__.py
@@ -6,6 +6,12 @@ from .refuge_fire import (
     fire_scene_signature,
     refuge_fire_renderer,
 )
+from .refuge_hall import (
+    REFUGE_HALL_RENDERER_VERSION,
+    RefugeHallRenderer,
+    hall_scene_signature,
+    refuge_hall_renderer,
+)
 from .refuge_world import (
     REFUGE_CANVAS_SIZE,
     RefugeRenderContext,
@@ -19,12 +25,16 @@ from .refuge_world import (
 __all__ = [
     "REFUGE_CANVAS_SIZE",
     "REFUGE_FIRE_RENDERER_VERSION",
+    "REFUGE_HALL_RENDERER_VERSION",
     "RefugeFireRenderer",
+    "RefugeHallRenderer",
     "RefugeRenderContext",
     "RefugeWorldRenderer",
     "daypart_for_hour",
     "fire_scene_signature",
+    "hall_scene_signature",
     "refuge_fire_renderer",
+    "refuge_hall_renderer",
     "refuge_world_renderer",
     "scene_render_signature",
     "season_for_month",

--- a/rendering/refuge_hall.py
+++ b/rendering/refuge_hall.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import json
+from typing import Final, Mapping
+
+from PIL import Image, ImageDraw
+
+from models.refuge_world import RefugeBuildingState, RefugeWorldState
+from rendering.refuge_fire import (
+    RefugeFireRenderer,
+    fire_scene_signature,
+    refuge_fire_renderer,
+)
+from rendering.refuge_world import REFUGE_CANVAS_SIZE, RefugeRenderContext
+from services.refuge_hall import (
+    HALL_BUILDING_ID,
+    HALL_MAX_LEVEL,
+    HALL_SECRET_EVENTS,
+)
+
+
+REFUGE_HALL_RENDERER_VERSION: Final[int] = 1
+HALL_SITE_CENTER: Final[tuple[int, int]] = (414, 512)
+
+
+def _shade(
+    color: tuple[int, int, int],
+    factor: float,
+) -> tuple[int, int, int]:
+    return tuple(
+        max(0, min(255, int(round(channel * factor))))
+        for channel in color
+    )
+
+
+def _mix(
+    left: tuple[int, int, int],
+    right: tuple[int, int, int],
+    ratio: float,
+) -> tuple[int, int, int]:
+    clamped = max(0.0, min(1.0, ratio))
+    return tuple(
+        int(round(a + (b - a) * clamped))
+        for a, b in zip(left, right)
+    )
+
+
+def _hall_building(state: RefugeWorldState) -> RefugeBuildingState | None:
+    return next(
+        (
+            building
+            for building in state.buildings
+            if building.building_id == HALL_BUILDING_ID
+        ),
+        None,
+    )
+
+
+def _state_list(
+    building: RefugeBuildingState,
+    key: str,
+) -> tuple[Mapping[str, object], ...]:
+    raw = building.state.get(key, ())
+    if not isinstance(raw, (list, tuple)):
+        return ()
+    return tuple(item for item in raw if isinstance(item, Mapping))
+
+
+def _secret_ids(building: RefugeBuildingState) -> frozenset[str]:
+    raw = building.state.get("secret_events", ())
+    if not isinstance(raw, (list, tuple, set, frozenset)):
+        return frozenset()
+    return frozenset(
+        str(value)
+        for value in raw
+        if str(value) in HALL_SECRET_EVENTS
+    )
+
+
+def hall_scene_signature(
+    state: RefugeWorldState,
+    context: RefugeRenderContext,
+) -> str:
+    payload = {
+        "base": fire_scene_signature(state, context),
+        "hall_renderer_version": REFUGE_HALL_RENDERER_VERSION,
+    }
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _palette(
+    context: RefugeRenderContext,
+) -> dict[str, tuple[int, int, int]]:
+    stone = {
+        "winter": (137, 141, 139),
+        "spring": (139, 132, 112),
+        "summer": (134, 126, 106),
+        "autumn": (139, 116, 87),
+    }[context.season]
+    timber = {
+        "winter": (91, 78, 64),
+        "spring": (106, 79, 55),
+        "summer": (101, 72, 48),
+        "autumn": (104, 68, 43),
+    }[context.season]
+    roof = {
+        "winter": (79, 83, 84),
+        "spring": (82, 72, 59),
+        "summer": (78, 65, 52),
+        "autumn": (92, 62, 46),
+    }[context.season]
+    if context.daypart == "night":
+        stone = _shade(stone, 0.70)
+        timber = _shade(timber, 0.65)
+        roof = _shade(roof, 0.62)
+    elif context.daypart == "sunset":
+        stone = _mix(stone, (151, 98, 70), 0.14)
+        timber = _mix(timber, (139, 77, 49), 0.12)
+
+    return {
+        "stone": stone,
+        "stone_dark": _shade(stone, 0.72),
+        "stone_light": _mix(stone, (205, 196, 170), 0.22),
+        "timber": timber,
+        "timber_dark": _shade(timber, 0.70),
+        "roof": roof,
+        "roof_dark": _shade(roof, 0.72),
+        "window": (
+            (236, 184, 89)
+            if context.daypart in {"night", "sunset"}
+            else (154, 177, 165)
+        ),
+        "gold": (
+            (220, 175, 76)
+            if context.daypart != "night"
+            else (187, 145, 65)
+        ),
+        "banner": (
+            (110, 55, 52)
+            if context.season != "winter"
+            else (74, 83, 91)
+        ),
+        "ink": (52, 45, 40),
+    }
+
+
+def _draw_shadow(
+    draw: ImageDraw.ImageDraw,
+    *,
+    x: int,
+    y: int,
+    width: int,
+) -> None:
+    draw.ellipse(
+        (x - width, y - 13, x + width, y + 19),
+        fill=(39, 49, 40),
+    )
+
+
+def _draw_cabin(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    palette: Mapping[str, tuple[int, int, int]],
+    winter: bool,
+) -> None:
+    x, y = center
+    _draw_shadow(draw, x=x, y=y + 8, width=52)
+    draw.rectangle((x - 43, y - 52, x + 43, y + 10), fill=palette["timber"])
+    draw.polygon(
+        ((x - 54, y - 49), (x, y - 91), (x + 54, y - 49)),
+        fill=palette["roof"],
+    )
+    draw.rectangle((x - 12, y - 21, x + 12, y + 10), fill=palette["timber_dark"])
+    draw.rectangle((x - 32, y - 31, x - 17, y - 14), fill=palette["window"])
+    draw.rectangle((x + 17, y - 31, x + 32, y - 14), fill=palette["window"])
+    draw.rectangle((x - 17, y - 3, x + 17, y + 5), fill=palette["stone_light"])
+    if winter:
+        draw.line((x - 45, y - 52, x, y - 88, x + 45, y - 52), fill=(219, 225, 221), width=4)
+
+
+def _draw_level_two(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    palette: Mapping[str, tuple[int, int, int]],
+    winter: bool,
+) -> None:
+    x, y = center
+    _draw_shadow(draw, x=x, y=y + 10, width=67)
+    draw.rectangle((x - 62, y - 63, x + 62, y + 11), fill=palette["stone"])
+    draw.rectangle((x - 54, y - 55, x + 54, y + 11), fill=palette["timber"])
+    draw.polygon(
+        ((x - 73, y - 60), (x, y - 104), (x + 73, y - 60)),
+        fill=palette["roof"],
+    )
+    draw.rectangle((x - 14, y - 26, x + 14, y + 11), fill=palette["timber_dark"])
+    for px in (x - 38, x + 38):
+        draw.rectangle((px - 9, y - 37, px + 9, y - 15), fill=palette["window"])
+    gold = palette["gold"]
+    draw.rectangle((x - 3, y - 79, x + 3, y - 67), fill=gold)
+    draw.arc((x - 17, y - 92, x + 17, y - 68), 0, 180, fill=gold, width=4)
+    draw.line((x - 14, y - 88, x - 24, y - 82), fill=gold, width=3)
+    draw.line((x + 14, y - 88, x + 24, y - 82), fill=gold, width=3)
+    if winter:
+        draw.line((x - 63, y - 62, x, y - 101, x + 63, y - 62), fill=(219, 225, 221), width=4)
+
+
+def _draw_level_three(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    palette: Mapping[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    _draw_shadow(draw, x=x, y=y + 12, width=79)
+    draw.rectangle((x - 76, y - 66, x + 76, y + 12), fill=palette["stone"])
+    draw.rectangle((x - 50, y - 82, x + 50, y + 12), fill=palette["stone_light"])
+    draw.polygon(
+        ((x - 58, y - 82), (x, y - 116), (x + 58, y - 82)),
+        fill=palette["roof"],
+    )
+    for px in (x - 58, x - 34, x + 34, x + 58):
+        draw.rectangle((px - 5, y - 58, px + 5, y + 7), fill=palette["stone_dark"])
+        draw.rectangle((px - 8, y - 62, px + 8, y - 57), fill=palette["stone_light"])
+    draw.rectangle((x - 16, y - 30, x + 16, y + 12), fill=palette["timber_dark"])
+    draw.rectangle((x - 25, y - 72, x + 25, y - 54), fill=palette["banner"])
+
+
+def _draw_level_four(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    palette: Mapping[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    _draw_shadow(draw, x=x, y=y + 13, width=92)
+    draw.rectangle((x - 88, y - 72, x + 88, y + 13), fill=palette["stone"])
+    draw.rectangle((x - 61, y - 99, x + 61, y + 13), fill=palette["stone_light"])
+    draw.polygon(
+        ((x - 73, y - 96), (x, y - 136), (x + 73, y - 96)),
+        fill=palette["roof"],
+    )
+    for px in (x - 72, x - 45, x - 22, x + 22, x + 45, x + 72):
+        draw.rectangle((px - 5, y - 67, px + 5, y + 8), fill=palette["stone_dark"])
+    draw.rectangle((x - 18, y - 34, x + 18, y + 13), fill=palette["timber_dark"])
+    draw.ellipse((x - 22, y - 126, x + 22, y - 84), fill=palette["stone_light"])
+    draw.arc((x - 22, y - 126, x + 22, y - 84), 180, 360, fill=palette["gold"], width=4)
+
+
+def _draw_level_five(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    palette: Mapping[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    _draw_shadow(draw, x=x, y=y + 14, width=108)
+    draw.rectangle((x - 103, y - 75, x + 103, y + 14), fill=palette["stone"])
+    draw.rectangle((x - 68, y - 111, x + 68, y + 14), fill=palette["stone_light"])
+    draw.rectangle((x - 34, y - 139, x + 34, y + 14), fill=palette["stone"])
+    draw.polygon(
+        ((x - 48, y - 136), (x, y - 168), (x + 48, y - 136)),
+        fill=palette["roof"],
+    )
+    for px in (x - 86, x - 58, x + 58, x + 86):
+        draw.rectangle((px - 9, y - 52, px + 9, y - 24), fill=palette["window"])
+    for px in (x - 51, x - 25, x + 25, x + 51):
+        draw.rectangle((px - 5, y - 82, px + 5, y + 8), fill=palette["stone_dark"])
+    draw.rectangle((x - 18, y - 39, x + 18, y + 14), fill=palette["timber_dark"])
+    draw.ellipse((x - 25, y - 158, x + 25, y - 113), fill=palette["stone_light"])
+    draw.arc((x - 25, y - 158, x + 25, y - 113), 180, 360, fill=palette["gold"], width=5)
+
+
+def _draw_history_details(
+    draw: ImageDraw.ImageDraw,
+    *,
+    building: RefugeBuildingState,
+    palette: Mapping[str, tuple[int, int, int]],
+) -> None:
+    x, y = HALL_SITE_CENTER
+    plaques = _state_list(building, "season_plaques")
+    firsts = _state_list(building, "historical_firsts")
+    gallery = _state_list(building, "gallery_markers")
+    showcase = building.state.get("rare_showcase")
+
+    for index, _item in enumerate(plaques[-5:]):
+        px = x - 42 + index * 21
+        draw.rectangle((px - 7, y + 20, px + 7, y + 30), fill=palette["stone_light"])
+        draw.line((px - 4, y + 25, px + 4, y + 25), fill=palette["ink"], width=1)
+
+    for index, _item in enumerate(firsts[:3]):
+        px = x - 22 + index * 22
+        draw.arc((px - 8, y - 151, px + 8, y - 133), 80, 280, fill=palette["gold"], width=2)
+
+    for index, _item in enumerate(gallery[-4:]):
+        px = x - 71 + index * 47
+        draw.polygon(
+            ((px - 8, y - 6), (px + 8, y - 6), (px + 6, y + 13), (px, y + 19), (px - 6, y + 13)),
+            fill=palette["banner"],
+        )
+
+    if isinstance(showcase, Mapping):
+        sx, sy = x + 92, y + 4
+        draw.ellipse((sx - 22, sy - 8, sx + 22, sy + 11), fill=_mix(palette["stone"], palette["gold"], 0.28))
+        draw.rectangle((sx - 9, sy - 30, sx + 9, sy + 1), fill=palette["stone_light"])
+        star = palette["gold"]
+        draw.polygon(
+            (
+                (sx, sy - 39),
+                (sx + 4, sy - 31),
+                (sx + 13, sy - 30),
+                (sx + 6, sy - 24),
+                (sx + 8, sy - 15),
+                (sx, sy - 20),
+                (sx - 8, sy - 15),
+                (sx - 6, sy - 24),
+                (sx - 13, sy - 30),
+                (sx - 4, sy - 31),
+            ),
+            fill=star,
+        )
+
+
+def _draw_secret_details(
+    draw: ImageDraw.ImageDraw,
+    *,
+    building: RefugeBuildingState,
+    palette: Mapping[str, tuple[int, int, int]],
+) -> None:
+    secrets = _secret_ids(building)
+    x, y = HALL_SITE_CENTER
+
+    if "memory_flame" in secrets:
+        fx, fy = x - 103, y + 6
+        draw.rectangle((fx - 4, fy - 24, fx + 4, fy + 4), fill=palette["stone_dark"])
+        draw.polygon(
+            ((fx, fy - 40), (fx - 9, fy - 23), (fx, fy - 28), (fx + 9, fy - 23)),
+            fill=(235, 131, 49),
+        )
+
+    if "endless_book" in secrets:
+        bx, by = x + 111, y + 18
+        draw.polygon(
+            ((bx - 21, by - 12), (bx - 2, by - 17), (bx, by + 3), (bx - 20, by + 7)),
+            fill=(115, 76, 48),
+        )
+        draw.polygon(
+            ((bx + 21, by - 12), (bx + 2, by - 17), (bx, by + 3), (bx + 20, by + 7)),
+            fill=(132, 88, 52),
+        )
+        draw.line((bx, by - 17, bx, by + 3), fill=palette["gold"], width=2)
+
+    if "forgotten_crown" in secrets:
+        cy = y - 178
+        draw.polygon(
+            (
+                (x - 18, cy + 12),
+                (x - 15, cy - 5),
+                (x - 6, cy + 4),
+                (x, cy - 9),
+                (x + 6, cy + 4),
+                (x + 15, cy - 5),
+                (x + 18, cy + 12),
+            ),
+            fill=palette["gold"],
+        )
+        draw.rectangle((x - 18, cy + 11, x + 18, cy + 17), fill=palette["gold"])
+
+
+def draw_refuge_hall(
+    draw: ImageDraw.ImageDraw,
+    state: RefugeWorldState,
+    *,
+    context: RefugeRenderContext,
+) -> None:
+    building = _hall_building(state)
+    if building is None or int(building.level) <= 0:
+        return
+
+    level = max(1, min(HALL_MAX_LEVEL, int(building.level)))
+    palette = _palette(context)
+    winter = context.season == "winter"
+
+    if level == 1:
+        _draw_cabin(draw, center=HALL_SITE_CENTER, palette=palette, winter=winter)
+    elif level == 2:
+        _draw_level_two(draw, center=HALL_SITE_CENTER, palette=palette, winter=winter)
+    elif level == 3:
+        _draw_level_three(draw, center=HALL_SITE_CENTER, palette=palette)
+    elif level == 4:
+        _draw_level_four(draw, center=HALL_SITE_CENTER, palette=palette)
+    else:
+        _draw_level_five(draw, center=HALL_SITE_CENTER, palette=palette)
+
+    _draw_history_details(draw, building=building, palette=palette)
+    _draw_secret_details(draw, building=building, palette=palette)
+
+
+class RefugeHallRenderer:
+    """Compose the terrain, Fire and Hall layers deterministically."""
+
+    def __init__(
+        self,
+        base_renderer: RefugeFireRenderer = refuge_fire_renderer,
+    ) -> None:
+        self.base_renderer = base_renderer
+
+    def render_png(
+        self,
+        state: RefugeWorldState,
+        *,
+        context: RefugeRenderContext | None = None,
+    ) -> bytes:
+        render_context = context or RefugeRenderContext.from_datetime()
+        base_png = self.base_renderer.render_png(state, context=render_context)
+        image = Image.open(io.BytesIO(base_png)).convert("RGB")
+        draw = ImageDraw.Draw(image)
+        draw_refuge_hall(draw, state, context=render_context)
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG", optimize=False, compress_level=9)
+        return buffer.getvalue()
+
+    async def render_png_async(
+        self,
+        state: RefugeWorldState,
+        *,
+        context: RefugeRenderContext | None = None,
+    ) -> bytes:
+        return await asyncio.to_thread(self.render_png, state, context=context)
+
+
+refuge_hall_renderer = RefugeHallRenderer()
+
+
+__all__ = [
+    "HALL_SITE_CENTER",
+    "REFUGE_HALL_RENDERER_VERSION",
+    "RefugeHallRenderer",
+    "draw_refuge_hall",
+    "hall_scene_signature",
+    "refuge_hall_renderer",
+]

--- a/services/refuge_hall.py
+++ b/services/refuge_hall.py
@@ -1,0 +1,836 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, Final, Mapping, Sequence
+
+from models.refuge_world import (
+    RefugeBuildingState,
+    RefugeHistoricalEvent,
+    RefugeWorldState,
+)
+from services.refuge_world import (
+    BuildingProgressionRule,
+    RefugeWorldService,
+    refuge_world_service,
+    world_render_signature,
+)
+from storage.achievement_store import AchievementStore, achievement_store
+from utils.achievements import ACHIEVEMENT_BY_ID
+from utils.seasons import season_id_for
+
+
+HALL_BUILDING_ID: Final[str] = "hall"
+HALL_METRIC_KEY: Final[str] = "hall_progression_points"
+HALL_MAX_LEVEL: Final[int] = 5
+HALL_RECENT_SHOWCASE_SECONDS: Final[int] = 24 * 60 * 60
+
+HALL_LEVEL_NAMES: Final[Mapping[int, str]] = {
+    1: "Cabane des Souvenirs",
+    2: "Salle des Trophées",
+    3: "Hall des Légendes",
+    4: "Panthéon du Refuge",
+    5: "Archives Éternelles",
+}
+
+HALL_SECRET_EVENTS: Final[Mapping[str, str]] = {
+    "memory_flame": "Flamme du Souvenir",
+    "endless_book": "Livre sans fin",
+    "forgotten_crown": "Couronne oubliée",
+}
+
+
+def _aware_utc(at: datetime | None = None) -> datetime:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
+
+
+def _utc_iso(at: datetime | None = None) -> str:
+    return _aware_utc(at).isoformat()
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _parse_int_tuple_env(name: str) -> tuple[int, ...]:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return ()
+    values: list[int] = []
+    for item in raw.split(","):
+        token = item.strip()
+        if not token:
+            raise ValueError(f"{name} contains an empty value")
+        try:
+            values.append(int(token))
+        except ValueError as exc:
+            raise ValueError(f"{name} must contain integers") from exc
+    return tuple(values)
+
+
+def _parse_str_tuple_env(name: str) -> tuple[str, ...]:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return ()
+    return tuple(dict.fromkeys(item.strip() for item in raw.split(",") if item.strip()))
+
+
+def _env_non_negative_int(name: str, default: int = 0) -> int:
+    raw = os.getenv(name, str(default)).strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if value < 0:
+        raise ValueError(f"{name} must be >= 0")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class HallUnlockEvent:
+    user_id: int
+    achievement_id: str
+    unlocked_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class HallHistoricalFirst:
+    achievement_id: str
+    user_id: int
+    unlocked_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class HallRareShowcase:
+    achievement_id: str
+    user_id: int
+    unlocked_at: str
+    expires_at: str
+    unlock_count: int
+    achiever_count: int
+    prevalence_per_10000: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "achievement_id": self.achievement_id,
+            "user_id": self.user_id,
+            "unlocked_at": self.unlocked_at,
+            "expires_at": self.expires_at,
+            "unlock_count": self.unlock_count,
+            "achiever_count": self.achiever_count,
+            "prevalence_per_10000": self.prevalence_per_10000,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HallSignalSnapshot:
+    total_unlocks: int
+    unique_achievers: int
+    unique_achievement_ids: int
+    category_diversity: int
+    historical_first_count: int
+    rarity_units: int
+    achievement_counts: tuple[tuple[str, int], ...]
+    historical_firsts: tuple[HallHistoricalFirst, ...]
+    rare_showcase: HallRareShowcase | None
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeHallConfig:
+    """Configurable Hall progression. Defaults intentionally keep level I."""
+
+    level_thresholds_points: tuple[int, ...] = ()
+    unlock_weight: int = 0
+    achiever_weight: int = 0
+    diversity_weight: int = 0
+    historical_first_weight: int = 0
+    rarity_weight: int = 0
+    historical_first_achievement_ids: tuple[str, ...] = ()
+    gallery_unlock_milestones: tuple[int, ...] = ()
+    gallery_achiever_milestones: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.level_thresholds_points and len(self.level_thresholds_points) != 4:
+            raise ValueError(
+                "hall level thresholds must contain exactly 4 values "
+                "to define levels II to V"
+            )
+        self._validate_increasing(
+            self.level_thresholds_points,
+            name="hall level thresholds",
+            positive=True,
+        )
+        self._validate_increasing(
+            self.gallery_unlock_milestones,
+            name="hall gallery unlock milestones",
+            positive=True,
+        )
+        self._validate_increasing(
+            self.gallery_achiever_milestones,
+            name="hall gallery achiever milestones",
+            positive=True,
+        )
+        for name, value in (
+            ("unlock_weight", self.unlock_weight),
+            ("achiever_weight", self.achiever_weight),
+            ("diversity_weight", self.diversity_weight),
+            ("historical_first_weight", self.historical_first_weight),
+            ("rarity_weight", self.rarity_weight),
+        ):
+            if int(value) < 0:
+                raise ValueError(f"{name} must be >= 0")
+        unknown = [
+            achievement_id
+            for achievement_id in self.historical_first_achievement_ids
+            if achievement_id not in ACHIEVEMENT_BY_ID
+        ]
+        if unknown:
+            raise ValueError(
+                "unknown historical-first achievement ids: " + ", ".join(unknown)
+            )
+
+    @staticmethod
+    def _validate_increasing(
+        values: Sequence[int],
+        *,
+        name: str,
+        positive: bool,
+    ) -> None:
+        previous: int | None = None
+        for raw in values:
+            value = int(raw)
+            if positive and value <= 0:
+                raise ValueError(f"{name} must be > 0")
+            if not positive and value < 0:
+                raise ValueError(f"{name} must be >= 0")
+            if previous is not None and value <= previous:
+                raise ValueError(f"{name} must be strictly increasing")
+            previous = value
+
+    @classmethod
+    def from_env(cls) -> "RefugeHallConfig":
+        return cls(
+            level_thresholds_points=_parse_int_tuple_env(
+                "REFUGE_HALL_LEVEL_THRESHOLDS_POINTS"
+            ),
+            unlock_weight=_env_non_negative_int("REFUGE_HALL_UNLOCK_WEIGHT"),
+            achiever_weight=_env_non_negative_int("REFUGE_HALL_ACHIEVER_WEIGHT"),
+            diversity_weight=_env_non_negative_int("REFUGE_HALL_DIVERSITY_WEIGHT"),
+            historical_first_weight=_env_non_negative_int(
+                "REFUGE_HALL_HISTORICAL_FIRST_WEIGHT"
+            ),
+            rarity_weight=_env_non_negative_int("REFUGE_HALL_RARITY_WEIGHT"),
+            historical_first_achievement_ids=_parse_str_tuple_env(
+                "REFUGE_HALL_HISTORICAL_FIRST_IDS"
+            ),
+            gallery_unlock_milestones=_parse_int_tuple_env(
+                "REFUGE_HALL_GALLERY_UNLOCK_MILESTONES"
+            ),
+            gallery_achiever_milestones=_parse_int_tuple_env(
+                "REFUGE_HALL_GALLERY_ACHIEVER_MILESTONES"
+            ),
+        )
+
+    def progression_points(self, signals: HallSignalSnapshot) -> int:
+        return (
+            signals.total_unlocks * int(self.unlock_weight)
+            + signals.unique_achievers * int(self.achiever_weight)
+            + signals.category_diversity * int(self.diversity_weight)
+            + signals.historical_first_count * int(self.historical_first_weight)
+            + signals.rarity_units * int(self.rarity_weight)
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeHallStatus:
+    state: RefugeWorldState
+    level: int
+    level_name: str
+    progression_points: int
+    signals: HallSignalSnapshot
+    changed: bool
+    render_signature: str
+
+
+def hall_level_name(level: int) -> str:
+    normalized = max(1, min(HALL_MAX_LEVEL, int(level)))
+    return HALL_LEVEL_NAMES[normalized]
+
+
+def _hall_building(state: RefugeWorldState) -> RefugeBuildingState | None:
+    return next(
+        (
+            building
+            for building in state.buildings
+            if building.building_id == HALL_BUILDING_ID
+        ),
+        None,
+    )
+
+
+def _replace_building(
+    state: RefugeWorldState,
+    building: RefugeBuildingState,
+) -> RefugeWorldState:
+    buildings = {current.building_id: current for current in state.buildings}
+    buildings[building.building_id] = building
+    return replace(
+        state,
+        buildings=tuple(
+            sorted(buildings.values(), key=lambda item: item.building_id)
+        ),
+    )
+
+
+def _achievement_events(snapshot: Mapping[str, Any]) -> tuple[HallUnlockEvent, ...]:
+    users = snapshot.get("users", {})
+    if not isinstance(users, Mapping):
+        return ()
+    events: list[HallUnlockEvent] = []
+    for raw_user_id, raw_achievements in users.items():
+        if not isinstance(raw_achievements, Mapping):
+            continue
+        try:
+            user_id = int(raw_user_id)
+        except (TypeError, ValueError):
+            continue
+        for raw_achievement_id, raw_unlocked_at in raw_achievements.items():
+            achievement_id = str(raw_achievement_id)
+            unlocked_at = _parse_timestamp(raw_unlocked_at)
+            if unlocked_at is None:
+                continue
+            events.append(
+                HallUnlockEvent(
+                    user_id=user_id,
+                    achievement_id=achievement_id,
+                    unlocked_at=unlocked_at,
+                )
+            )
+    events.sort(
+        key=lambda event: (
+            event.unlocked_at,
+            event.achievement_id,
+            event.user_id,
+        )
+    )
+    return tuple(events)
+
+
+def _build_signals(
+    events: Sequence[HallUnlockEvent],
+    *,
+    config: RefugeHallConfig,
+    at: datetime,
+) -> HallSignalSnapshot:
+    counts: dict[str, int] = {}
+    users: set[int] = set()
+    categories: set[str] = set()
+    by_achievement: dict[str, list[HallUnlockEvent]] = {}
+
+    for event in events:
+        users.add(event.user_id)
+        counts[event.achievement_id] = counts.get(event.achievement_id, 0) + 1
+        by_achievement.setdefault(event.achievement_id, []).append(event)
+        definition = ACHIEVEMENT_BY_ID.get(event.achievement_id)
+        if definition is not None:
+            categories.add(definition.category)
+
+    historical_firsts: list[HallHistoricalFirst] = []
+    for achievement_id in config.historical_first_achievement_ids:
+        candidates = by_achievement.get(achievement_id, ())
+        if not candidates:
+            continue
+        first = min(
+            candidates,
+            key=lambda event: (event.unlocked_at, event.user_id),
+        )
+        historical_firsts.append(
+            HallHistoricalFirst(
+                achievement_id=achievement_id,
+                user_id=first.user_id,
+                unlocked_at=first.unlocked_at.isoformat(),
+            )
+        )
+
+    achiever_count = len(users)
+    rarity_units = sum(
+        max(0, achiever_count - unlock_count)
+        for unlock_count in counts.values()
+    )
+
+    window_start = at - timedelta(seconds=HALL_RECENT_SHOWCASE_SECONDS)
+    recent = [
+        event
+        for event in events
+        if window_start <= event.unlocked_at <= at
+    ]
+    showcase: HallRareShowcase | None = None
+    if recent and achiever_count > 0:
+        recent.sort(
+            key=lambda event: (
+                counts.get(event.achievement_id, 0),
+                -event.unlocked_at.timestamp(),
+                event.achievement_id,
+                event.user_id,
+            )
+        )
+        selected = recent[0]
+        unlock_count = counts.get(selected.achievement_id, 0)
+        prevalence = int(round((unlock_count / achiever_count) * 10000))
+        showcase = HallRareShowcase(
+            achievement_id=selected.achievement_id,
+            user_id=selected.user_id,
+            unlocked_at=selected.unlocked_at.isoformat(),
+            expires_at=(
+                selected.unlocked_at
+                + timedelta(seconds=HALL_RECENT_SHOWCASE_SECONDS)
+            ).isoformat(),
+            unlock_count=unlock_count,
+            achiever_count=achiever_count,
+            prevalence_per_10000=prevalence,
+        )
+
+    return HallSignalSnapshot(
+        total_unlocks=len(events),
+        unique_achievers=achiever_count,
+        unique_achievement_ids=len(counts),
+        category_diversity=len(categories),
+        historical_first_count=len(historical_firsts),
+        rarity_units=rarity_units,
+        achievement_counts=tuple(sorted(counts.items())),
+        historical_firsts=tuple(historical_firsts),
+        rare_showcase=showcase,
+    )
+
+
+def _season_plaques(
+    events: Sequence[HallUnlockEvent],
+    *,
+    world_created_at: str | None,
+) -> list[dict[str, Any]]:
+    created = _parse_timestamp(world_created_at)
+    by_season: dict[str, dict[str, Any]] = {}
+    for event in events:
+        if created is not None and event.unlocked_at < created:
+            continue
+        season_id = season_id_for(event.unlocked_at)
+        payload = by_season.setdefault(
+            season_id,
+            {"season_id": season_id, "unlock_count": 0, "user_ids": set()},
+        )
+        payload["unlock_count"] += 1
+        payload["user_ids"].add(event.user_id)
+
+    plaques: list[dict[str, Any]] = []
+    for season_id in sorted(by_season):
+        payload = by_season[season_id]
+        plaques.append(
+            {
+                "season_id": season_id,
+                "unlock_count": int(payload["unlock_count"]),
+                "unique_achievers": len(payload["user_ids"]),
+            }
+        )
+    return plaques
+
+
+def _gallery_markers(
+    events: Sequence[HallUnlockEvent],
+    *,
+    world_created_at: str | None,
+    unlock_milestones: Sequence[int],
+    achiever_milestones: Sequence[int],
+    existing: object,
+) -> list[dict[str, Any]]:
+    created = _parse_timestamp(world_created_at)
+    eligible = [
+        event
+        for event in events
+        if created is None or event.unlocked_at >= created
+    ]
+    markers: dict[str, dict[str, Any]] = {}
+    if isinstance(existing, (list, tuple)):
+        for item in existing:
+            if not isinstance(item, Mapping):
+                continue
+            marker_id = str(item.get("marker_id", "")).strip()
+            if marker_id:
+                markers[marker_id] = dict(item)
+
+    if eligible:
+        first = eligible[0]
+        markers.setdefault(
+            "first_refuge_achievement",
+            {
+                "marker_id": "first_refuge_achievement",
+                "kind": "first_achievement",
+                "occurred_at": first.unlocked_at.isoformat(),
+                "achievement_id": first.achievement_id,
+                "user_id": first.user_id,
+            },
+        )
+
+    for milestone in unlock_milestones:
+        index = int(milestone) - 1
+        if index < 0 or index >= len(eligible):
+            continue
+        event = eligible[index]
+        markers.setdefault(
+            f"achievement_unlock:{milestone}",
+            {
+                "marker_id": f"achievement_unlock:{milestone}",
+                "kind": "achievement_unlock_milestone",
+                "occurred_at": event.unlocked_at.isoformat(),
+                "achievement_id": event.achievement_id,
+                "user_id": event.user_id,
+                "unlock_number": int(milestone),
+            },
+        )
+
+    first_by_user: dict[int, HallUnlockEvent] = {}
+    for event in eligible:
+        first_by_user.setdefault(event.user_id, event)
+    first_achievers = sorted(
+        first_by_user.values(),
+        key=lambda event: (event.unlocked_at, event.user_id),
+    )
+    for milestone in achiever_milestones:
+        index = int(milestone) - 1
+        if index < 0 or index >= len(first_achievers):
+            continue
+        event = first_achievers[index]
+        markers.setdefault(
+            f"unique_achiever:{milestone}",
+            {
+                "marker_id": f"unique_achiever:{milestone}",
+                "kind": "unique_achiever_milestone",
+                "occurred_at": event.unlocked_at.isoformat(),
+                "achievement_id": event.achievement_id,
+                "user_id": event.user_id,
+                "achiever_number": int(milestone),
+            },
+        )
+
+    return [markers[key] for key in sorted(markers)]
+
+
+def _merge_historical_firsts(
+    existing: object,
+    discovered: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    if isinstance(existing, (list, tuple)):
+        for item in existing:
+            if not isinstance(item, Mapping):
+                continue
+            achievement_id = str(item.get("achievement_id", "")).strip()
+            if achievement_id:
+                merged[achievement_id] = dict(item)
+    for item in discovered:
+        achievement_id = str(item.get("achievement_id", "")).strip()
+        if achievement_id:
+            merged.setdefault(achievement_id, dict(item))
+    return [merged[key] for key in sorted(merged)]
+
+
+def _merge_season_plaques(
+    existing: object,
+    computed: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    merged: dict[str, dict[str, Any]] = {}
+    if isinstance(existing, (list, tuple)):
+        for item in existing:
+            if not isinstance(item, Mapping):
+                continue
+            season_id = str(item.get("season_id", "")).strip()
+            if season_id:
+                merged[season_id] = dict(item)
+    for item in computed:
+        season_id = str(item.get("season_id", "")).strip()
+        if not season_id:
+            continue
+        previous = merged.get(season_id, {})
+        merged[season_id] = {
+            "season_id": season_id,
+            "unlock_count": max(
+                int(previous.get("unlock_count", 0) or 0),
+                int(item.get("unlock_count", 0) or 0),
+            ),
+            "unique_achievers": max(
+                int(previous.get("unique_achievers", 0) or 0),
+                int(item.get("unique_achievers", 0) or 0),
+            ),
+        }
+    return [merged[key] for key in sorted(merged)]
+
+
+class RefugeHallService:
+    """Project persisted achievement history into the living Hall."""
+
+    def __init__(
+        self,
+        *,
+        achievement_store_: AchievementStore = achievement_store,
+        world_service: RefugeWorldService = refuge_world_service,
+    ) -> None:
+        self.achievement_store = achievement_store_
+        self.world_service = world_service
+        self.world_store = world_service.store
+        self._lock = asyncio.Lock()
+
+    async def evaluate(
+        self,
+        *,
+        config: RefugeHallConfig | None = None,
+        at: datetime | None = None,
+    ) -> RefugeHallStatus:
+        hall_config = config or RefugeHallConfig.from_env()
+        async with self._lock:
+            return await self._evaluate_locked(config=hall_config, at=at)
+
+    async def _evaluate_locked(
+        self,
+        *,
+        config: RefugeHallConfig,
+        at: datetime | None,
+    ) -> RefugeHallStatus:
+        now = _aware_utc(at)
+        snapshot = await self.achievement_store.get_snapshot()
+        events = _achievement_events(snapshot)
+        signals = _build_signals(events, config=config, at=now)
+        progression_points = config.progression_points(signals)
+
+        progression = await self.world_service.evaluate(
+            metrics={HALL_METRIC_KEY: progression_points},
+            rules=(
+                BuildingProgressionRule(
+                    building_id=HALL_BUILDING_ID,
+                    metric_key=HALL_METRIC_KEY,
+                    thresholds=config.level_thresholds_points,
+                    minimum_level=1,
+                    event_from_level=2,
+                ),
+            ),
+            at=now,
+        )
+        state = progression.state
+        building = _hall_building(state)
+        if building is None:
+            raise RuntimeError("Refuge Hall progression did not create a building")
+
+        building_state = dict(building.state)
+        desired_showcase = (
+            signals.rare_showcase.to_dict()
+            if signals.rare_showcase is not None
+            else None
+        )
+        discovered_firsts = [
+            {
+                "achievement_id": first.achievement_id,
+                "user_id": first.user_id,
+                "unlocked_at": first.unlocked_at,
+            }
+            for first in signals.historical_firsts
+        ]
+        desired_firsts = _merge_historical_firsts(
+            building_state.get("historical_firsts"),
+            discovered_firsts,
+        )
+        desired_plaques = _merge_season_plaques(
+            building_state.get("season_plaques"),
+            _season_plaques(
+                events,
+                world_created_at=state.created_at,
+            ),
+        )
+        desired_gallery = _gallery_markers(
+            events,
+            world_created_at=state.created_at,
+            unlock_milestones=config.gallery_unlock_milestones,
+            achiever_milestones=config.gallery_achiever_milestones,
+            existing=building_state.get("gallery_markers"),
+        )
+
+        changed_visual = False
+        for key, desired in (
+            ("rare_showcase", desired_showcase),
+            ("historical_firsts", desired_firsts),
+            ("season_plaques", desired_plaques),
+            ("gallery_markers", desired_gallery),
+        ):
+            if building_state.get(key) != desired:
+                if desired is None:
+                    building_state.pop(key, None)
+                else:
+                    building_state[key] = desired
+                changed_visual = True
+
+        state_changed = progression.changed
+        if changed_visual:
+            building = replace(building, state=building_state)
+            state = _replace_building(state, building)
+            state = await self.world_store.save_state(state)
+            state_changed = True
+
+        return RefugeHallStatus(
+            state=state,
+            level=max(1, min(HALL_MAX_LEVEL, int(building.level))),
+            level_name=hall_level_name(building.level),
+            progression_points=progression_points,
+            signals=signals,
+            changed=state_changed,
+            render_signature=world_render_signature(state),
+        )
+
+    async def record_gallery_marker(
+        self,
+        marker_id: str,
+        *,
+        kind: str,
+        occurred_at: datetime | None = None,
+        data: Mapping[str, Any] | None = None,
+        config: RefugeHallConfig | None = None,
+    ) -> RefugeWorldState:
+        """Persist one Hall-owned community-history marker idempotently."""
+
+        normalized = str(marker_id).strip()
+        marker_kind = str(kind).strip()
+        if not normalized:
+            raise ValueError("marker_id is required")
+        if not marker_kind:
+            raise ValueError("kind is required")
+
+        hall_config = config or RefugeHallConfig.from_env()
+        async with self._lock:
+            status = await self._evaluate_locked(config=hall_config, at=occurred_at)
+            state = status.state
+            building = _hall_building(state)
+            if building is None:
+                raise RuntimeError("Refuge Hall building is missing")
+
+            building_state = dict(building.state)
+            raw_markers = building_state.get("gallery_markers", ())
+            markers = [
+                dict(item)
+                for item in raw_markers
+                if isinstance(item, Mapping)
+            ] if isinstance(raw_markers, (list, tuple)) else []
+            if any(str(item.get("marker_id")) == normalized for item in markers):
+                return state
+
+            marker = {
+                "marker_id": normalized,
+                "kind": marker_kind,
+                "occurred_at": _utc_iso(occurred_at),
+            }
+            if data:
+                marker["data"] = dict(data)
+            markers.append(marker)
+            markers.sort(key=lambda item: str(item.get("marker_id", "")))
+            building_state["gallery_markers"] = markers
+            updated = _replace_building(
+                state,
+                replace(building, state=building_state),
+            )
+            event = RefugeHistoricalEvent(
+                event_id=f"hall:gallery:{normalized}",
+                event_type="hall_gallery_marker",
+                occurred_at=_utc_iso(occurred_at),
+                data={
+                    "building_id": HALL_BUILDING_ID,
+                    "marker_id": normalized,
+                    "kind": marker_kind,
+                },
+            )
+            if not any(item.event_id == event.event_id for item in updated.events):
+                updated = replace(updated, events=updated.events + (event,))
+            return await self.world_store.save_state(updated)
+
+    async def unlock_secret(
+        self,
+        secret_id: str,
+        *,
+        at: datetime | None = None,
+        config: RefugeHallConfig | None = None,
+    ) -> RefugeWorldState:
+        """Persist one Hall secret; trigger conditions remain in REFUGE-012."""
+
+        normalized = str(secret_id).strip()
+        if normalized not in HALL_SECRET_EVENTS:
+            raise ValueError(f"unsupported Hall secret: {normalized}")
+
+        hall_config = config or RefugeHallConfig.from_env()
+        async with self._lock:
+            status = await self._evaluate_locked(config=hall_config, at=at)
+            state = status.state
+            building = _hall_building(state)
+            if building is None:
+                raise RuntimeError("Refuge Hall building is missing")
+
+            event_id = f"hall:secret:{normalized}"
+            if any(event.event_id == event_id for event in state.events):
+                return state
+
+            raw_secrets = building.state.get("secret_events", ())
+            secrets = {
+                str(value)
+                for value in raw_secrets
+                if str(value) in HALL_SECRET_EVENTS
+            } if isinstance(raw_secrets, (list, tuple, set, frozenset)) else set()
+            secrets.add(normalized)
+            building_state = dict(building.state)
+            building_state["secret_events"] = sorted(secrets)
+            updated = _replace_building(
+                state,
+                replace(building, state=building_state),
+            )
+            updated = replace(
+                updated,
+                events=updated.events
+                + (
+                    RefugeHistoricalEvent(
+                        event_id=event_id,
+                        event_type="hall_secret_discovered",
+                        occurred_at=_utc_iso(at),
+                        data={
+                            "building_id": HALL_BUILDING_ID,
+                            "secret_id": normalized,
+                            "name": HALL_SECRET_EVENTS[normalized],
+                        },
+                    ),
+                ),
+            )
+            return await self.world_store.save_state(updated)
+
+
+refuge_hall_service = RefugeHallService()
+
+
+__all__ = [
+    "HALL_BUILDING_ID",
+    "HALL_LEVEL_NAMES",
+    "HALL_MAX_LEVEL",
+    "HALL_RECENT_SHOWCASE_SECONDS",
+    "HALL_SECRET_EVENTS",
+    "HallHistoricalFirst",
+    "HallRareShowcase",
+    "HallSignalSnapshot",
+    "RefugeHallConfig",
+    "RefugeHallService",
+    "RefugeHallStatus",
+    "hall_level_name",
+    "refuge_hall_service",
+]

--- a/storage/achievement_store.py
+++ b/storage/achievement_store.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import weakref
+from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Mapping
@@ -47,6 +48,13 @@ class AchievementStore:
                 }
         self._data = {"schema_version": 1, "users": users}
         self._loaded = True
+
+    async def get_snapshot(self) -> dict[str, Any]:
+        """Return a defensive snapshot of all persisted unlock history."""
+
+        async with self._get_lock():
+            await self._ensure_loaded_locked()
+            return deepcopy(self._data)
 
     async def get_user_achievements(self, user_id: int) -> dict[str, str]:
         """Return a copy of one user's ``achievement_id -> unlocked_at`` map."""

--- a/tests/test_refuge_hall.py
+++ b/tests/test_refuge_hall.py
@@ -1,0 +1,317 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services.refuge_hall import (
+    HALL_LEVEL_NAMES,
+    HALL_SECRET_EVENTS,
+    RefugeHallConfig,
+    RefugeHallService,
+)
+from services.refuge_world import RefugeWorldService
+from storage.achievement_store import AchievementStore
+from storage.refuge_world_store import RefugeWorldStore
+
+
+def _hall_building(state):
+    return next(
+        building
+        for building in state.buildings
+        if building.building_id == "hall"
+    )
+
+
+def _service(tmp_path):
+    achievements = AchievementStore(tmp_path / "achievements.json")
+    world_store = RefugeWorldStore(tmp_path / "refuge_world.json")
+    world_service = RefugeWorldService(world_store)
+    hall = RefugeHallService(
+        achievement_store_=achievements,
+        world_service=world_service,
+    )
+    return achievements, world_store, hall
+
+
+def test_hall_level_names_are_the_five_validated_names():
+    assert HALL_LEVEL_NAMES == {
+        1: "Cabane des Souvenirs",
+        2: "Salle des Trophées",
+        3: "Hall des Légendes",
+        4: "Panthéon du Refuge",
+        5: "Archives Éternelles",
+    }
+
+
+def test_hall_config_keeps_production_progression_unconfigured_by_default():
+    config = RefugeHallConfig()
+    assert config.level_thresholds_points == ()
+    assert config.unlock_weight == 0
+    assert config.achiever_weight == 0
+    assert config.diversity_weight == 0
+    assert config.historical_first_weight == 0
+    assert config.rarity_weight == 0
+
+    with pytest.raises(ValueError):
+        RefugeHallConfig(level_thresholds_points=(10, 20))
+    with pytest.raises(ValueError):
+        RefugeHallConfig(level_thresholds_points=(10, 10, 20, 30))
+    with pytest.raises(ValueError):
+        RefugeHallConfig(unlock_weight=-1)
+    with pytest.raises(ValueError):
+        RefugeHallConfig(historical_first_achievement_ids=("unknown",))
+
+
+def test_hall_config_reads_explicit_environment(monkeypatch):
+    monkeypatch.setenv("REFUGE_HALL_LEVEL_THRESHOLDS_POINTS", "10,20,40,80")
+    monkeypatch.setenv("REFUGE_HALL_UNLOCK_WEIGHT", "2")
+    monkeypatch.setenv("REFUGE_HALL_ACHIEVER_WEIGHT", "3")
+    monkeypatch.setenv("REFUGE_HALL_DIVERSITY_WEIGHT", "5")
+    monkeypatch.setenv("REFUGE_HALL_HISTORICAL_FIRST_WEIGHT", "7")
+    monkeypatch.setenv("REFUGE_HALL_RARITY_WEIGHT", "1")
+    monkeypatch.setenv("REFUGE_HALL_HISTORICAL_FIRST_IDS", "level_5,casino_1_bet")
+    monkeypatch.setenv("REFUGE_HALL_GALLERY_UNLOCK_MILESTONES", "3,10")
+    monkeypatch.setenv("REFUGE_HALL_GALLERY_ACHIEVER_MILESTONES", "2,5")
+
+    config = RefugeHallConfig.from_env()
+
+    assert config.level_thresholds_points == (10, 20, 40, 80)
+    assert config.unlock_weight == 2
+    assert config.historical_first_achievement_ids == ("level_5", "casino_1_bet")
+    assert config.gallery_unlock_milestones == (3, 10)
+    assert config.gallery_achiever_milestones == (2, 5)
+
+
+@pytest.mark.asyncio
+async def test_achievement_snapshot_is_defensive_and_read_only(tmp_path):
+    store = AchievementStore(tmp_path / "achievements.json")
+    at = datetime(2026, 8, 9, 5, 0, tzinfo=timezone.utc)
+    await store.unlock_many(1, ["level_5"], unlocked_at=at)
+
+    snapshot = await store.get_snapshot()
+    snapshot["users"]["1"]["level_5"] = "changed"
+
+    again = await store.get_snapshot()
+    assert again["users"]["1"]["level_5"] == at.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_hall_starts_at_level_one_without_calibrated_weights_or_thresholds(tmp_path):
+    achievements, _world_store, hall = _service(tmp_path)
+    at = datetime(2026, 8, 9, 5, 0, tzinfo=timezone.utc)
+    await achievements.unlock_many(1, ["level_5", "casino_1_bet"], unlocked_at=at)
+
+    status = await hall.evaluate(config=RefugeHallConfig(), at=at + timedelta(minutes=1))
+
+    assert status.level == 1
+    assert status.level_name == "Cabane des Souvenirs"
+    assert status.progression_points == 0
+    assert status.signals.total_unlocks == 2
+    assert status.signals.unique_achievers == 1
+
+
+@pytest.mark.asyncio
+async def test_hall_uses_real_unlocks_diversity_controlled_firsts_and_relative_rarity(tmp_path):
+    achievements, world_store, hall = _service(tmp_path)
+    start = datetime(2026, 8, 9, 5, 0, tzinfo=timezone.utc)
+    await world_store.initialize(created_at=start)
+
+    await achievements.unlock_many(1, ["level_5"], unlocked_at=start + timedelta(minutes=1))
+    await achievements.unlock_many(2, ["level_5"], unlocked_at=start + timedelta(minutes=2))
+    await achievements.unlock_many(3, ["level_5"], unlocked_at=start + timedelta(minutes=3))
+    await achievements.unlock_many(
+        4,
+        ["casino_1_bet", "tenure_30_days"],
+        unlocked_at=start + timedelta(minutes=4),
+    )
+
+    config = RefugeHallConfig(
+        historical_first_achievement_ids=("level_5", "casino_1_bet"),
+    )
+    status = await hall.evaluate(config=config, at=start + timedelta(minutes=5))
+
+    assert status.signals.total_unlocks == 5
+    assert status.signals.unique_achievers == 4
+    assert status.signals.category_diversity == 3
+    assert status.signals.historical_first_count == 2
+    assert {
+        first.achievement_id: first.user_id
+        for first in status.signals.historical_firsts
+    } == {"level_5": 1, "casino_1_bet": 4}
+    assert status.signals.rare_showcase is not None
+    assert status.signals.rare_showcase.achievement_id in {
+        "casino_1_bet",
+        "tenure_30_days",
+    }
+    assert status.signals.rare_showcase.unlock_count == 1
+
+
+@pytest.mark.asyncio
+async def test_hall_progression_can_reach_five_and_never_regresses(tmp_path):
+    achievements, world_store, hall = _service(tmp_path)
+    start = datetime(2026, 8, 9, 5, 0, tzinfo=timezone.utc)
+    await world_store.initialize(created_at=start)
+    for user_id in range(1, 6):
+        await achievements.unlock_many(
+            user_id,
+            ["level_5"],
+            unlocked_at=start + timedelta(minutes=user_id),
+        )
+
+    config = RefugeHallConfig(
+        level_thresholds_points=(1, 2, 3, 4),
+        unlock_weight=1,
+    )
+    first = await hall.evaluate(config=config, at=start + timedelta(minutes=10))
+    assert first.level == 5
+    assert first.progression_points == 5
+
+    empty_store = AchievementStore(tmp_path / "empty_achievements.json")
+    restarted = RefugeHallService(
+        achievement_store_=empty_store,
+        world_service=RefugeWorldService(world_store),
+    )
+    later = await restarted.evaluate(config=config, at=start + timedelta(days=1))
+    assert later.level == 5
+
+
+@pytest.mark.asyncio
+async def test_hall_rare_showcase_expires_after_24_hours(tmp_path):
+    achievements, world_store, hall = _service(tmp_path)
+    start = datetime(2026, 8, 9, 5, 0, tzinfo=timezone.utc)
+    await world_store.initialize(created_at=start)
+    await achievements.unlock_many(1, ["level_5"], unlocked_at=start)
+    await achievements.unlock_many(2, ["casino_1_bet"], unlocked_at=start + timedelta(hours=1))
+
+    recent = await hall.evaluate(
+        config=RefugeHallConfig(),
+        at=start + timedelta(hours=2),
+    )
+    expired = await hall.evaluate(
+        config=RefugeHallConfig(),
+        at=start + timedelta(hours=26),
+    )
+
+    assert recent.signals.rare_showcase is not None
+    assert _hall_building(recent.state).state.get("rare_showcase") is not None
+    assert expired.signals.rare_showcase is None
+    assert "rare_showcase" not in _hall_building(expired.state).state
+
+
+@pytest.mark.asyncio
+async def test_hall_builds_season_plaques_only_from_world_history(tmp_path):
+    achievements, world_store, hall = _service(tmp_path)
+    created = datetime(2026, 8, 9, 5, 0, tzinfo=timezone.utc)
+    await world_store.initialize(created_at=created)
+
+    await achievements.unlock_many(
+        1,
+        ["level_5"],
+        unlocked_at=created - timedelta(days=2),
+    )
+    await achievements.unlock_many(
+        2,
+        ["casino_1_bet"],
+        unlocked_at=created + timedelta(hours=1),
+    )
+    await achievements.unlock_many(
+        3,
+        ["tenure_30_days"],
+        unlocked_at=datetime(2026, 9, 2, 8, 0, tzinfo=timezone.utc),
+    )
+
+    status = await hall.evaluate(
+        config=RefugeHallConfig(),
+        at=datetime(2026, 9, 2, 9, 0, tzinfo=timezone.utc),
+    )
+    plaques = _hall_building(status.state).state["season_plaques"]
+
+    assert [item["season_id"] for item in plaques] == ["2026-08", "2026-09"]
+    assert plaques[0]["unlock_count"] == 1
+    assert plaques[1]["unlock_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_hall_gallery_milestones_are_configurable_and_persistent(tmp_path):
+    achievements, world_store, hall = _service(tmp_path)
+    start = datetime(2026, 8, 9, 5, 0, tzinfo=timezone.utc)
+    await world_store.initialize(created_at=start)
+    for user_id, achievement_id in (
+        (1, "level_5"),
+        (2, "casino_1_bet"),
+        (3, "tenure_30_days"),
+    ):
+        await achievements.unlock_many(
+            user_id,
+            [achievement_id],
+            unlocked_at=start + timedelta(minutes=user_id),
+        )
+
+    status = await hall.evaluate(
+        config=RefugeHallConfig(
+            gallery_unlock_milestones=(3,),
+            gallery_achiever_milestones=(2,),
+        ),
+        at=start + timedelta(minutes=10),
+    )
+    markers = _hall_building(status.state).state["gallery_markers"]
+    ids = {item["marker_id"] for item in markers}
+
+    assert ids == {
+        "first_refuge_achievement",
+        "achievement_unlock:3",
+        "unique_achiever:2",
+    }
+
+
+@pytest.mark.asyncio
+async def test_external_gallery_marker_is_idempotent(tmp_path):
+    _achievements, _world_store, hall = _service(tmp_path)
+    at = datetime(2026, 8, 9, 5, 0, tzinfo=timezone.utc)
+
+    first = await hall.record_gallery_marker(
+        "community_goal:first",
+        kind="community_goal",
+        occurred_at=at,
+    )
+    second = await hall.record_gallery_marker(
+        "community_goal:first",
+        kind="community_goal",
+        occurred_at=at + timedelta(hours=1),
+    )
+
+    assert _hall_building(first).state["gallery_markers"] == _hall_building(second).state["gallery_markers"]
+    matching = [
+        event
+        for event in second.events
+        if event.event_id == "hall:gallery:community_goal:first"
+    ]
+    assert len(matching) == 1
+
+
+@pytest.mark.asyncio
+async def test_hall_secret_unlock_is_persistent_and_idempotent(tmp_path):
+    _achievements, world_store, hall = _service(tmp_path)
+    at = datetime(2026, 8, 9, 5, 0, tzinfo=timezone.utc)
+
+    await hall.unlock_secret("memory_flame", at=at)
+    await hall.unlock_secret("memory_flame", at=at + timedelta(hours=1))
+    restarted = await world_store.get_state()
+
+    assert _hall_building(restarted).state["secret_events"] == ["memory_flame"]
+    matching = [
+        event
+        for event in restarted.events
+        if event.event_id == "hall:secret:memory_flame"
+    ]
+    assert len(matching) == 1
+    assert matching[0].data["name"] == HALL_SECRET_EVENTS["memory_flame"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_hall_secret_is_rejected(tmp_path):
+    _achievements, _world_store, hall = _service(tmp_path)
+
+    with pytest.raises(ValueError):
+        await hall.unlock_secret("not-a-secret")

--- a/tests/test_refuge_hall_renderer.py
+++ b/tests/test_refuge_hall_renderer.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import hashlib
+import io
+
+import pytest
+from PIL import Image
+
+from models.refuge_world import RefugeBuildingState, RefugeWorldState
+from rendering.refuge_hall import RefugeHallRenderer, hall_scene_signature
+from rendering.refuge_world import REFUGE_CANVAS_SIZE, RefugeRenderContext
+
+
+CONTEXT = RefugeRenderContext(season="summer", daypart="night")
+
+
+def _state(
+    *,
+    hall_level: int,
+    showcase: bool = False,
+    secrets: tuple[str, ...] = (),
+) -> RefugeWorldState:
+    hall_state = {
+        "historical_firsts": [
+            {
+                "achievement_id": "level_5",
+                "user_id": 1,
+                "unlocked_at": "2026-08-09T05:00:00+00:00",
+            }
+        ],
+        "season_plaques": [
+            {
+                "season_id": "2026-08",
+                "unlock_count": 3,
+                "unique_achievers": 2,
+            }
+        ],
+        "gallery_markers": [
+            {
+                "marker_id": "first_refuge_achievement",
+                "kind": "first_achievement",
+                "occurred_at": "2026-08-09T05:00:00+00:00",
+            }
+        ],
+        "secret_events": list(secrets),
+    }
+    if showcase:
+        hall_state["rare_showcase"] = {
+            "achievement_id": "casino_1_bet",
+            "user_id": 2,
+            "unlocked_at": "2026-08-09T05:10:00+00:00",
+            "expires_at": "2026-08-10T05:10:00+00:00",
+            "unlock_count": 1,
+            "achiever_count": 4,
+            "prevalence_per_10000": 2500,
+        }
+
+    return RefugeWorldState(
+        buildings=(
+            RefugeBuildingState(
+                building_id="fire",
+                level=2,
+                unlocked_at="2026-08-09T05:00:00+00:00",
+                state={"intensity": "normal", "secret_events": []},
+            ),
+            RefugeBuildingState(
+                building_id="hall",
+                level=hall_level,
+                unlocked_at="2026-08-09T05:00:00+00:00",
+                state=hall_state,
+            ),
+        ),
+    )
+
+
+def _digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def test_hall_renderer_produces_expected_png_dimensions():
+    payload = RefugeHallRenderer().render_png(_state(hall_level=1), context=CONTEXT)
+
+    image = Image.open(io.BytesIO(payload))
+    assert image.size == REFUGE_CANVAS_SIZE
+    assert image.mode == "RGB"
+
+
+def test_all_five_hall_levels_have_distinct_silhouettes():
+    renderer = RefugeHallRenderer()
+
+    digests = {
+        _digest(renderer.render_png(_state(hall_level=level), context=CONTEXT))
+        for level in range(1, 6)
+    }
+
+    assert len(digests) == 5
+
+
+def test_hall_renderer_keeps_the_fire_layer_in_composition():
+    renderer = RefugeHallRenderer()
+    state = _state(hall_level=3)
+
+    with_hall = renderer.render_png(state, context=CONTEXT)
+
+    fire_only = RefugeWorldState(buildings=(state.buildings[0],))
+    without_hall = renderer.render_png(fire_only, context=CONTEXT)
+
+    assert with_hall != without_hall
+
+
+def test_recent_rare_showcase_changes_the_visual_without_changing_level():
+    renderer = RefugeHallRenderer()
+
+    normal = renderer.render_png(_state(hall_level=3), context=CONTEXT)
+    showcased = renderer.render_png(
+        _state(hall_level=3, showcase=True),
+        context=CONTEXT,
+    )
+
+    assert showcased != normal
+
+
+@pytest.mark.parametrize(
+    "secret_id",
+    ["memory_flame", "endless_book", "forgotten_crown"],
+)
+def test_each_hall_secret_adds_a_permanent_visual_trace(secret_id):
+    renderer = RefugeHallRenderer()
+
+    base = renderer.render_png(_state(hall_level=4), context=CONTEXT)
+    discovered = renderer.render_png(
+        _state(hall_level=4, secrets=(secret_id,)),
+        context=CONTEXT,
+    )
+
+    assert discovered != base
+
+
+def test_hall_renderer_is_byte_deterministic():
+    renderer = RefugeHallRenderer()
+    state = _state(
+        hall_level=5,
+        showcase=True,
+        secrets=("memory_flame", "endless_book", "forgotten_crown"),
+    )
+
+    first = renderer.render_png(state, context=CONTEXT)
+    second = renderer.render_png(state, context=CONTEXT)
+
+    assert first == second
+
+
+def test_hall_scene_signature_tracks_hall_visual_state():
+    base = hall_scene_signature(_state(hall_level=2), CONTEXT)
+    level = hall_scene_signature(_state(hall_level=3), CONTEXT)
+    showcase = hall_scene_signature(
+        _state(hall_level=2, showcase=True),
+        CONTEXT,
+    )
+    secret = hall_scene_signature(
+        _state(hall_level=2, secrets=("memory_flame",)),
+        CONTEXT,
+    )
+
+    assert len({base, level, showcase, secret}) == 4
+
+
+@pytest.mark.asyncio
+async def test_hall_async_renderer_matches_sync_renderer():
+    renderer = RefugeHallRenderer()
+    state = _state(hall_level=3, showcase=True)
+
+    expected = renderer.render_png(state, context=CONTEXT)
+    actual = await renderer.render_png_async(state, context=CONTEXT)
+
+    assert actual == expected


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-006 — Hall des accomplissements** : projeter l’historique réel des succès existants dans un bâtiment persistant du Refuge, sans recalculer les critères de succès et sans toucher au Casino, Chantier ou panneau public.

## Source de vérité
Le Hall lit exclusivement `AchievementStore`.

`AchievementStore` reçoit une seule extension : `get_snapshot()`, lecture défensive de l’historique complet `user_id -> achievement_id -> unlocked_at`. Cette méthode n’écrit rien et ne modifie ni les critères, ni les déblocages, ni la fréquence de synchronisation des succès.

## 5 niveaux permanents
1. **Cabane des Souvenirs**
2. **Salle des Trophées**
3. **Hall des Légendes**
4. **Panthéon du Refuge**
5. **Archives Éternelles**

La progression reste monotone via REFUGE-003.

### Aucun calibrage arbitraire
Aucun seuil II→V ni poids de production n’est activé par défaut.

Variables prévues :
- `REFUGE_HALL_LEVEL_THRESHOLDS_POINTS` — 4 seuils II→V ;
- `REFUGE_HALL_UNLOCK_WEIGHT` ;
- `REFUGE_HALL_ACHIEVER_WEIGHT` ;
- `REFUGE_HALL_DIVERSITY_WEIGHT` ;
- `REFUGE_HALL_HISTORICAL_FIRST_WEIGHT` ;
- `REFUGE_HALL_RARITY_WEIGHT`.

Sans calibration explicite, le Hall reste au niveau I. Les valeurs utilisées dans les tests sont uniquement des fixtures.

## Signaux du Hall
Le service dérive uniquement des données réellement persistées :
- nombre total de déblocages ;
- nombre de membres distincts ayant au moins un succès ;
- nombre de succès distincts ;
- diversité des catégories ;
- premières historiques contrôlées ;
- signal de rareté relatif à la communauté.

### Rareté
Aucun tier `rare/épique/légendaire` n’est inventé.

La rareté est relative : pour chaque succès, le Hall utilise sa prévalence réelle parmi les membres ayant au moins un succès. La vitrine 24 h sélectionne, parmi les succès réellement débloqués dans les dernières 24 h, celui dont la prévalence est la plus faible ; les égalités sont déterministes.

La vitrine expire après 24 h lors de la prochaine évaluation et n’altère jamais le niveau permanent du Hall.

## Premières historiques
Les premières ne sont **pas** un classement général.

Seuls les IDs explicitement configurés dans `REFUGE_HALL_HISTORICAL_FIRST_IDS` peuvent devenir des premières historiques. Le gagnant est reconstruit à partir du timestamp réel le plus ancien dans `AchievementStore`.

Une première enregistrée dans le monde devient permanente et n’est pas supprimée si la configuration ou la source change ensuite.

## Galerie communautaire
Le Hall possède des marqueurs persistants et idempotents :
- premier succès depuis le lancement du monde ;
- jalons configurables de nombre total de succès via `REFUGE_HALL_GALLERY_UNLOCK_MILESTONES` ;
- jalons configurables de membres distincts via `REFUGE_HALL_GALLERY_ACHIEVER_MILESTONES` ;
- `record_gallery_marker()` permet aux futurs systèmes de déposer des accomplissements exceptionnels (objectif communautaire, jalon vocal, etc.) sans nouveau schéma de persistance.

Aucun jalon numérique n’est activé par défaut.

## Plaques saisonnières
Les succès obtenus depuis `RefugeWorldState.created_at` sont regroupés par saison mensuelle Europe/Paris.

Chaque saison conserve :
- nombre de succès débloqués ;
- nombre de membres distincts concernés.

Les plaques sont monotones : une plaque déjà inscrite ne disparaît pas si une source est ensuite réduite ou modifiée. La chronologie complète reste prévue pour REFUGE-011.

## Rendu du Hall
Nouveau `RefugeHallRenderer`, composé au-dessus du renderer Fire :

`terrain REFUGE-004 → Fire REFUGE-005 → Hall REFUGE-006`

Silhouettes :
- niveau I : petite cabane mémorielle ;
- niveau II : salle des trophées élargie ;
- niveau III : hall monumental à colonnes ;
- niveau IV : panthéon structuré ;
- niveau V : grandes archives avec tour centrale.

Traces visuelles :
- plaques saisonnières ;
- premières historiques contrôlées ;
- marqueurs de galerie ;
- vitrine rare 24 h ;
- variations saison/jour-nuit héritées du renderer existant.

Le rendu reste déterministe 1280×720 et son wrapper async reste hors event loop Discord.

## Secrets du Hall
Les trois secrets validés sont persistables et rendables :
- **Flamme du Souvenir** ;
- **Livre sans fin** ;
- **Couronne oubliée**.

Comme pour le Feu, leurs conditions automatiques restent volontairement réservées à **REFUGE-012 — événements secrets**.

## Fichiers
- `services/refuge_hall.py` — nouveau ;
- `rendering/refuge_hall.py` — nouveau ;
- `rendering/__init__.py` — export du Hall ;
- `storage/achievement_store.py` — ajout lecture défensive `get_snapshot()` ;
- `tests/test_refuge_hall.py` — nouveau ;
- `tests/test_refuge_hall_renderer.py` — nouveau.

## Hors périmètre
Aucune modification de :
- définitions ou critères de succès ;
- `cogs/achievements.py` ;
- logique XP ;
- logique Casino ;
- REFUGE-002 vocal ;
- progression ou rendu du Feu ;
- objectifs communautaires ;
- Chantier ;
- Components V2 ;
- panneau public Discord ;
- commandes Discord.

## Validation effectuée
Le checkout réseau GitHub n’est pas disponible dans le runtime ChatGPT (`Could not resolve host: github.com`), donc la suite pytest du dépôt n’a pas été exécutée et n’est pas déclarée comme passée.

Validations isolées exécutées sur le code exact préparé :
- compilation syntaxique des nouveaux modules et tests ;
- service Hall : signaux, points, niveau V avec seuils de test, plaques, galerie et absence de deadlock ;
- premières historiques conservées après retrait de leur configuration ;
- renderer Hall : PNG 1280×720 ;
- 5 niveaux = 5 rendus distincts ;
- vitrine 24 h = rendu distinct ;
- chacun des 3 secrets = trace visuelle distincte ;
- composition Hall au-dessus du Fire.

La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.