### PR TITLE
feat: add the living Refuge Casino

### DIFF
--- a/cogs/xp.py
+++ b/cogs/xp.py
@@ -35,6 +35,7 @@ from storage.season_store import season_store
 from utils.game_events import get_multiplier, record_participant
 from utils.voice_bonus import get_voice_multiplier
 from utils.seasons import should_count_xp_source
+from utils.refuge_casino_observer import observe_casino_xp_transaction
 logger = logging.getLogger(__name__)
 
 # Fichiers de persistance
@@ -143,6 +144,7 @@ async def award_xp(
     permettent de retirer de l'XP, sans bonus.
     """
     now = datetime.now(timezone.utc)
+    requested_amount = int(amount)
     if amount > 0:
         boost_exp = XP_BOOSTS.get(str(user_id))
         if boost_exp:
@@ -156,6 +158,13 @@ async def award_xp(
     )
     old_level, new_level, old_xp, new_xp = result
     delta = new_xp - old_xp
+    observe_casino_xp_transaction(
+        user_id=user_id,
+        source=source,
+        requested_amount=requested_amount,
+        applied_delta=delta,
+        at=now,
+    )
     if should_count_xp_source(source, delta):
         try:
             await season_store.record(user_id, at=now, xp_earned=delta)

--- a/rendering/__init__.py
+++ b/rendering/__init__.py
@@ -1,5 +1,11 @@
 """Deterministic visual rendering helpers for the Refuge world."""
 
+from .refuge_casino import (
+    REFUGE_CASINO_RENDERER_VERSION,
+    RefugeCasinoRenderer,
+    casino_scene_signature,
+    refuge_casino_renderer,
+)
 from .refuge_fire import (
     REFUGE_FIRE_RENDERER_VERSION,
     RefugeFireRenderer,
@@ -24,15 +30,19 @@ from .refuge_world import (
 
 __all__ = [
     "REFUGE_CANVAS_SIZE",
+    "REFUGE_CASINO_RENDERER_VERSION",
     "REFUGE_FIRE_RENDERER_VERSION",
     "REFUGE_HALL_RENDERER_VERSION",
+    "RefugeCasinoRenderer",
     "RefugeFireRenderer",
     "RefugeHallRenderer",
     "RefugeRenderContext",
     "RefugeWorldRenderer",
+    "casino_scene_signature",
     "daypart_for_hour",
     "fire_scene_signature",
     "hall_scene_signature",
+    "refuge_casino_renderer",
     "refuge_fire_renderer",
     "refuge_hall_renderer",
     "refuge_world_renderer",

--- a/rendering/refuge_casino.py
+++ b/rendering/refuge_casino.py
@@ -1,0 +1,456 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import json
+from typing import Any, Final, Mapping
+
+from PIL import Image, ImageDraw
+
+from models.refuge_world import RefugeBuildingState, RefugeWorldState
+from rendering.refuge_hall import (
+    RefugeHallRenderer,
+    hall_scene_signature,
+    refuge_hall_renderer,
+)
+from rendering.refuge_world import RefugeRenderContext
+from services.refuge_casino import (
+    CASINO_BUILDING_ID,
+    CASINO_EVENTS,
+    CASINO_MAX_LEVEL,
+    CASINO_SECRET_EVENTS,
+)
+
+
+REFUGE_CASINO_RENDERER_VERSION: Final[int] = 1
+CASINO_SITE_CENTER: Final[tuple[int, int]] = (900, 508)
+_VALID_FORTUNES = frozenset(
+    {"ruined", "difficulty", "stable", "prosperous", "insolent"}
+)
+
+
+def _shade(color: tuple[int, int, int], factor: float) -> tuple[int, int, int]:
+    return tuple(
+        max(0, min(255, int(round(channel * factor))))
+        for channel in color
+    )
+
+
+def _mix(
+    left: tuple[int, int, int],
+    right: tuple[int, int, int],
+    ratio: float,
+) -> tuple[int, int, int]:
+    clamped = max(0.0, min(1.0, ratio))
+    return tuple(
+        int(round(a + (b - a) * clamped))
+        for a, b in zip(left, right)
+    )
+
+
+def _casino_building(state: RefugeWorldState) -> RefugeBuildingState | None:
+    return next(
+        (
+            building
+            for building in state.buildings
+            if building.building_id == CASINO_BUILDING_ID
+        ),
+        None,
+    )
+
+
+def _fortune(building: RefugeBuildingState) -> str:
+    value = str(building.state.get("fortune", "stable")).strip().lower()
+    return value if value in _VALID_FORTUNES else "stable"
+
+
+def _ids(value: Any, allowed: Mapping[str, str]) -> frozenset[str]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return frozenset()
+    return frozenset(str(item) for item in value if str(item) in allowed)
+
+
+def casino_scene_signature(
+    state: RefugeWorldState,
+    context: RefugeRenderContext,
+) -> str:
+    payload = {
+        "base": hall_scene_signature(state, context),
+        "casino_renderer_version": REFUGE_CASINO_RENDERER_VERSION,
+    }
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _palette(
+    context: RefugeRenderContext,
+    fortune: str,
+    is_open: bool,
+) -> dict[str, tuple[int, int, int]]:
+    wall = (119, 82, 65)
+    roof = (70, 53, 54)
+    trim = (159, 126, 73)
+    lamp = (244, 191, 84) if is_open else (96, 89, 73)
+    window = (228, 163, 78) if is_open else (60, 62, 67)
+
+    if fortune == "ruined":
+        wall = (84, 76, 70)
+        roof = (58, 55, 55)
+        trim = (99, 91, 76)
+        lamp = (106, 77, 62) if is_open else (65, 61, 58)
+        window = (105, 74, 65) if is_open else (48, 49, 51)
+    elif fortune == "difficulty":
+        wall = (103, 77, 68)
+        trim = (127, 106, 77)
+    elif fortune == "prosperous":
+        wall = (133, 83, 60)
+        trim = (189, 151, 72)
+        lamp = (255, 207, 91) if is_open else lamp
+    elif fortune == "insolent":
+        wall = (142, 83, 55)
+        roof = (74, 44, 50)
+        trim = (218, 174, 69)
+        lamp = (255, 221, 107) if is_open else (123, 108, 76)
+        window = (255, 198, 88) if is_open else (75, 69, 66)
+
+    if context.daypart == "night":
+        wall = _shade(wall, 0.68)
+        roof = _shade(roof, 0.72)
+    elif context.daypart == "sunset":
+        wall = _mix(wall, (142, 83, 66), 0.16)
+
+    return {
+        "wall": wall,
+        "wall_dark": _shade(wall, 0.72),
+        "roof": roof,
+        "trim": trim,
+        "trim_dark": _shade(trim, 0.70),
+        "lamp": lamp,
+        "window": window,
+        "door": (62, 47, 43),
+        "stone": (105, 104, 98),
+        "gold": (218, 174, 69),
+        "red": (116, 50, 51),
+        "black": (39, 39, 42),
+    }
+
+
+def _shadow(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    radius_x: int,
+) -> None:
+    x, y = center
+    draw.ellipse((x - radius_x, y - 12, x + radius_x, y + 20), fill=(44, 55, 43))
+
+
+def _lamp(
+    draw: ImageDraw.ImageDraw,
+    *,
+    x: int,
+    y: int,
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    draw.line((x, y, x, y - 28), fill=palette["trim_dark"], width=3)
+    draw.ellipse((x - 6, y - 34, x + 6, y - 22), fill=palette["lamp"])
+
+
+def _window(
+    draw: ImageDraw.ImageDraw,
+    *,
+    box: tuple[int, int, int, int],
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    draw.rectangle(box, fill=palette["trim_dark"])
+    left, top, right, bottom = box
+    draw.rectangle((left + 3, top + 3, right - 3, bottom - 3), fill=palette["window"])
+
+
+def _draw_level_one(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    _shadow(draw, center=(x, y + 8), radius_x=55)
+    draw.rectangle((x - 48, y - 50, x + 48, y + 9), fill=palette["wall"])
+    draw.polygon(
+        ((x - 58, y - 49), (x, y - 80), (x + 58, y - 49)),
+        fill=palette["roof"],
+    )
+    draw.rectangle((x - 13, y - 24, x + 13, y + 9), fill=palette["door"])
+    _window(draw, box=(x - 38, y - 34, x - 20, y - 15), palette=palette)
+    _window(draw, box=(x + 20, y - 34, x + 38, y - 15), palette=palette)
+    draw.rectangle((x - 27, y - 59, x + 27, y - 48), fill=palette["trim"])
+
+
+def _draw_level_two(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    _shadow(draw, center=(x, y + 9), radius_x=70)
+    draw.rectangle((x - 66, y - 58, x + 66, y + 10), fill=palette["wall"])
+    draw.polygon(
+        ((x - 78, y - 57), (x, y - 94), (x + 78, y - 57)),
+        fill=palette["roof"],
+    )
+    draw.rectangle((x - 16, y - 30, x + 16, y + 10), fill=palette["door"])
+    for px in (x - 43, x + 43):
+        _window(draw, box=(px - 11, y - 39, px + 11, y - 15), palette=palette)
+    for px in (x - 62, x + 62):
+        _lamp(draw, x=px, y=y + 6, palette=palette)
+    draw.arc((x - 23, y - 82, x + 23, y - 54), 180, 360, fill=palette["gold"], width=4)
+
+
+def _draw_level_three(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    _shadow(draw, center=(x, y + 10), radius_x=88)
+    draw.rectangle((x - 84, y - 65, x + 84, y + 11), fill=palette["wall"])
+    draw.rectangle((x - 58, y - 83, x + 58, y + 11), fill=palette["wall_dark"])
+    draw.polygon(
+        ((x - 68, y - 82), (x, y - 116), (x + 68, y - 82)),
+        fill=palette["roof"],
+    )
+    for px in (x - 65, x - 42, x + 42, x + 65):
+        draw.rectangle((px - 5, y - 58, px + 5, y + 6), fill=palette["trim"])
+    draw.rectangle((x - 18, y - 34, x + 18, y + 11), fill=palette["door"])
+    _window(draw, box=(x - 36, y - 71, x - 16, y - 50), palette=palette)
+    _window(draw, box=(x + 16, y - 71, x + 36, y - 50), palette=palette)
+    draw.ellipse((x - 17, y - 105, x + 17, y - 76), fill=palette["gold"])
+
+
+def _draw_level_four(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    _shadow(draw, center=(x, y + 11), radius_x=103)
+    draw.rectangle((x - 99, y - 70, x + 99, y + 12), fill=palette["wall"])
+    draw.rectangle((x - 66, y - 101, x + 66, y + 12), fill=palette["wall_dark"])
+    draw.polygon(
+        ((x - 78, y - 99), (x, y - 141), (x + 78, y - 99)),
+        fill=palette["roof"],
+    )
+    for px in (x - 83, x - 56, x - 31, x + 31, x + 56, x + 83):
+        draw.rectangle((px - 5, y - 65, px + 5, y + 7), fill=palette["trim"])
+    draw.rectangle((x - 20, y - 38, x + 20, y + 12), fill=palette["door"])
+    draw.ellipse((x - 27, y - 131, x + 27, y - 88), fill=palette["trim"])
+    draw.ellipse((x - 19, y - 123, x + 19, y - 95), fill=palette["window"])
+    for px in (x - 95, x + 95):
+        _lamp(draw, x=px, y=y + 7, palette=palette)
+
+
+def _draw_level_five(
+    draw: ImageDraw.ImageDraw,
+    *,
+    center: tuple[int, int],
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    _shadow(draw, center=(x, y + 12), radius_x=116)
+    draw.rectangle((x - 112, y - 73, x + 112, y + 13), fill=palette["wall"])
+    draw.rectangle((x - 75, y - 109, x + 75, y + 13), fill=palette["wall_dark"])
+    draw.rectangle((x - 38, y - 142, x + 38, y + 13), fill=palette["wall"])
+    draw.polygon(
+        ((x - 52, y - 140), (x, y - 174), (x + 52, y - 140)),
+        fill=palette["roof"],
+    )
+    for px in (x - 93, x - 64, x + 64, x + 93):
+        _window(draw, box=(px - 10, y - 50, px + 10, y - 24), palette=palette)
+    for px in (x - 58, x - 30, x + 30, x + 58):
+        draw.rectangle((px - 5, y - 80, px + 5, y + 8), fill=palette["trim"])
+    draw.rectangle((x - 21, y - 42, x + 21, y + 13), fill=palette["door"])
+    draw.ellipse((x - 29, y - 163, x + 29, y - 112), fill=palette["gold"])
+    draw.ellipse((x - 21, y - 155, x + 21, y - 119), fill=palette["window"])
+    for px in (x - 109, x + 109):
+        _lamp(draw, x=px, y=y + 8, palette=palette)
+
+
+def _draw_fortune_details(
+    draw: ImageDraw.ImageDraw,
+    *,
+    building: RefugeBuildingState,
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = CASINO_SITE_CENTER
+    fortune = _fortune(building)
+    if fortune == "ruined":
+        for dx in (-42, 12, 48):
+            draw.line((x + dx, y - 52, x + dx + 15, y - 30), fill=palette["black"], width=3)
+        draw.line((x - 28, y - 17, x + 27, y - 2), fill=palette["stone"], width=5)
+    elif fortune == "difficulty":
+        draw.rectangle((x - 7, y - 92, x + 7, y - 82), fill=palette["trim_dark"])
+    elif fortune == "prosperous":
+        for px in (x - 78, x + 78):
+            draw.ellipse((px - 6, y - 86, px + 6, y - 74), fill=palette["gold"])
+    elif fortune == "insolent":
+        for px in (x - 90, x - 60, x + 60, x + 90):
+            draw.ellipse((px - 6, y - 91, px + 6, y - 79), fill=palette["gold"])
+        draw.polygon(
+            ((x - 19, y - 180), (x - 11, y - 194), (x, y - 183), (x + 11, y - 194), (x + 19, y - 180)),
+            fill=palette["gold"],
+        )
+
+
+def _draw_history_details(
+    draw: ImageDraw.ImageDraw,
+    *,
+    building: RefugeBuildingState,
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = CASINO_SITE_CENTER
+    last = building.state.get("last_jackpot")
+    if isinstance(last, Mapping):
+        try:
+            tier = int(last.get("tier", 0))
+        except (TypeError, ValueError):
+            tier = 0
+        if tier in {500, 1000}:
+            color = palette["gold"] if tier == 1000 else palette["trim"]
+            draw.polygon(
+                ((x + 82, y - 112), (x + 90, y - 99), (x + 82, y - 86), (x + 74, y - 99)),
+                fill=color,
+            )
+            if tier == 1000:
+                draw.ellipse((x + 76, y - 105, x + 88, y - 93), fill=(231, 237, 230))
+
+    events = _ids(building.state.get("casino_events", ()), CASINO_EVENTS)
+    if "grand_heist" in events:
+        sx, sy = x - 96, y + 3
+        draw.rectangle((sx - 16, sy - 22, sx + 16, sy + 8), fill=palette["stone"])
+        draw.ellipse((sx - 7, sy - 13, sx + 7, sy + 1), outline=palette["black"], width=3)
+        draw.line((sx + 2, sy - 9, sx + 18, sy - 25), fill=palette["red"], width=3)
+    if "black_night" in events:
+        draw.ellipse((x - 118, y - 91, x - 96, y - 69), fill=palette["black"])
+    if "break_in" in events:
+        for dx in (-9, 0, 9):
+            draw.line((x + dx, y - 34, x + dx, y + 7), fill=palette["stone"], width=3)
+    if "house_always_wins" in events:
+        for index in range(4):
+            px = x + 102 + index * 4
+            py = y + 4 - index * 5
+            draw.ellipse((px - 8, py - 4, px + 8, py + 4), fill=palette["gold"])
+
+
+def _draw_secret_details(
+    draw: ImageDraw.ImageDraw,
+    *,
+    building: RefugeBuildingState,
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = CASINO_SITE_CENTER
+    secrets = _ids(building.state.get("secret_events", ()), CASINO_SECRET_EVENTS)
+    if "black_cat" in secrets:
+        cx, cy = x - 110, y - 2
+        draw.ellipse((cx - 12, cy - 9, cx + 12, cy + 8), fill=palette["black"])
+        draw.polygon(((cx - 9, cy - 7), (cx - 5, cy - 18), (cx, cy - 7)), fill=palette["black"])
+        draw.polygon(((cx + 3, cy - 7), (cx + 8, cy - 18), (cx + 11, cy - 6)), fill=palette["black"])
+        draw.ellipse((cx - 5, cy - 2, cx - 2, cy + 1), fill=palette["gold"])
+        draw.ellipse((cx + 3, cy - 2, cx + 6, cy + 1), fill=palette["gold"])
+    if "diamond" in secrets:
+        dx, dy = x + 118, y - 52
+        draw.polygon(
+            ((dx, dy - 13), (dx + 12, dy), (dx, dy + 15), (dx - 12, dy)),
+            fill=(181, 218, 226),
+        )
+    if "ghost_player" in secrets:
+        gx, gy = x + 116, y + 6
+        ghost = (176, 190, 187)
+        draw.ellipse((gx - 12, gy - 28, gx + 12, gy - 4), fill=ghost)
+        draw.rectangle((gx - 12, gy - 16, gx + 12, gy + 8), fill=ghost)
+        draw.ellipse((gx - 6, gy - 18, gx - 2, gy - 14), fill=palette["black"])
+        draw.ellipse((gx + 2, gy - 18, gx + 6, gy - 14), fill=palette["black"])
+
+
+def draw_refuge_casino(
+    draw: ImageDraw.ImageDraw,
+    state: RefugeWorldState,
+    *,
+    context: RefugeRenderContext,
+) -> None:
+    building = _casino_building(state)
+    if building is None or int(building.level) <= 0:
+        return
+    level = max(1, min(CASINO_MAX_LEVEL, int(building.level)))
+    fortune = _fortune(building)
+    is_open = bool(building.state.get("is_open", False))
+    palette = _palette(context, fortune, is_open)
+
+    if level == 1:
+        _draw_level_one(draw, center=CASINO_SITE_CENTER, palette=palette)
+    elif level == 2:
+        _draw_level_two(draw, center=CASINO_SITE_CENTER, palette=palette)
+    elif level == 3:
+        _draw_level_three(draw, center=CASINO_SITE_CENTER, palette=palette)
+    elif level == 4:
+        _draw_level_four(draw, center=CASINO_SITE_CENTER, palette=palette)
+    else:
+        _draw_level_five(draw, center=CASINO_SITE_CENTER, palette=palette)
+
+    _draw_fortune_details(draw, building=building, palette=palette)
+    _draw_history_details(draw, building=building, palette=palette)
+    _draw_secret_details(draw, building=building, palette=palette)
+
+
+class RefugeCasinoRenderer:
+    """Compose terrain, Fire, Hall and Casino layers deterministically."""
+
+    def __init__(
+        self,
+        base_renderer: RefugeHallRenderer = refuge_hall_renderer,
+    ) -> None:
+        self.base_renderer = base_renderer
+
+    def render_png(
+        self,
+        state: RefugeWorldState,
+        *,
+        context: RefugeRenderContext | None = None,
+    ) -> bytes:
+        render_context = context or RefugeRenderContext.from_datetime()
+        base_png = self.base_renderer.render_png(state, context=render_context)
+        image = Image.open(io.BytesIO(base_png)).convert("RGB")
+        draw = ImageDraw.Draw(image)
+        draw_refuge_casino(draw, state, context=render_context)
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG", optimize=False, compress_level=9)
+        return buffer.getvalue()
+
+    async def render_png_async(
+        self,
+        state: RefugeWorldState,
+        *,
+        context: RefugeRenderContext | None = None,
+    ) -> bytes:
+        return await asyncio.to_thread(self.render_png, state, context=context)
+
+
+refuge_casino_renderer = RefugeCasinoRenderer()
+
+
+__all__ = [
+    "CASINO_SITE_CENTER",
+    "REFUGE_CASINO_RENDERER_VERSION",
+    "RefugeCasinoRenderer",
+    "casino_scene_signature",
+    "draw_refuge_casino",
+    "refuge_casino_renderer",
+]

--- a/services/refuge_casino.py
+++ b/services/refuge_casino.py
@@ -1,0 +1,598 @@
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final, Mapping
+
+from config import CASINO_CLOSE_HOUR, CASINO_OPEN_HOUR, DATA_DIR
+from models.refuge_world import (
+    RefugeBuildingState,
+    RefugeHistoricalEvent,
+    RefugeWorldState,
+)
+from services.refuge_world import (
+    BuildingProgressionRule,
+    RefugeWorldService,
+    refuge_world_service,
+    world_render_signature,
+)
+from storage.refuge_casino_activity_store import (
+    RefugeCasinoActivityStore,
+    refuge_casino_activity_store,
+)
+from utils.persistence import read_json_safe
+from utils.timezones import PARIS_TZ
+
+
+CASINO_BUILDING_ID: Final[str] = "casino"
+CASINO_METRIC_KEY: Final[str] = "casino_prestige_points"
+CASINO_MAX_LEVEL: Final[int] = 5
+CASINO_RECENT_WINDOW_SECONDS: Final[int] = 24 * 60 * 60
+CASINO_STATE_FILE = Path(DATA_DIR) / "pari_xp_state.json"
+
+CASINO_LEVEL_NAMES: Final[Mapping[int, str]] = {
+    1: "Baraque de Jeux",
+    2: "Comptoir Chanceux",
+    3: "Casino du Refuge",
+    4: "Palais du Hasard",
+    5: "Maison Éternelle",
+}
+CASINO_FORTUNE_NAMES: Final[Mapping[str, str]] = {
+    "ruined": "Ruiné",
+    "difficulty": "En difficulté",
+    "stable": "Stable",
+    "prosperous": "Prospère",
+    "insolent": "Insolent",
+}
+CASINO_EVENTS: Final[Mapping[str, str]] = {
+    "grand_heist": "Le Grand Braquage",
+    "black_night": "La Nuit Noire",
+    "break_in": "Le Casse",
+    "house_always_wins": "La Maison gagne toujours",
+}
+CASINO_SECRET_EVENTS: Final[Mapping[str, str]] = {
+    "black_cat": "Le Chat Noir",
+    "diamond": "Le Diamant",
+    "ghost_player": "Le Joueur Fantôme",
+}
+
+
+def _utc_iso(at: datetime | None = None) -> str:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).isoformat()
+
+
+def _csv_ints(name: str) -> tuple[int, ...]:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return ()
+    values: list[int] = []
+    for part in raw.split(","):
+        token = part.strip()
+        if not token:
+            raise ValueError(f"{name} contains an empty value")
+        try:
+            values.append(int(token))
+        except ValueError as exc:
+            raise ValueError(f"{name} must contain integers") from exc
+    return tuple(values)
+
+
+def _env_nonnegative_int(name: str) -> int:
+    raw = os.getenv(name, "0").strip()
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+    if value < 0:
+        raise ValueError(f"{name} must be >= 0")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeCasinoConfig:
+    level_thresholds_points: tuple[int, ...] = ()
+    roulette_bet_weight: int = 0
+    roulette_player_weight: int = 0
+    jackpot_500_weight: int = 0
+    jackpot_1000_weight: int = 0
+    fortune_thresholds_xp: tuple[int, ...] = ()
+
+    def __post_init__(self) -> None:
+        if self.level_thresholds_points and len(self.level_thresholds_points) != 4:
+            raise ValueError("casino level thresholds must contain exactly 4 values")
+        previous = -1
+        for value in self.level_thresholds_points:
+            if int(value) <= 0 or int(value) <= previous:
+                raise ValueError(
+                    "casino level thresholds must be positive and strictly increasing"
+                )
+            previous = int(value)
+        for value in (
+            self.roulette_bet_weight,
+            self.roulette_player_weight,
+            self.jackpot_500_weight,
+            self.jackpot_1000_weight,
+        ):
+            if int(value) < 0:
+                raise ValueError("casino prestige weights must be >= 0")
+        if self.fortune_thresholds_xp and len(self.fortune_thresholds_xp) != 4:
+            raise ValueError("casino fortune thresholds must contain exactly 4 values")
+        previous_fortune: int | None = None
+        for value in self.fortune_thresholds_xp:
+            current = int(value)
+            if previous_fortune is not None and current <= previous_fortune:
+                raise ValueError("casino fortune thresholds must be strictly increasing")
+            previous_fortune = current
+
+    @classmethod
+    def from_env(cls) -> "RefugeCasinoConfig":
+        return cls(
+            level_thresholds_points=_csv_ints(
+                "REFUGE_CASINO_LEVEL_THRESHOLDS_POINTS"
+            ),
+            roulette_bet_weight=_env_nonnegative_int(
+                "REFUGE_CASINO_ROULETTE_BET_WEIGHT"
+            ),
+            roulette_player_weight=_env_nonnegative_int(
+                "REFUGE_CASINO_ROULETTE_PLAYER_WEIGHT"
+            ),
+            jackpot_500_weight=_env_nonnegative_int(
+                "REFUGE_CASINO_JACKPOT_500_WEIGHT"
+            ),
+            jackpot_1000_weight=_env_nonnegative_int(
+                "REFUGE_CASINO_JACKPOT_1000_WEIGHT"
+            ),
+            fortune_thresholds_xp=_csv_ints(
+                "REFUGE_CASINO_FORTUNE_THRESHOLDS_XP"
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CasinoSourceSnapshot:
+    roulette_bet_count: int = 0
+    roulette_unique_players: int = 0
+    roulette_wagered_xp: int = 0
+    roulette_winnings_xp: int = 0
+
+    @property
+    def roulette_house_net_xp(self) -> int:
+        return self.roulette_wagered_xp - self.roulette_winnings_xp
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeCasinoStatus:
+    state: RefugeWorldState
+    level: int
+    level_name: str
+    prestige_points: int
+    fortune: str
+    fortune_name: str
+    is_open: bool
+    roulette_bet_count: int
+    roulette_unique_players: int
+    roulette_lifetime_house_net_xp: int
+    recent_house_net_xp: int
+    recent_transactions: int
+    tracking_started_at: str | None
+    last_jackpot: Mapping[str, Any] | None
+    changed: bool
+    render_signature: str
+
+
+def casino_level_name(level: int) -> str:
+    normalized = max(1, min(CASINO_MAX_LEVEL, int(level)))
+    return CASINO_LEVEL_NAMES[normalized]
+
+
+def casino_is_open(at: datetime | None = None) -> bool:
+    current = at or datetime.now(PARIS_TZ)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=PARIS_TZ)
+    local = current.astimezone(PARIS_TZ)
+    hour = local.hour
+    if CASINO_OPEN_HOUR < CASINO_CLOSE_HOUR:
+        return CASINO_OPEN_HOUR <= hour < CASINO_CLOSE_HOUR
+    return hour >= CASINO_OPEN_HOUR or hour < CASINO_CLOSE_HOUR
+
+
+def casino_fortune_for_net(
+    net_xp: int,
+    *,
+    transactions: int,
+    thresholds: tuple[int, ...] = (),
+) -> str:
+    net = int(net_xp)
+    if thresholds:
+        if len(thresholds) != 4:
+            raise ValueError("casino fortune thresholds must contain 4 values")
+        a, b, c, d = (int(value) for value in thresholds)
+        if net < a:
+            return "ruined"
+        if net < b:
+            return "difficulty"
+        if net < c:
+            return "stable"
+        if net < d:
+            return "prosperous"
+        return "insolent"
+
+    # Without calibrated magnitude thresholds, only the sign of an actually
+    # observed recent net can be interpreted safely. Extreme states remain
+    # unavailable until explicit thresholds are configured.
+    if int(transactions) <= 0 or net == 0:
+        return "stable"
+    return "prosperous" if net > 0 else "difficulty"
+
+
+def casino_source_snapshot(raw: Any) -> CasinoSourceSnapshot:
+    if not isinstance(raw, dict):
+        return CasinoSourceSnapshot()
+    players = raw.get("players", {})
+    if not isinstance(players, dict):
+        players = {}
+    bet_count = 0
+    unique_players = 0
+    for payload in players.values():
+        if not isinstance(payload, dict):
+            continue
+        try:
+            bets = max(0, int(payload.get("bets", 0)))
+        except (TypeError, ValueError):
+            bets = 0
+        bet_count += bets
+        if bets > 0:
+            unique_players += 1
+    try:
+        wagered = max(0, int(raw.get("total_bets", 0)))
+    except (TypeError, ValueError):
+        wagered = 0
+    try:
+        winnings = max(0, int(raw.get("total_winnings", 0)))
+    except (TypeError, ValueError):
+        winnings = 0
+    return CasinoSourceSnapshot(
+        roulette_bet_count=bet_count,
+        roulette_unique_players=unique_players,
+        roulette_wagered_xp=wagered,
+        roulette_winnings_xp=winnings,
+    )
+
+
+def casino_prestige_points(
+    source: CasinoSourceSnapshot,
+    activity_snapshot: Mapping[str, Any],
+    config: RefugeCasinoConfig,
+) -> int:
+    totals = activity_snapshot.get("totals", {})
+    if not isinstance(totals, Mapping):
+        totals = {}
+    try:
+        jackpot_500 = max(0, int(totals.get("jackpots_500", 0)))
+        jackpot_1000 = max(0, int(totals.get("jackpots_1000", 0)))
+    except (TypeError, ValueError):
+        jackpot_500 = 0
+        jackpot_1000 = 0
+    return (
+        source.roulette_bet_count * int(config.roulette_bet_weight)
+        + source.roulette_unique_players * int(config.roulette_player_weight)
+        + jackpot_500 * int(config.jackpot_500_weight)
+        + jackpot_1000 * int(config.jackpot_1000_weight)
+    )
+
+
+def _casino_building(state: RefugeWorldState) -> RefugeBuildingState | None:
+    return next(
+        (
+            building
+            for building in state.buildings
+            if building.building_id == CASINO_BUILDING_ID
+        ),
+        None,
+    )
+
+
+def _replace_building(
+    state: RefugeWorldState,
+    building: RefugeBuildingState,
+) -> RefugeWorldState:
+    buildings = {item.building_id: item for item in state.buildings}
+    buildings[building.building_id] = building
+    return replace(
+        state,
+        buildings=tuple(sorted(buildings.values(), key=lambda item: item.building_id)),
+    )
+
+
+def _string_list(value: Any, *, allowed: Mapping[str, str]) -> list[str]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return []
+    return sorted({str(item) for item in value if str(item) in allowed})
+
+
+class RefugeCasinoService:
+    """Project existing casino evidence into permanent Refuge world state."""
+
+    def __init__(
+        self,
+        *,
+        activity_store: RefugeCasinoActivityStore = refuge_casino_activity_store,
+        world_service: RefugeWorldService = refuge_world_service,
+        state_file: str | Path = CASINO_STATE_FILE,
+    ) -> None:
+        self.activity_store = activity_store
+        self.world_service = world_service
+        self.world_store = world_service.store
+        self.state_file = Path(state_file)
+        self._lock = asyncio.Lock()
+
+    async def _source_snapshot(self) -> CasinoSourceSnapshot:
+        raw = await asyncio.to_thread(read_json_safe, self.state_file, {})
+        return casino_source_snapshot(raw)
+
+    async def evaluate(
+        self,
+        *,
+        config: RefugeCasinoConfig | None = None,
+        at: datetime | None = None,
+    ) -> RefugeCasinoStatus:
+        casino_config = config or RefugeCasinoConfig.from_env()
+        async with self._lock:
+            return await self._evaluate_locked(config=casino_config, at=at)
+
+    async def _evaluate_locked(
+        self,
+        *,
+        config: RefugeCasinoConfig,
+        at: datetime | None,
+    ) -> RefugeCasinoStatus:
+        source = await self._source_snapshot()
+        activity = await self.activity_store.initialize(at=at)
+        recent = await self.activity_store.get_recent_totals(
+            window_seconds=CASINO_RECENT_WINDOW_SECONDS,
+            at=at,
+        )
+        prestige = casino_prestige_points(source, activity, config)
+        progression = await self.world_service.evaluate(
+            metrics={CASINO_METRIC_KEY: prestige},
+            rules=(
+                BuildingProgressionRule(
+                    building_id=CASINO_BUILDING_ID,
+                    metric_key=CASINO_METRIC_KEY,
+                    thresholds=config.level_thresholds_points,
+                    minimum_level=1,
+                    event_from_level=2,
+                ),
+            ),
+            at=at,
+        )
+        state = progression.state
+        building = _casino_building(state)
+        if building is None:
+            raise RuntimeError("Refuge Casino progression did not create a building")
+
+        recent_net = (
+            int(recent.get("roulette_wagered_xp", 0))
+            - int(recent.get("roulette_payout_xp", 0))
+            - int(recent.get("machine_payout_xp", 0))
+        )
+        recent_transactions = max(0, int(recent.get("transactions", 0)))
+        fortune = casino_fortune_for_net(
+            recent_net,
+            transactions=recent_transactions,
+            thresholds=config.fortune_thresholds_xp,
+        )
+        open_now = casino_is_open(at)
+
+        events = list(state.events)
+        event_ids = {event.event_id for event in events}
+        raw_jackpots = activity.get("jackpots", [])
+        jackpots = [dict(item) for item in raw_jackpots if isinstance(item, dict)]
+        jackpots.sort(
+            key=lambda item: (
+                str(item.get("occurred_at", "")),
+                str(item.get("event_id", "")),
+            )
+        )
+        imported_jackpot = False
+        for item in jackpots:
+            source_event_id = str(item.get("event_id", "")).strip()
+            if not source_event_id:
+                continue
+            event_id = f"casino:jackpot:{source_event_id}"
+            if event_id in event_ids:
+                continue
+            try:
+                tier = int(item.get("tier", 0))
+                user_id = int(item.get("user_id", 0))
+                applied_xp = max(0, int(item.get("applied_xp", 0)))
+            except (TypeError, ValueError):
+                continue
+            if tier not in {500, 1000}:
+                continue
+            events.append(
+                RefugeHistoricalEvent(
+                    event_id=event_id,
+                    event_type="casino_jackpot_observed",
+                    occurred_at=str(item.get("occurred_at") or _utc_iso(at)),
+                    data={
+                        "building_id": CASINO_BUILDING_ID,
+                        "tier": tier,
+                        "user_id": user_id,
+                        "applied_xp": applied_xp,
+                    },
+                )
+            )
+            event_ids.add(event_id)
+            imported_jackpot = True
+
+        building_state = dict(building.state)
+        desired = {
+            "fortune": fortune,
+            "is_open": open_now,
+            "casino_events": _string_list(
+                building_state.get("casino_events", ()),
+                allowed=CASINO_EVENTS,
+            ),
+            "secret_events": _string_list(
+                building_state.get("secret_events", ()),
+                allowed=CASINO_SECRET_EVENTS,
+            ),
+        }
+        last_jackpot: dict[str, Any] | None = jackpots[-1] if jackpots else None
+        if last_jackpot is not None:
+            try:
+                desired["last_jackpot"] = {
+                    "tier": int(last_jackpot.get("tier", 0)),
+                    "occurred_at": str(last_jackpot.get("occurred_at", "")),
+                }
+            except (TypeError, ValueError):
+                last_jackpot = None
+        elif isinstance(building_state.get("last_jackpot"), Mapping):
+            desired["last_jackpot"] = dict(building_state["last_jackpot"])
+
+        state_changed = progression.changed or imported_jackpot
+        if any(building_state.get(key) != value for key, value in desired.items()):
+            building_state.update(desired)
+            building = replace(building, state=building_state)
+            state = _replace_building(state, building)
+            state_changed = True
+        if imported_jackpot:
+            state = replace(state, events=tuple(events))
+
+        if state_changed:
+            state = await self.world_store.save_state(state)
+
+        tracking_started = activity.get("tracking_started_at")
+        return RefugeCasinoStatus(
+            state=state,
+            level=max(1, min(CASINO_MAX_LEVEL, int(building.level))),
+            level_name=casino_level_name(building.level),
+            prestige_points=prestige,
+            fortune=fortune,
+            fortune_name=CASINO_FORTUNE_NAMES[fortune],
+            is_open=open_now,
+            roulette_bet_count=source.roulette_bet_count,
+            roulette_unique_players=source.roulette_unique_players,
+            roulette_lifetime_house_net_xp=source.roulette_house_net_xp,
+            recent_house_net_xp=recent_net,
+            recent_transactions=recent_transactions,
+            tracking_started_at=str(tracking_started) if tracking_started else None,
+            last_jackpot=last_jackpot,
+            changed=state_changed,
+            render_signature=world_render_signature(state),
+        )
+
+    async def _unlock_marker(
+        self,
+        marker_id: str,
+        *,
+        mapping: Mapping[str, str],
+        state_key: str,
+        event_type: str,
+        at: datetime | None,
+        config: RefugeCasinoConfig | None,
+    ) -> RefugeWorldState:
+        normalized = str(marker_id).strip()
+        if normalized not in mapping:
+            raise ValueError(f"unsupported Casino marker: {normalized}")
+        casino_config = config or RefugeCasinoConfig.from_env()
+        async with self._lock:
+            status = await self._evaluate_locked(config=casino_config, at=at)
+            state = status.state
+            building = _casino_building(state)
+            if building is None:
+                raise RuntimeError("Refuge Casino building is missing")
+            event_id = f"casino:{state_key}:{normalized}"
+            if any(event.event_id == event_id for event in state.events):
+                return state
+
+            building_state = dict(building.state)
+            values = set(
+                _string_list(building_state.get(state_key, ()), allowed=mapping)
+            )
+            values.add(normalized)
+            building_state[state_key] = sorted(values)
+            updated = _replace_building(
+                state,
+                replace(building, state=building_state),
+            )
+            updated = replace(
+                updated,
+                events=updated.events
+                + (
+                    RefugeHistoricalEvent(
+                        event_id=event_id,
+                        event_type=event_type,
+                        occurred_at=_utc_iso(at),
+                        data={
+                            "building_id": CASINO_BUILDING_ID,
+                            "marker_id": normalized,
+                            "name": mapping[normalized],
+                        },
+                    ),
+                ),
+            )
+            return await self.world_store.save_state(updated)
+
+    async def unlock_event(
+        self,
+        event_id: str,
+        *,
+        at: datetime | None = None,
+        config: RefugeCasinoConfig | None = None,
+    ) -> RefugeWorldState:
+        return await self._unlock_marker(
+            event_id,
+            mapping=CASINO_EVENTS,
+            state_key="casino_events",
+            event_type="casino_event_discovered",
+            at=at,
+            config=config,
+        )
+
+    async def unlock_secret(
+        self,
+        secret_id: str,
+        *,
+        at: datetime | None = None,
+        config: RefugeCasinoConfig | None = None,
+    ) -> RefugeWorldState:
+        return await self._unlock_marker(
+            secret_id,
+            mapping=CASINO_SECRET_EVENTS,
+            state_key="secret_events",
+            event_type="casino_secret_discovered",
+            at=at,
+            config=config,
+        )
+
+
+refuge_casino_service = RefugeCasinoService()
+
+
+__all__ = [
+    "CASINO_BUILDING_ID",
+    "CASINO_EVENTS",
+    "CASINO_FORTUNE_NAMES",
+    "CASINO_LEVEL_NAMES",
+    "CASINO_MAX_LEVEL",
+    "CASINO_RECENT_WINDOW_SECONDS",
+    "CASINO_SECRET_EVENTS",
+    "CasinoSourceSnapshot",
+    "RefugeCasinoConfig",
+    "RefugeCasinoService",
+    "RefugeCasinoStatus",
+    "casino_fortune_for_net",
+    "casino_is_open",
+    "casino_level_name",
+    "casino_prestige_points",
+    "casino_source_snapshot",
+    "refuge_casino_service",
+]

--- a/storage/refuge_casino_activity_store.py
+++ b/storage/refuge_casino_activity_store.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import weakref
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from config import DATA_DIR
+from utils.persistence import atomic_write_json_async, read_json_safe
+
+
+REFUGE_CASINO_ACTIVITY_SCHEMA_VERSION = 1
+REFUGE_CASINO_ACTIVITY_FILE = Path(DATA_DIR) / "refuge_casino_activity.json"
+RECENT_RETENTION_SECONDS = 48 * 60 * 60
+
+
+def _aware_utc(at: datetime | None = None) -> datetime:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
+
+
+def _minute_key(at: datetime) -> str:
+    return at.replace(second=0, microsecond=0).isoformat()
+
+
+def _empty_data() -> dict[str, Any]:
+    return {
+        "schema_version": REFUGE_CASINO_ACTIVITY_SCHEMA_VERSION,
+        "tracking_started_at": None,
+        "totals": {
+            "roulette_wagered_xp": 0,
+            "roulette_payout_xp": 0,
+            "machine_payout_xp": 0,
+            "machine_xp_events": 0,
+            "jackpots_500": 0,
+            "jackpots_1000": 0,
+        },
+        "recent_buckets": {},
+        "jackpots": [],
+    }
+
+
+class RefugeCasinoActivitySchemaError(RuntimeError):
+    pass
+
+
+class RefugeCasinoActivityStore:
+    """Prospective Refuge-only observation of concrete casino XP flows."""
+
+    def __init__(self, path: str | Path = REFUGE_CASINO_ACTIVITY_FILE) -> None:
+        self.path = Path(path)
+        self._loaded = False
+        self._data: dict[str, Any] = _empty_data()
+        self._locks: weakref.WeakKeyDictionary[
+            asyncio.AbstractEventLoop, asyncio.Lock
+        ] = weakref.WeakKeyDictionary()
+
+    def _get_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[loop] = lock
+        return lock
+
+    async def _load_locked(self) -> None:
+        if self._loaded:
+            return
+        raw = await asyncio.to_thread(read_json_safe, self.path, {})
+        data = _empty_data()
+        if isinstance(raw, dict) and raw:
+            try:
+                schema = int(raw.get("schema_version", 0))
+            except (TypeError, ValueError):
+                schema = 0
+            if schema != REFUGE_CASINO_ACTIVITY_SCHEMA_VERSION:
+                raise RefugeCasinoActivitySchemaError(
+                    f"unsupported Refuge casino activity schema: {schema}"
+                )
+            started = raw.get("tracking_started_at")
+            if started:
+                data["tracking_started_at"] = str(started)
+            raw_totals = raw.get("totals", {})
+            if isinstance(raw_totals, dict):
+                totals = data["totals"]
+                for key in totals:
+                    try:
+                        totals[key] = max(0, int(raw_totals.get(key, 0)))
+                    except (TypeError, ValueError):
+                        totals[key] = 0
+            raw_buckets = raw.get("recent_buckets", {})
+            if isinstance(raw_buckets, dict):
+                for key, payload in raw_buckets.items():
+                    if not isinstance(payload, dict):
+                        continue
+                    bucket: dict[str, int] = {}
+                    for field in (
+                        "roulette_wagered_xp",
+                        "roulette_payout_xp",
+                        "machine_payout_xp",
+                        "transactions",
+                    ):
+                        try:
+                            bucket[field] = max(0, int(payload.get(field, 0)))
+                        except (TypeError, ValueError):
+                            bucket[field] = 0
+                    data["recent_buckets"][str(key)] = bucket
+            raw_jackpots = raw.get("jackpots", [])
+            if isinstance(raw_jackpots, list):
+                data["jackpots"] = [
+                    dict(item) for item in raw_jackpots if isinstance(item, dict)
+                ]
+        self._data = data
+        self._loaded = True
+
+    def _prune_locked(self, now: datetime) -> None:
+        cutoff = now - timedelta(seconds=RECENT_RETENTION_SECONDS)
+        buckets = self._data["recent_buckets"]
+        for key in list(buckets):
+            try:
+                moment = datetime.fromisoformat(str(key))
+                if moment.tzinfo is None:
+                    moment = moment.replace(tzinfo=timezone.utc)
+            except ValueError:
+                buckets.pop(key, None)
+                continue
+            if moment.astimezone(timezone.utc) < cutoff:
+                buckets.pop(key, None)
+
+    async def initialize(self, *, at: datetime | None = None) -> dict[str, Any]:
+        now = _aware_utc(at)
+        async with self._get_lock():
+            await self._load_locked()
+            changed = False
+            if not self._data.get("tracking_started_at"):
+                self._data["tracking_started_at"] = now.isoformat()
+                changed = True
+            self._prune_locked(now)
+            if changed:
+                await atomic_write_json_async(self.path, self._data)
+            return copy.deepcopy(self._data)
+
+    async def record_transaction(
+        self,
+        *,
+        user_id: int,
+        source: str,
+        requested_amount: int,
+        applied_delta: int,
+        at: datetime | None = None,
+    ) -> None:
+        """Record only successful concrete XP movements from existing casino code."""
+
+        normalized_source = str(source).strip()
+        if normalized_source not in {"pari_xp", "machine_a_sous"}:
+            return
+        now = _aware_utc(at)
+        async with self._get_lock():
+            await self._load_locked()
+            if not self._data.get("tracking_started_at"):
+                self._data["tracking_started_at"] = now.isoformat()
+            self._prune_locked(now)
+            totals = self._data["totals"]
+            bucket = self._data["recent_buckets"].setdefault(
+                _minute_key(now),
+                {
+                    "roulette_wagered_xp": 0,
+                    "roulette_payout_xp": 0,
+                    "machine_payout_xp": 0,
+                    "transactions": 0,
+                },
+            )
+            bucket["transactions"] = int(bucket.get("transactions", 0)) + 1
+
+            if normalized_source == "pari_xp":
+                if applied_delta < 0:
+                    value = -int(applied_delta)
+                    totals["roulette_wagered_xp"] += value
+                    bucket["roulette_wagered_xp"] += value
+                elif applied_delta > 0:
+                    value = int(applied_delta)
+                    totals["roulette_payout_xp"] += value
+                    bucket["roulette_payout_xp"] += value
+            else:
+                totals["machine_xp_events"] += 1
+                if applied_delta > 0:
+                    value = int(applied_delta)
+                    totals["machine_payout_xp"] += value
+                    bucket["machine_payout_xp"] += value
+                nominal = int(requested_amount)
+                if nominal in {500, 1000}:
+                    counter = f"jackpots_{nominal}"
+                    totals[counter] += 1
+                    event_id = (
+                        f"machine:{nominal}:{int(user_id)}:"
+                        f"{int(now.timestamp() * 1_000_000)}"
+                    )
+                    self._data["jackpots"].append(
+                        {
+                            "event_id": event_id,
+                            "user_id": int(user_id),
+                            "tier": nominal,
+                            "nominal_xp": nominal,
+                            "applied_xp": max(0, int(applied_delta)),
+                            "occurred_at": now.isoformat(),
+                        }
+                    )
+
+            await atomic_write_json_async(self.path, self._data)
+
+    async def get_snapshot(self, *, at: datetime | None = None) -> dict[str, Any]:
+        now = _aware_utc(at)
+        async with self._get_lock():
+            await self._load_locked()
+            self._prune_locked(now)
+            return copy.deepcopy(self._data)
+
+    async def get_recent_totals(
+        self,
+        *,
+        window_seconds: int = 24 * 60 * 60,
+        at: datetime | None = None,
+    ) -> dict[str, int]:
+        now = _aware_utc(at)
+        cutoff = now - timedelta(seconds=max(1, int(window_seconds)))
+        totals = {
+            "roulette_wagered_xp": 0,
+            "roulette_payout_xp": 0,
+            "machine_payout_xp": 0,
+            "transactions": 0,
+        }
+        async with self._get_lock():
+            await self._load_locked()
+            self._prune_locked(now)
+            for key, payload in self._data["recent_buckets"].items():
+                try:
+                    moment = datetime.fromisoformat(str(key))
+                    if moment.tzinfo is None:
+                        moment = moment.replace(tzinfo=timezone.utc)
+                    moment = moment.astimezone(timezone.utc)
+                except ValueError:
+                    continue
+                if moment < cutoff or moment > now:
+                    continue
+                for field in totals:
+                    totals[field] += max(0, int(payload.get(field, 0)))
+        return totals
+
+
+refuge_casino_activity_store = RefugeCasinoActivityStore()
+
+
+__all__ = [
+    "RECENT_RETENTION_SECONDS",
+    "REFUGE_CASINO_ACTIVITY_FILE",
+    "REFUGE_CASINO_ACTIVITY_SCHEMA_VERSION",
+    "RefugeCasinoActivitySchemaError",
+    "RefugeCasinoActivityStore",
+    "refuge_casino_activity_store",
+]

--- a/tests/test_refuge_casino.py
+++ b/tests/test_refuge_casino.py
@@ -1,0 +1,351 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services.refuge_casino import (
+    CASINO_EVENTS,
+    CASINO_LEVEL_NAMES,
+    CASINO_SECRET_EVENTS,
+    CasinoSourceSnapshot,
+    RefugeCasinoConfig,
+    RefugeCasinoService,
+    casino_fortune_for_net,
+    casino_prestige_points,
+    casino_source_snapshot,
+)
+from services.refuge_world import RefugeWorldService
+from storage.refuge_casino_activity_store import RefugeCasinoActivityStore
+from storage.refuge_world_store import RefugeWorldStore
+
+
+def _casino_building(state):
+    return next(
+        building for building in state.buildings if building.building_id == "casino"
+    )
+
+
+def _service(tmp_path, *, raw_state=None):
+    state_file = tmp_path / "pari_xp_state.json"
+    state_file.write_text(json.dumps(raw_state or {}), encoding="utf-8")
+    activity = RefugeCasinoActivityStore(tmp_path / "refuge_casino_activity.json")
+    world_store = RefugeWorldStore(tmp_path / "refuge_world.json")
+    world_service = RefugeWorldService(world_store)
+    casino = RefugeCasinoService(
+        activity_store=activity,
+        world_service=world_service,
+        state_file=state_file,
+    )
+    return state_file, activity, world_store, casino
+
+
+def test_casino_level_names_are_the_five_validated_names():
+    assert CASINO_LEVEL_NAMES == {
+        1: "Baraque de Jeux",
+        2: "Comptoir Chanceux",
+        3: "Casino du Refuge",
+        4: "Palais du Hasard",
+        5: "Maison Éternelle",
+    }
+
+
+def test_casino_config_has_no_production_progression_by_default():
+    config = RefugeCasinoConfig()
+    assert config.level_thresholds_points == ()
+    assert config.roulette_bet_weight == 0
+    assert config.roulette_player_weight == 0
+    assert config.jackpot_500_weight == 0
+    assert config.jackpot_1000_weight == 0
+    assert config.fortune_thresholds_xp == ()
+
+    with pytest.raises(ValueError):
+        RefugeCasinoConfig(level_thresholds_points=(1, 2))
+    with pytest.raises(ValueError):
+        RefugeCasinoConfig(level_thresholds_points=(10, 10, 20, 30))
+    with pytest.raises(ValueError):
+        RefugeCasinoConfig(roulette_bet_weight=-1)
+    with pytest.raises(ValueError):
+        RefugeCasinoConfig(fortune_thresholds_xp=(-100, 0, 0, 100))
+
+
+def test_casino_config_reads_only_explicit_environment_values(monkeypatch):
+    monkeypatch.setenv("REFUGE_CASINO_LEVEL_THRESHOLDS_POINTS", "10,30,60,100")
+    monkeypatch.setenv("REFUGE_CASINO_ROULETTE_BET_WEIGHT", "2")
+    monkeypatch.setenv("REFUGE_CASINO_ROULETTE_PLAYER_WEIGHT", "5")
+    monkeypatch.setenv("REFUGE_CASINO_JACKPOT_500_WEIGHT", "20")
+    monkeypatch.setenv("REFUGE_CASINO_JACKPOT_1000_WEIGHT", "50")
+    monkeypatch.setenv("REFUGE_CASINO_FORTUNE_THRESHOLDS_XP", "-500,-50,50,500")
+
+    config = RefugeCasinoConfig.from_env()
+
+    assert config.level_thresholds_points == (10, 30, 60, 100)
+    assert config.roulette_bet_weight == 2
+    assert config.roulette_player_weight == 5
+    assert config.jackpot_500_weight == 20
+    assert config.jackpot_1000_weight == 50
+    assert config.fortune_thresholds_xp == (-500, -50, 50, 500)
+
+
+def test_casino_source_snapshot_uses_existing_roulette_counters_only():
+    snapshot = casino_source_snapshot(
+        {
+            "total_bets": 900,
+            "total_winnings": 650,
+            "players": {
+                "1": {"bets": 2, "wagered": 300, "winnings": 200},
+                "2": {"bets": 4, "wagered": 600, "winnings": 450},
+                "3": {"bets": 0},
+            },
+        }
+    )
+
+    assert snapshot.roulette_bet_count == 6
+    assert snapshot.roulette_unique_players == 2
+    assert snapshot.roulette_wagered_xp == 900
+    assert snapshot.roulette_winnings_xp == 650
+    assert snapshot.roulette_house_net_xp == 250
+
+
+@pytest.mark.parametrize(
+    ("net", "transactions", "expected"),
+    [
+        (-1, 1, "difficulty"),
+        (0, 0, "stable"),
+        (0, 3, "stable"),
+        (1, 1, "prosperous"),
+    ],
+)
+def test_uncalibrated_fortune_uses_only_sign(net, transactions, expected):
+    assert casino_fortune_for_net(
+        net,
+        transactions=transactions,
+        thresholds=(),
+    ) == expected
+
+
+@pytest.mark.parametrize(
+    ("net", "expected"),
+    [
+        (-501, "ruined"),
+        (-500, "difficulty"),
+        (-50, "stable"),
+        (50, "prosperous"),
+        (500, "insolent"),
+    ],
+)
+def test_calibrated_fortune_supports_all_five_states(net, expected):
+    assert casino_fortune_for_net(
+        net,
+        transactions=1,
+        thresholds=(-500, -50, 50, 500),
+    ) == expected
+
+
+@pytest.mark.asyncio
+async def test_activity_store_records_concrete_flows_and_machine_jackpot(tmp_path):
+    store = RefugeCasinoActivityStore(tmp_path / "casino_activity.json")
+    at = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+
+    await store.record_transaction(
+        user_id=1,
+        source="pari_xp",
+        requested_amount=-100,
+        applied_delta=-100,
+        at=at,
+    )
+    await store.record_transaction(
+        user_id=1,
+        source="pari_xp",
+        requested_amount=200,
+        applied_delta=400,
+        at=at + timedelta(seconds=1),
+    )
+    await store.record_transaction(
+        user_id=2,
+        source="machine_a_sous",
+        requested_amount=500,
+        applied_delta=1000,
+        at=at + timedelta(seconds=2),
+    )
+
+    snapshot = await store.get_snapshot(at=at + timedelta(minutes=1))
+    recent = await store.get_recent_totals(at=at + timedelta(minutes=1))
+
+    assert snapshot["totals"]["roulette_wagered_xp"] == 100
+    assert snapshot["totals"]["roulette_payout_xp"] == 400
+    assert snapshot["totals"]["machine_payout_xp"] == 1000
+    assert snapshot["totals"]["jackpots_500"] == 1
+    assert snapshot["totals"]["jackpots_1000"] == 0
+    assert len(snapshot["jackpots"]) == 1
+    assert snapshot["jackpots"][0]["nominal_xp"] == 500
+    assert snapshot["jackpots"][0]["applied_xp"] == 1000
+    assert recent["roulette_wagered_xp"] == 100
+    assert recent["roulette_payout_xp"] == 400
+    assert recent["machine_payout_xp"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_recent_activity_expires_without_erasing_lifetime_totals(tmp_path):
+    store = RefugeCasinoActivityStore(tmp_path / "casino_activity.json")
+    at = datetime(2026, 8, 7, 12, 0, tzinfo=timezone.utc)
+    await store.record_transaction(
+        user_id=1,
+        source="pari_xp",
+        requested_amount=-100,
+        applied_delta=-100,
+        at=at,
+    )
+
+    recent = await store.get_recent_totals(at=at + timedelta(days=3))
+    snapshot = await store.get_snapshot(at=at + timedelta(days=3))
+
+    assert recent["transactions"] == 0
+    assert snapshot["totals"]["roulette_wagered_xp"] == 100
+
+
+def test_prestige_points_use_only_explicit_weights():
+    source = CasinoSourceSnapshot(
+        roulette_bet_count=10,
+        roulette_unique_players=3,
+        roulette_wagered_xp=1000,
+        roulette_winnings_xp=800,
+    )
+    activity = {
+        "totals": {
+            "jackpots_500": 2,
+            "jackpots_1000": 1,
+        }
+    }
+
+    assert casino_prestige_points(source, activity, RefugeCasinoConfig()) == 0
+    assert casino_prestige_points(
+        source,
+        activity,
+        RefugeCasinoConfig(
+            roulette_bet_weight=2,
+            roulette_player_weight=5,
+            jackpot_500_weight=20,
+            jackpot_1000_weight=50,
+        ),
+    ) == 125
+
+
+@pytest.mark.asyncio
+async def test_casino_starts_level_one_and_fortune_uses_recent_exact_net(tmp_path):
+    raw = {
+        "total_bets": 1000,
+        "total_winnings": 800,
+        "players": {"1": {"bets": 10}},
+    }
+    _state_file, activity, _world_store, casino = _service(tmp_path, raw_state=raw)
+    at = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+    await activity.record_transaction(
+        user_id=1,
+        source="pari_xp",
+        requested_amount=-100,
+        applied_delta=-100,
+        at=at,
+    )
+    await activity.record_transaction(
+        user_id=1,
+        source="pari_xp",
+        requested_amount=200,
+        applied_delta=200,
+        at=at + timedelta(seconds=1),
+    )
+
+    status = await casino.evaluate(config=RefugeCasinoConfig(), at=at + timedelta(minutes=1))
+
+    assert status.level == 1
+    assert status.level_name == "Baraque de Jeux"
+    assert status.prestige_points == 0
+    assert status.roulette_lifetime_house_net_xp == 200
+    assert status.recent_house_net_xp == -100
+    assert status.fortune == "difficulty"
+    assert _casino_building(status.state).state["fortune"] == "difficulty"
+
+
+@pytest.mark.asyncio
+async def test_casino_reaches_level_five_and_never_regresses(tmp_path):
+    raw = {
+        "total_bets": 1000,
+        "total_winnings": 800,
+        "players": {"1": {"bets": 10}, "2": {"bets": 5}},
+    }
+    state_file, _activity, _world_store, casino = _service(tmp_path, raw_state=raw)
+    config = RefugeCasinoConfig(
+        level_thresholds_points=(5, 10, 20, 30),
+        roulette_bet_weight=2,
+        roulette_player_weight=5,
+    )
+    at = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+
+    first = await casino.evaluate(config=config, at=at)
+    state_file.write_text("{}", encoding="utf-8")
+    later = await casino.evaluate(config=config, at=at + timedelta(days=1))
+
+    assert first.level == 5
+    assert later.level == 5
+    level_events = [
+        event
+        for event in later.state.events
+        if event.event_type == "building_level_reached"
+        and event.data.get("building_id") == "casino"
+    ]
+    assert [event.data["level"] for event in level_events] == [2, 3, 4, 5]
+
+
+@pytest.mark.asyncio
+async def test_machine_jackpot_is_imported_to_world_history_once(tmp_path):
+    _state_file, activity, _world_store, casino = _service(tmp_path)
+    at = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+    await activity.record_transaction(
+        user_id=42,
+        source="machine_a_sous",
+        requested_amount=1000,
+        applied_delta=1000,
+        at=at,
+    )
+
+    first = await casino.evaluate(config=RefugeCasinoConfig(), at=at + timedelta(minutes=1))
+    second = await casino.evaluate(config=RefugeCasinoConfig(), at=at + timedelta(minutes=2))
+
+    matching = [
+        event for event in second.state.events
+        if event.event_type == "casino_jackpot_observed"
+    ]
+    assert len(matching) == 1
+    assert matching[0].data["tier"] == 1000
+    assert matching[0].data["user_id"] == 42
+    assert _casino_building(first.state).state["last_jackpot"]["tier"] == 1000
+
+
+@pytest.mark.asyncio
+async def test_casino_event_and_secret_unlock_are_idempotent(tmp_path):
+    _state_file, _activity, _world_store, casino = _service(tmp_path)
+    at = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+
+    await casino.unlock_event("grand_heist", at=at, config=RefugeCasinoConfig())
+    await casino.unlock_event("grand_heist", at=at + timedelta(minutes=1), config=RefugeCasinoConfig())
+    state = await casino.unlock_secret("black_cat", at=at, config=RefugeCasinoConfig())
+    state = await casino.unlock_secret("black_cat", at=at + timedelta(minutes=1), config=RefugeCasinoConfig())
+
+    building = _casino_building(state)
+    assert building.state["casino_events"] == ["grand_heist"]
+    assert building.state["secret_events"] == ["black_cat"]
+    assert len([event for event in state.events if event.event_id == "casino:casino_events:grand_heist"]) == 1
+    assert len([event for event in state.events if event.event_id == "casino:secret_events:black_cat"]) == 1
+    assert CASINO_EVENTS["grand_heist"] == "Le Grand Braquage"
+    assert CASINO_SECRET_EVENTS["black_cat"] == "Le Chat Noir"
+
+
+@pytest.mark.asyncio
+async def test_unknown_casino_markers_are_rejected(tmp_path):
+    _state_file, _activity, _world_store, casino = _service(tmp_path)
+    with pytest.raises(ValueError):
+        await casino.unlock_event("unknown")
+    with pytest.raises(ValueError):
+        await casino.unlock_secret("unknown")

--- a/tests/test_refuge_casino_observer.py
+++ b/tests/test_refuge_casino_observer.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from utils import xp_adapter
+
+
+@pytest.mark.asyncio
+async def test_xp_adapter_observes_successful_roulette_spend_without_changing_amount(monkeypatch):
+    calls = []
+
+    async def fake_spend(user_id, amount, *, guild_id=None, source="spend"):
+        assert user_id == 7
+        assert amount == 125
+        assert guild_id == 99
+        assert source == "pari_xp"
+        return True
+
+    monkeypatch.setattr(xp_adapter.xp_store, "try_spend_xp", fake_spend)
+    monkeypatch.setattr(
+        xp_adapter,
+        "observe_casino_xp_transaction",
+        lambda **payload: calls.append(payload),
+    )
+
+    await xp_adapter.add_xp(7, -125, 99, "pari_xp")
+
+    assert calls == [
+        {
+            "user_id": 7,
+            "source": "pari_xp",
+            "requested_amount": -125,
+            "applied_delta": -125,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_award_xp_preserves_nominal_machine_jackpot_when_double_xp_applies(monkeypatch):
+    from cogs import xp as xp_cog
+
+    calls = []
+    store_amounts = []
+    now = datetime.now(timezone.utc)
+
+    async def fake_add_xp(user_id, amount, *, guild_id=None, source="manual"):
+        store_amounts.append(amount)
+        return 1, 2, 100, 100 + amount
+
+    async def fake_season_record(*args, **kwargs):
+        return None
+
+    monkeypatch.setitem(xp_cog.XP_BOOSTS, "42", now + timedelta(hours=1))
+    monkeypatch.setattr(xp_cog.xp_store, "add_xp", fake_add_xp)
+    monkeypatch.setattr(xp_cog.season_store, "record", fake_season_record)
+    monkeypatch.setattr(
+        xp_cog,
+        "observe_casino_xp_transaction",
+        lambda **payload: calls.append(payload),
+    )
+
+    result = await xp_cog.award_xp(
+        42,
+        500,
+        guild_id=99,
+        source="machine_a_sous",
+    )
+
+    assert store_amounts == [1000]
+    assert result == (1, 2, 100, 1100)
+    assert len(calls) == 1
+    assert calls[0]["user_id"] == 42
+    assert calls[0]["source"] == "machine_a_sous"
+    assert calls[0]["requested_amount"] == 500
+    assert calls[0]["applied_delta"] == 1000
+    assert calls[0]["at"].tzinfo is not None

--- a/tests/test_refuge_casino_renderer.py
+++ b/tests/test_refuge_casino_renderer.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import hashlib
+import io
+
+import pytest
+from PIL import Image
+
+from models.refuge_world import RefugeBuildingState, RefugeWorldState
+from rendering.refuge_casino import RefugeCasinoRenderer, casino_scene_signature
+from rendering.refuge_world import REFUGE_CANVAS_SIZE, RefugeRenderContext
+
+
+CONTEXT = RefugeRenderContext(season="summer", daypart="night")
+
+
+def _state(
+    *,
+    level: int,
+    fortune: str = "stable",
+    is_open: bool = True,
+    jackpot_tier: int | None = None,
+    events: tuple[str, ...] = (),
+    secrets: tuple[str, ...] = (),
+) -> RefugeWorldState:
+    state = {
+        "fortune": fortune,
+        "is_open": is_open,
+        "casino_events": list(events),
+        "secret_events": list(secrets),
+    }
+    if jackpot_tier is not None:
+        state["last_jackpot"] = {
+            "tier": jackpot_tier,
+            "occurred_at": "2026-08-09T12:00:00+00:00",
+        }
+    return RefugeWorldState(
+        buildings=(
+            RefugeBuildingState(
+                building_id="casino",
+                level=level,
+                unlocked_at="2026-08-09T12:00:00+00:00",
+                state=state,
+            ),
+        ),
+    )
+
+
+def _digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def test_casino_renderer_produces_expected_png_dimensions():
+    payload = RefugeCasinoRenderer().render_png(_state(level=1), context=CONTEXT)
+    image = Image.open(io.BytesIO(payload))
+    assert image.size == REFUGE_CANVAS_SIZE
+    assert image.mode == "RGB"
+
+
+def test_all_five_casino_levels_have_distinct_silhouettes():
+    renderer = RefugeCasinoRenderer()
+    digests = {
+        _digest(renderer.render_png(_state(level=level), context=CONTEXT))
+        for level in range(1, 6)
+    }
+    assert len(digests) == 5
+
+
+def test_all_five_fortune_states_change_the_visual():
+    renderer = RefugeCasinoRenderer()
+    digests = {
+        _digest(
+            renderer.render_png(
+                _state(level=5, fortune=fortune),
+                context=CONTEXT,
+            )
+        )
+        for fortune in (
+            "ruined",
+            "difficulty",
+            "stable",
+            "prosperous",
+            "insolent",
+        )
+    }
+    assert len(digests) == 5
+
+
+def test_open_and_closed_casino_have_distinct_lighting():
+    renderer = RefugeCasinoRenderer()
+    opened = renderer.render_png(
+        _state(level=3, is_open=True),
+        context=CONTEXT,
+    )
+    closed = renderer.render_png(
+        _state(level=3, is_open=False),
+        context=CONTEXT,
+    )
+    assert opened != closed
+
+
+@pytest.mark.parametrize("tier", [500, 1000])
+def test_jackpot_tiers_leave_visual_trace(tier):
+    renderer = RefugeCasinoRenderer()
+    base = renderer.render_png(_state(level=3), context=CONTEXT)
+    jackpot = renderer.render_png(
+        _state(level=3, jackpot_tier=tier),
+        context=CONTEXT,
+    )
+    assert jackpot != base
+
+
+@pytest.mark.parametrize(
+    "event_id",
+    ["grand_heist", "black_night", "break_in", "house_always_wins"],
+)
+def test_each_casino_event_adds_a_visual_trace(event_id):
+    renderer = RefugeCasinoRenderer()
+    base = renderer.render_png(_state(level=4), context=CONTEXT)
+    discovered = renderer.render_png(
+        _state(level=4, events=(event_id,)),
+        context=CONTEXT,
+    )
+    assert discovered != base
+
+
+@pytest.mark.parametrize(
+    "secret_id",
+    ["black_cat", "diamond", "ghost_player"],
+)
+def test_each_casino_secret_adds_a_visual_trace(secret_id):
+    renderer = RefugeCasinoRenderer()
+    base = renderer.render_png(_state(level=4), context=CONTEXT)
+    discovered = renderer.render_png(
+        _state(level=4, secrets=(secret_id,)),
+        context=CONTEXT,
+    )
+    assert discovered != base
+
+
+def test_casino_renderer_is_byte_deterministic():
+    renderer = RefugeCasinoRenderer()
+    state = _state(
+        level=5,
+        fortune="insolent",
+        is_open=True,
+        jackpot_tier=1000,
+        events=("grand_heist", "house_always_wins"),
+        secrets=("black_cat", "diamond", "ghost_player"),
+    )
+    first = renderer.render_png(state, context=CONTEXT)
+    second = renderer.render_png(state, context=CONTEXT)
+    assert first == second
+
+
+def test_casino_scene_signature_tracks_visual_state():
+    base = casino_scene_signature(_state(level=2), CONTEXT)
+    level = casino_scene_signature(_state(level=3), CONTEXT)
+    fortune = casino_scene_signature(
+        _state(level=2, fortune="prosperous"),
+        CONTEXT,
+    )
+    closed = casino_scene_signature(
+        _state(level=2, is_open=False),
+        CONTEXT,
+    )
+    jackpot = casino_scene_signature(
+        _state(level=2, jackpot_tier=1000),
+        CONTEXT,
+    )
+    assert len({base, level, fortune, closed, jackpot}) == 5
+
+
+@pytest.mark.asyncio
+async def test_casino_async_renderer_matches_sync_renderer():
+    renderer = RefugeCasinoRenderer()
+    state = _state(level=3, fortune="prosperous")
+    expected = renderer.render_png(state, context=CONTEXT)
+    actual = await renderer.render_png_async(state, context=CONTEXT)
+    assert actual == expected

--- a/utils/refuge_casino_observer.py
+++ b/utils/refuge_casino_observer.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+
+from storage.refuge_casino_activity_store import refuge_casino_activity_store
+
+
+logger = logging.getLogger(__name__)
+_CASINO_SOURCES = frozenset({"pari_xp", "machine_a_sous"})
+
+
+async def _record(
+    *,
+    user_id: int,
+    source: str,
+    requested_amount: int,
+    applied_delta: int,
+    at: datetime | None,
+) -> None:
+    try:
+        await refuge_casino_activity_store.record_transaction(
+            user_id=user_id,
+            source=source,
+            requested_amount=requested_amount,
+            applied_delta=applied_delta,
+            at=at,
+        )
+    except Exception:
+        logger.exception(
+            "[refuge] casino XP observation failed for source=%s user=%s",
+            source,
+            user_id,
+        )
+
+
+def observe_casino_xp_transaction(
+    *,
+    user_id: int,
+    source: str,
+    requested_amount: int,
+    applied_delta: int,
+    at: datetime | None = None,
+) -> None:
+    """Schedule best-effort Refuge observation without blocking XP logic."""
+
+    normalized = str(source).strip()
+    if normalized not in _CASINO_SOURCES:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    loop.create_task(
+        _record(
+            user_id=int(user_id),
+            source=normalized,
+            requested_amount=int(requested_amount),
+            applied_delta=int(applied_delta),
+            at=at,
+        )
+    )
+
+
+__all__ = ["observe_casino_xp_transaction"]

--- a/utils/xp_adapter.py
+++ b/utils/xp_adapter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from storage.xp_store import xp_store
 from utils.persistence import read_json_safe
+from utils.refuge_casino_observer import observe_casino_xp_transaction
 
 
 class InsufficientXPError(ValueError):
@@ -56,9 +57,27 @@ async def add_xp(user_id: int, amount: int, guild_id: int, source: str) -> None:
             raise InsufficientXPError(
                 f"user {user_id} cannot spend {-amount} XP"
             )
+        observe_casino_xp_transaction(
+            user_id=user_id,
+            source=source,
+            requested_amount=amount,
+            applied_delta=amount,
+        )
         return
 
-    await xp_store.add_xp(user_id, amount, guild_id=guild_id, source=source)
+    result = await xp_store.add_xp(
+        user_id,
+        amount,
+        guild_id=guild_id,
+        source=source,
+    )
+    _old_level, _new_level, old_xp, new_xp = result
+    observe_casino_xp_transaction(
+        user_id=user_id,
+        source=source,
+        requested_amount=amount,
+        applied_delta=new_xp - old_xp,
+    )
 
 
 __all__ = ["InsufficientXPError", "get_balance", "add_xp"]


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-007 — Casino vivant** : transformer les données casino existantes en Prestige permanent + Fortune dynamique et ajouter la couche graphique Casino, sans modifier aucune probabilité, récompense, mise, multiplicateur, ticket ou règle économique.

## Audit des sources casino
Toutes les sources existantes ont été contrôlées avant agrégation :

### `pari_xp_state.json` — roulette XP
Source historique exploitable :
- `total_bets` = XP misés cumulés ;
- `total_winnings` = gains nominaux cumulés ;
- `players.*.bets` = nombre de paris ;
- `players.*.wagered` / `winnings` = cumuls individuels ;
- dernier gagnant et état ouvert/fermé opérationnel.

### `season_stats.json`
Ne contient que des deltas prospectifs de **roulette XP** dérivés de `pari_xp_state.json`. Il ne couvre pas la machine à sous.

### `roulette.json`
Store opérationnel de la machine à sous : poster, claims quotidiens, tickets et rôles jackpot 24 h. Il ne conserve ni historique complet des spins ni gains 500/1000 de façon durable.

### XP store
Le store XP persiste les soldes, mais ne conserve pas un journal historique par `source`. Il ne permet donc pas de reconstruire a posteriori les flux `machine_a_sous` ou les 24 dernières heures.

Conclusion : les métriques 24 h globales et les jackpots machine historiques sont **irrécupérables rétroactivement**. REFUGE-007 introduit donc un suivi prospectif minimal, comme REFUGE-002 l’avait fait pour le vocal communautaire.

## Observation XP non intrusive
Nouveau `refuge_casino_activity.json` :
- schéma versionné 1 ;
- début de tracking persistant ;
- flux concrets roulette : XP débités / crédités ;
- flux concrets machine : XP réellement crédités ;
- détection des jackpots machine **500 / 1000 XP nominaux** ;
- conservation séparée du montant nominal et du delta réellement appliqué (ex. Double XP) ;
- buckets UTC par minute, rétention 48 h pour calculer une fenêtre 24 h ;
- jackpots conservés comme événements source persistants.

Les hooks sont placés **après** une transaction XP réussie :
- `utils/xp_adapter.py` observe les dépenses roulette ;
- `cogs/xp.py::award_xp` observe les crédits `pari_xp` / `machine_a_sous`.

`utils/refuge_casino_observer.py` filtre strictement ces deux sources et lance l’écriture en tâche best-effort. Une erreur Refuge est loggée et ne peut jamais faire échouer la transaction XP d’origine.

Aucune ligne de hasard, `REWARDS`, `WEIGHTS`, règle de ticket ou multiplicateur n’est modifiée.

## Prestige permanent
5 niveaux :
1. **Baraque de Jeux**
2. **Comptoir Chanceux**
3. **Casino du Refuge**
4. **Palais du Hasard**
5. **Maison Éternelle**

Le Prestige passe par REFUGE-003 et ne peut jamais régresser.

Aucun seuil/poids de production n’est activé par défaut. Configuration prévue :
- `REFUGE_CASINO_LEVEL_THRESHOLDS_POINTS` ;
- `REFUGE_CASINO_ROULETTE_BET_WEIGHT` ;
- `REFUGE_CASINO_ROULETTE_PLAYER_WEIGHT` ;
- `REFUGE_CASINO_JACKPOT_500_WEIGHT` ;
- `REFUGE_CASINO_JACKPOT_1000_WEIGHT`.

Les seules valeurs non nulles présentes dans les tests sont des fixtures.

## Fortune dynamique
États validés :
- `Ruiné` ;
- `En difficulté` ;
- `Stable` ;
- `Prospère` ;
- `Insolent`.

La Fortune utilise le **net maison observé sur les dernières 24 h** :
`roulette_wagered - roulette_payout - machine_concrete_payout`.

Cela compte uniquement les flux XP réellement quantifiables. Tickets et Double XP futur ne reçoivent aucune valorisation arbitraire.

`REFUGE_CASINO_FORTUNE_THRESHOLDS_XP` accepte 4 seuils croissants. Sans calibration :
- aucune transaction / net 0 → `Stable` ;
- net négatif → `En difficulté` ;
- net positif → `Prospère` ;
- `Ruiné` / `Insolent` restent indisponibles jusqu’à calibration explicite.

## Ouvert / fermé
Le service réutilise directement `CASINO_OPEN_HOUR`, `CASINO_CLOSE_HOUR` et Europe/Paris, donc le rendu reflète la même plage que la roulette et la machine existantes.

## Histoire et événements
Les jackpots machine observés 500/1000 sont importés idempotemment dans `RefugeWorldState.events` et la dernière trace devient visible sur le bâtiment.

Événements Casino persistables/rendables :
- **Le Grand Braquage** ;
- **La Nuit Noire** ;
- **Le Casse** ;
- **La Maison gagne toujours**.

Secrets persistables/rendables :
- **Le Chat Noir** ;
- **Le Diamant** ;
- **Le Joueur Fantôme**.

Comme pour Feu/Hall, leurs conditions automatiques restent réservées à **REFUGE-012**.

## Renderer
Nouveau `RefugeCasinoRenderer` :
`terrain → Feu → Hall → Casino`.

- 1280×720 ;
- 5 silhouettes permanentes ;
- éclairage réel ouvert/fermé ;
- apparence liée aux 5 fortunes ;
- traces jackpots, événements et secrets ;
- variations saison/jour-nuit héritées ;
- déterministe ;
- wrapper async hors event loop.

## Fichiers
- `storage/refuge_casino_activity_store.py` — nouveau ;
- `utils/refuge_casino_observer.py` — nouveau ;
- `services/refuge_casino.py` — nouveau ;
- `rendering/refuge_casino.py` — nouveau ;
- `rendering/__init__.py` — export Casino ;
- `utils/xp_adapter.py` — observation post-dépense ;
- `cogs/xp.py` — observation post-crédit uniquement ;
- `tests/test_refuge_casino.py` — nouveau ;
- `tests/test_refuge_casino_renderer.py` — nouveau ;
- `tests/test_refuge_casino_observer.py` — nouveau.

## Hors périmètre / invariants
Aucune modification de :
- `_draw_number_for_roll` ;
- probabilités roulette ;
- multiplicateurs x2/x10 ;
- min/max des mises ;
- `REWARDS` / `WEIGHTS` machine à sous ;
- tickets et priorités de tickets ;
- tentative quotidienne ;
- règles de jackpot ;
- attribution XP finale ;
- Hall / Feu ;
- Chantier ;
- Components V2 ;
- panneau public Discord.

## Validation en cours
Le diff contre `main` confirme notamment `cogs/xp.py` : **9 ajouts / 0 suppression**.

Des tests ciblés ont été ajoutés pour :
- absence de calibrage arbitraire ;
- lecture des cumuls roulette ;
- flux XP prospectifs ;
- Double XP : jackpot nominal conservé / delta réel observé ;
- Fortune 3 états sans seuils + 5 états configurés ;
- progression I→V avec fixtures et non-régression ;
- import jackpot idempotent ;
- événements/secrets idempotents ;
- 5 silhouettes, 5 fortunes, ouvert/fermé, jackpots, événements/secrets ;
- déterminisme et rendu async.

La suite complète pytest n’est pas encore déclarée comme passée. La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.