### PR TITLE
feat: add the Refuge public V2 panel

### DIFF
--- a/cogs/refuge_panel.py
+++ b/cogs/refuge_panel.py
@@ -58,6 +58,20 @@ def panel_refresh_action(
     return "none"
 
 
+def panel_reference_needs_retirement(
+    panel: RefugePanelState,
+    *,
+    target_channel_id: int,
+) -> bool:
+    """Whether a stored Refuge panel points at another configured channel."""
+
+    return (
+        panel.channel_id is not None
+        and panel.message_id is not None
+        and panel.channel_id != int(target_channel_id)
+    )
+
+
 class RefugePanelCog(commands.Cog):
     """Maintain exactly one low-churn public panel for the living Refuge."""
 
@@ -111,6 +125,47 @@ class RefugePanelCog(commands.Cog):
             return None
         return channel
 
+    async def _retire_previous_panel_if_moved(
+        self,
+        *,
+        target_channel_id: int,
+    ) -> None:
+        """Best-effort removal of the previously owned panel after channel moves."""
+
+        state = await self.world_store.get_state()
+        panel = state.panel
+        if not panel_reference_needs_retirement(
+            panel,
+            target_channel_id=target_channel_id,
+        ):
+            return
+
+        assert panel.channel_id is not None
+        assert panel.message_id is not None
+        old_channel = self.bot.get_channel(panel.channel_id)
+        if old_channel is None:
+            try:
+                old_channel = await self.bot.fetch_channel(panel.channel_id)
+            except discord.HTTPException:
+                logger.warning(
+                    "[refuge] Ancien salon du panneau inaccessible: %s",
+                    panel.channel_id,
+                )
+                return
+        if not isinstance(old_channel, (discord.TextChannel, discord.Thread)):
+            return
+        try:
+            old_message = await old_channel.fetch_message(panel.message_id)
+            await old_message.delete()
+        except discord.NotFound:
+            return
+        except discord.HTTPException:
+            logger.warning(
+                "[refuge] Impossible de retirer l'ancien panneau %s/%s",
+                panel.channel_id,
+                panel.message_id,
+            )
+
     async def _fetch_stored_message(
         self,
         channel: discord.TextChannel | discord.Thread,
@@ -156,6 +211,9 @@ class RefugePanelCog(commands.Cog):
             if channel is None:
                 return
 
+            await self._retire_previous_panel_if_moved(
+                target_channel_id=channel.id,
+            )
             message = await self._fetch_stored_message(channel)
             snapshot = await self.panel_service.evaluate()
             action = panel_refresh_action(
@@ -230,5 +288,6 @@ __all__ = [
     "REFUGE_PANEL_CHANNEL_ID",
     "REFUGE_PANEL_REFRESH_SECONDS",
     "RefugePanelCog",
+    "panel_reference_needs_retirement",
     "panel_refresh_action",
 ]

--- a/cogs/refuge_panel.py
+++ b/cogs/refuge_panel.py
@@ -1,0 +1,234 @@
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import os
+from dataclasses import replace
+
+import discord
+from discord.ext import commands, tasks
+
+from models.refuge_world import RefugePanelState
+from services.refuge_panel import RefugePanelService, refuge_panel_service
+from storage.refuge_world_store import RefugeWorldStore, refuge_world_store
+from ui.refuge_panel_view import (
+    REFUGE_MAP_FILENAME,
+    RefugePublicControlsView,
+    RefugePublicPanelView,
+)
+from utils.discord_utils import safe_message_edit
+
+
+logger = logging.getLogger(__name__)
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except ValueError:
+        return default
+
+
+REFUGE_PANEL_CHANNEL_ID = max(0, _env_int("REFUGE_PANEL_CHANNEL_ID", 0))
+REFUGE_PANEL_REFRESH_SECONDS = max(
+    30,
+    _env_int("REFUGE_PANEL_REFRESH_SECONDS", 60),
+)
+
+
+def panel_refresh_action(
+    *,
+    message_exists: bool,
+    previous_visual_signature: str | None,
+    previous_summary_signature: str | None,
+    visual_signature: str,
+    summary_signature: str,
+) -> str:
+    """Return create/render/summary/none without performing Discord I/O."""
+
+    if not message_exists:
+        return "create"
+    if previous_visual_signature is None or previous_summary_signature is None:
+        return "render"
+    if previous_visual_signature != visual_signature:
+        return "render"
+    if previous_summary_signature != summary_signature:
+        return "summary"
+    return "none"
+
+
+class RefugePanelCog(commands.Cog):
+    """Maintain exactly one low-churn public panel for the living Refuge."""
+
+    def __init__(
+        self,
+        bot: commands.Bot,
+        *,
+        panel_service: RefugePanelService = refuge_panel_service,
+        world_store: RefugeWorldStore = refuge_world_store,
+    ) -> None:
+        self.bot = bot
+        self.panel_service = panel_service
+        self.world_store = world_store
+        self._refresh_lock = asyncio.Lock()
+        self._last_visual_signature: str | None = None
+        self._last_summary_signature: str | None = None
+
+    async def cog_load(self) -> None:
+        if not getattr(self.bot, "_refuge_public_controls_added", False):
+            self.bot.add_view(RefugePublicControlsView())
+            self.bot._refuge_public_controls_added = True  # type: ignore[attr-defined]
+
+        if REFUGE_PANEL_CHANNEL_ID <= 0:
+            logger.info(
+                "[refuge] Panneau public désactivé: REFUGE_PANEL_CHANNEL_ID=0"
+            )
+            return
+        self.refresh_panel.change_interval(seconds=REFUGE_PANEL_REFRESH_SECONDS)
+        if not self.refresh_panel.is_running():
+            self.refresh_panel.start()
+
+    def cog_unload(self) -> None:
+        self.refresh_panel.cancel()
+
+    async def _resolve_channel(self) -> discord.TextChannel | discord.Thread | None:
+        channel = self.bot.get_channel(REFUGE_PANEL_CHANNEL_ID)
+        if channel is None:
+            try:
+                channel = await self.bot.fetch_channel(REFUGE_PANEL_CHANNEL_ID)
+            except discord.HTTPException:
+                logger.warning(
+                    "[refuge] Salon du panneau introuvable: %s",
+                    REFUGE_PANEL_CHANNEL_ID,
+                )
+                return None
+        if not isinstance(channel, (discord.TextChannel, discord.Thread)):
+            logger.warning(
+                "[refuge] REFUGE_PANEL_CHANNEL_ID=%s n'est pas un salon texte/thread",
+                REFUGE_PANEL_CHANNEL_ID,
+            )
+            return None
+        return channel
+
+    async def _fetch_stored_message(
+        self,
+        channel: discord.TextChannel | discord.Thread,
+    ) -> discord.Message | None:
+        state = await self.world_store.get_state()
+        panel = state.panel
+        if panel.channel_id != channel.id or panel.message_id is None:
+            return None
+        try:
+            return await channel.fetch_message(panel.message_id)
+        except discord.NotFound:
+            return None
+        except discord.HTTPException:
+            logger.warning(
+                "[refuge] Impossible de récupérer le panneau %s/%s",
+                channel.id,
+                panel.message_id,
+            )
+            return None
+
+    async def _persist_panel_reference(self, message: discord.Message) -> None:
+        state = await self.world_store.get_state()
+        desired = RefugePanelState(
+            channel_id=message.channel.id,
+            message_id=message.id,
+        )
+        if state.panel == desired:
+            return
+        await self.world_store.save_state(replace(state, panel=desired))
+
+    async def _render_file(self, snapshot) -> discord.File:
+        png = await self.panel_service.render_png(snapshot)
+        return discord.File(
+            io.BytesIO(png),
+            filename=REFUGE_MAP_FILENAME,
+        )
+
+    async def ensure_panel(self) -> None:
+        if REFUGE_PANEL_CHANNEL_ID <= 0:
+            return
+        async with self._refresh_lock:
+            channel = await self._resolve_channel()
+            if channel is None:
+                return
+
+            message = await self._fetch_stored_message(channel)
+            snapshot = await self.panel_service.evaluate()
+            action = panel_refresh_action(
+                message_exists=message is not None,
+                previous_visual_signature=self._last_visual_signature,
+                previous_summary_signature=self._last_summary_signature,
+                visual_signature=snapshot.visual_signature,
+                summary_signature=snapshot.summary_signature,
+            )
+
+            if action == "none":
+                return
+
+            view = RefugePublicPanelView(snapshot)
+            if action == "create":
+                file = await self._render_file(snapshot)
+                try:
+                    message = await channel.send(file=file, view=view)
+                except discord.HTTPException:
+                    logger.exception("[refuge] Échec création du panneau public")
+                    return
+                await self._persist_panel_reference(message)
+            elif action == "render":
+                assert message is not None
+                file = await self._render_file(snapshot)
+                try:
+                    edited = await safe_message_edit(
+                        message,
+                        attachments=[file],
+                        view=view,
+                    )
+                except discord.HTTPException:
+                    logger.exception("[refuge] Échec mise à jour graphique du panneau")
+                    return
+                if edited is not None:
+                    message = edited
+            else:
+                assert action == "summary"
+                assert message is not None
+                try:
+                    edited = await safe_message_edit(message, view=view)
+                except discord.HTTPException:
+                    logger.exception("[refuge] Échec mise à jour du résumé du panneau")
+                    return
+                if edited is not None:
+                    message = edited
+
+            self._last_visual_signature = snapshot.visual_signature
+            self._last_summary_signature = snapshot.summary_signature
+            if message is not None:
+                await self._persist_panel_reference(message)
+
+    @tasks.loop(seconds=60)
+    async def refresh_panel(self) -> None:
+        try:
+            await self.ensure_panel()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("[refuge] Rafraîchissement du panneau public échoué")
+
+    @refresh_panel.before_loop
+    async def before_refresh_panel(self) -> None:
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RefugePanelCog(bot))
+
+
+__all__ = [
+    "REFUGE_PANEL_CHANNEL_ID",
+    "REFUGE_PANEL_REFRESH_SECONDS",
+    "RefugePanelCog",
+    "panel_refresh_action",
+]

--- a/services/refuge_panel.py
+++ b/services/refuge_panel.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Final, Mapping
+
+from models.refuge_world import RefugeHistoricalEvent, RefugeWorldState
+from rendering.refuge_casino import (
+    RefugeCasinoRenderer,
+    casino_scene_signature,
+    refuge_casino_renderer,
+)
+from rendering.refuge_world import RefugeRenderContext
+from services.refuge_casino import RefugeCasinoService, refuge_casino_service
+from services.refuge_fire import RefugeFireService, refuge_fire_service
+from services.refuge_hall import RefugeHallService, refuge_hall_service
+from utils.seasons import season_id_for, season_label
+
+
+_FIRE_INTENSITY_NAMES: Final[Mapping[str, str]] = {
+    "low": "Calme",
+    "normal": "Vivant",
+    "high": "Ardent",
+}
+_CONSTRUCTION_STATUS_NAMES: Final[Mapping[str, str]] = {
+    "open": "Vote en cours",
+    "voting": "Vote en cours",
+    "tie_break": "Départage en cours",
+    "building": "Construction en cours",
+    "constructing": "Construction en cours",
+    "completed": "Inauguration prête",
+    "complete": "Inauguration prête",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RefugePanelSnapshot:
+    state: RefugeWorldState
+    context: RefugeRenderContext
+    season_id: str
+    season_label: str
+    fire_level: int
+    fire_name: str
+    fire_intensity: str
+    fire_intensity_name: str
+    hall_level: int
+    hall_name: str
+    casino_level: int
+    casino_name: str
+    casino_fortune: str
+    casino_fortune_name: str
+    casino_is_open: bool
+    construction_label: str
+    latest_event_id: str | None
+    latest_event_label: str | None
+    visual_signature: str
+    summary_signature: str
+    changed: bool
+
+
+def _aware_utc(at: datetime | None = None) -> datetime:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
+
+
+def construction_label(state: RefugeWorldState) -> str:
+    construction = state.active_construction
+    if construction is None:
+        return "Aucun chantier actif"
+
+    raw_name = construction.data.get("project_name") or construction.data.get("name")
+    project_name = str(raw_name).strip() if raw_name else ""
+    status = _CONSTRUCTION_STATUS_NAMES.get(
+        str(construction.status).strip().lower(),
+        "Chantier actif",
+    )
+    return f"{status} · {project_name}" if project_name else status
+
+
+def _event_timestamp(event: RefugeHistoricalEvent) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(str(event.occurred_at).replace("Z", "+00:00"))
+    except ValueError:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def latest_event(state: RefugeWorldState) -> RefugeHistoricalEvent | None:
+    if not state.events:
+        return None
+    return max(
+        state.events,
+        key=lambda event: (_event_timestamp(event), event.event_id),
+    )
+
+
+def event_label(event: RefugeHistoricalEvent | None) -> str | None:
+    if event is None:
+        return None
+    explicit_name = event.data.get("name")
+    if explicit_name:
+        return str(explicit_name)
+
+    if event.event_type == "building_level_reached":
+        building = str(event.data.get("building_id", "")).strip()
+        level = event.data.get("level")
+        labels = {
+            "fire": "Le Feu",
+            "hall": "Le Hall",
+            "casino": "Le Casino",
+        }
+        subject = labels.get(building, "Le Refuge")
+        try:
+            return f"{subject} a atteint le niveau {int(level)}"
+        except (TypeError, ValueError):
+            return f"{subject} a évolué"
+
+    if event.event_type == "casino_jackpot_observed":
+        try:
+            tier = int(event.data.get("tier", 0))
+        except (TypeError, ValueError):
+            tier = 0
+        return f"Jackpot machine à sous · {tier} XP" if tier else "Jackpot au Casino"
+
+    if event.event_type == "hall_gallery_marker":
+        return "Une nouvelle trace est entrée au Hall"
+    if event.event_type.endswith("secret_discovered"):
+        return "Un mystère du Refuge a été découvert"
+    return "Un nouvel événement a marqué le Refuge"
+
+
+def _summary_signature(payload: Mapping[str, object]) -> str:
+    canonical = json.dumps(
+        dict(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+class RefugePanelService:
+    """Orchestrate current Refuge systems for one public read model."""
+
+    def __init__(
+        self,
+        *,
+        fire_service: RefugeFireService = refuge_fire_service,
+        hall_service: RefugeHallService = refuge_hall_service,
+        casino_service: RefugeCasinoService = refuge_casino_service,
+        renderer: RefugeCasinoRenderer = refuge_casino_renderer,
+    ) -> None:
+        self.fire_service = fire_service
+        self.hall_service = hall_service
+        self.casino_service = casino_service
+        self.renderer = renderer
+        self._lock = asyncio.Lock()
+
+    async def evaluate(self, *, at: datetime | None = None) -> RefugePanelSnapshot:
+        now = _aware_utc(at)
+        async with self._lock:
+            # Sequential evaluation is intentional: all three services share
+            # RefugeWorldStore and each stage must observe the previous write.
+            fire = await self.fire_service.evaluate(at=now)
+            hall = await self.hall_service.evaluate(at=now)
+            casino = await self.casino_service.evaluate(at=now)
+
+            state = casino.state
+            context = RefugeRenderContext.from_datetime(now)
+            current_season = season_id_for(now)
+            last_event = latest_event(state)
+            last_event_label = event_label(last_event)
+            build_label = construction_label(state)
+            fire_intensity_name = _FIRE_INTENSITY_NAMES.get(
+                fire.intensity,
+                fire.intensity.capitalize(),
+            )
+            visual_signature = casino_scene_signature(state, context)
+            summary_payload = {
+                "season_id": current_season,
+                "fire_level": fire.level,
+                "fire_name": fire.level_name,
+                "fire_intensity": fire.intensity,
+                "hall_level": hall.level,
+                "hall_name": hall.level_name,
+                "casino_level": casino.level,
+                "casino_name": casino.level_name,
+                "casino_fortune": casino.fortune,
+                "casino_open": casino.is_open,
+                "construction": build_label,
+                "latest_event_id": last_event.event_id if last_event else None,
+            }
+
+            return RefugePanelSnapshot(
+                state=state,
+                context=context,
+                season_id=current_season,
+                season_label=season_label(current_season),
+                fire_level=fire.level,
+                fire_name=fire.level_name,
+                fire_intensity=fire.intensity,
+                fire_intensity_name=fire_intensity_name,
+                hall_level=hall.level,
+                hall_name=hall.level_name,
+                casino_level=casino.level,
+                casino_name=casino.level_name,
+                casino_fortune=casino.fortune,
+                casino_fortune_name=casino.fortune_name,
+                casino_is_open=casino.is_open,
+                construction_label=build_label,
+                latest_event_id=last_event.event_id if last_event else None,
+                latest_event_label=last_event_label,
+                visual_signature=visual_signature,
+                summary_signature=_summary_signature(summary_payload),
+                changed=bool(fire.changed or hall.changed or casino.changed),
+            )
+
+    async def render_png(self, snapshot: RefugePanelSnapshot) -> bytes:
+        return await self.renderer.render_png_async(
+            snapshot.state,
+            context=snapshot.context,
+        )
+
+
+refuge_panel_service = RefugePanelService()
+
+
+__all__ = [
+    "RefugePanelService",
+    "RefugePanelSnapshot",
+    "construction_label",
+    "event_label",
+    "latest_event",
+    "refuge_panel_service",
+]

--- a/tests/test_refuge_panel_cog.py
+++ b/tests/test_refuge_panel_cog.py
@@ -1,0 +1,51 @@
+from cogs.refuge_panel import panel_refresh_action
+
+
+def test_refresh_creates_when_message_is_missing():
+    assert panel_refresh_action(
+        message_exists=False,
+        previous_visual_signature="v1",
+        previous_summary_signature="s1",
+        visual_signature="v1",
+        summary_signature="s1",
+    ) == "create"
+
+
+def test_first_observation_after_restart_forces_render_refresh():
+    assert panel_refresh_action(
+        message_exists=True,
+        previous_visual_signature=None,
+        previous_summary_signature=None,
+        visual_signature="v1",
+        summary_signature="s1",
+    ) == "render"
+
+
+def test_visual_change_requires_rerender():
+    assert panel_refresh_action(
+        message_exists=True,
+        previous_visual_signature="v1",
+        previous_summary_signature="s1",
+        visual_signature="v2",
+        summary_signature="s1",
+    ) == "render"
+
+
+def test_summary_only_change_reuses_attachment():
+    assert panel_refresh_action(
+        message_exists=True,
+        previous_visual_signature="v1",
+        previous_summary_signature="s1",
+        visual_signature="v1",
+        summary_signature="s2",
+    ) == "summary"
+
+
+def test_identical_state_does_nothing():
+    assert panel_refresh_action(
+        message_exists=True,
+        previous_visual_signature="v1",
+        previous_summary_signature="s1",
+        visual_signature="v1",
+        summary_signature="s1",
+    ) == "none"

--- a/tests/test_refuge_panel_cog.py
+++ b/tests/test_refuge_panel_cog.py
@@ -1,4 +1,8 @@
-from cogs.refuge_panel import panel_refresh_action
+from cogs.refuge_panel import (
+    panel_reference_needs_retirement,
+    panel_refresh_action,
+)
+from models.refuge_world import RefugePanelState
 
 
 def test_refresh_creates_when_message_is_missing():
@@ -49,3 +53,13 @@ def test_identical_state_does_nothing():
         visual_signature="v1",
         summary_signature="s1",
     ) == "none"
+
+
+def test_panel_reference_is_retired_only_when_configured_channel_moves():
+    panel = RefugePanelState(channel_id=123, message_id=456)
+    assert panel_reference_needs_retirement(panel, target_channel_id=789) is True
+    assert panel_reference_needs_retirement(panel, target_channel_id=123) is False
+    assert panel_reference_needs_retirement(
+        RefugePanelState(channel_id=123, message_id=None),
+        target_channel_id=789,
+    ) is False

--- a/tests/test_refuge_panel_service.py
+++ b/tests/test_refuge_panel_service.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from models.refuge_world import (
+    RefugeConstructionState,
+    RefugeHistoricalEvent,
+    RefugeWorldState,
+)
+from services.refuge_panel import (
+    RefugePanelService,
+    construction_label,
+    event_label,
+    latest_event,
+)
+
+
+class _Service:
+    def __init__(self, status):
+        self.status = status
+        self.calls = []
+
+    async def evaluate(self, *, at=None):
+        self.calls.append(at)
+        return self.status
+
+
+class _Renderer:
+    def __init__(self):
+        self.calls = []
+
+    async def render_png_async(self, state, *, context=None):
+        self.calls.append((state, context))
+        return b"PNG"
+
+
+def _status(state, **kwargs):
+    defaults = {
+        "state": state,
+        "level": 1,
+        "level_name": "Niveau I",
+        "changed": False,
+    }
+    defaults.update(kwargs)
+    return SimpleNamespace(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_panel_service_evaluates_systems_sequentially_and_builds_snapshot():
+    at = datetime(2026, 8, 9, 14, 0, tzinfo=timezone.utc)
+    base = RefugeWorldState(created_at="2026-08-09T00:00:00+00:00")
+    fire_state = replace(base, state={"stage": "fire"})
+    hall_state = replace(base, state={"stage": "hall"})
+    final_state = replace(base, state={"stage": "casino"})
+
+    fire = _Service(
+        _status(
+            fire_state,
+            level=2,
+            level_name="Le Campement",
+            intensity="normal",
+            changed=True,
+        )
+    )
+    hall = _Service(
+        _status(
+            hall_state,
+            level=3,
+            level_name="Hall des Légendes",
+        )
+    )
+    casino = _Service(
+        _status(
+            final_state,
+            level=1,
+            level_name="Baraque de Jeux",
+            fortune="stable",
+            fortune_name="Stable",
+            is_open=True,
+        )
+    )
+    renderer = _Renderer()
+    service = RefugePanelService(
+        fire_service=fire,
+        hall_service=hall,
+        casino_service=casino,
+        renderer=renderer,
+    )
+
+    snapshot = await service.evaluate(at=at)
+
+    assert snapshot.state == final_state
+    assert snapshot.season_id == "2026-08"
+    assert snapshot.season_label == "Août 2026"
+    assert snapshot.fire_level == 2
+    assert snapshot.fire_intensity_name == "Vivant"
+    assert snapshot.hall_level == 3
+    assert snapshot.casino_fortune_name == "Stable"
+    assert snapshot.casino_is_open is True
+    assert snapshot.construction_label == "Aucun chantier actif"
+    assert snapshot.changed is True
+    assert len(fire.calls) == len(hall.calls) == len(casino.calls) == 1
+    assert fire.calls[0] == hall.calls[0] == casino.calls[0]
+
+    assert await service.render_png(snapshot) == b"PNG"
+    assert renderer.calls[0][0] == final_state
+    assert renderer.calls[0][1] == snapshot.context
+
+
+def test_construction_label_prefers_persisted_project_name():
+    state = RefugeWorldState(
+        active_construction=RefugeConstructionState(
+            construction_id="build-1",
+            status="building",
+            project_id="observatory",
+            data={"project_name": "Observatoire"},
+        )
+    )
+    assert construction_label(state) == "Construction en cours · Observatoire"
+
+
+def test_latest_event_and_labels_are_deterministic():
+    early = RefugeHistoricalEvent(
+        event_id="first",
+        event_type="hall_gallery_marker",
+        occurred_at="2026-08-09T10:00:00+00:00",
+    )
+    late = RefugeHistoricalEvent(
+        event_id="second",
+        event_type="casino_jackpot_observed",
+        occurred_at="2026-08-09T11:00:00+00:00",
+        data={"tier": 1000},
+    )
+    state = RefugeWorldState(events=(late, early))
+    selected = latest_event(state)
+    assert selected == late
+    assert event_label(selected) == "Jackpot machine à sous · 1000 XP"
+
+
+def test_explicit_event_name_wins_over_generic_copy():
+    event = RefugeHistoricalEvent(
+        event_id="secret",
+        event_type="casino_secret_discovered",
+        occurred_at="2026-08-09T11:00:00+00:00",
+        data={"name": "Le Chat Noir"},
+    )
+    assert event_label(event) == "Le Chat Noir"

--- a/tests/test_refuge_panel_view.py
+++ b/tests/test_refuge_panel_view.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import discord
+
+from models.refuge_world import RefugeWorldState
+from rendering.refuge_world import RefugeRenderContext
+from services.refuge_panel import RefugePanelSnapshot
+from ui.refuge_panel_view import (
+    REFUGE_MAP_FILENAME,
+    RefugePendingActionView,
+    RefugePublicControlsView,
+    RefugePublicPanelView,
+)
+
+
+def _snapshot() -> RefugePanelSnapshot:
+    return RefugePanelSnapshot(
+        state=RefugeWorldState(),
+        context=RefugeRenderContext(season="summer", daypart="day"),
+        season_id="2026-08",
+        season_label="Août 2026",
+        fire_level=1,
+        fire_name="L’Étincelle",
+        fire_intensity="normal",
+        fire_intensity_name="Vivant",
+        hall_level=1,
+        hall_name="Cabane des Souvenirs",
+        casino_level=1,
+        casino_name="Baraque de Jeux",
+        casino_fortune="stable",
+        casino_fortune_name="Stable",
+        casino_is_open=True,
+        construction_label="Aucun chantier actif",
+        latest_event_id=None,
+        latest_event_label=None,
+        visual_signature="visual",
+        summary_signature="summary",
+        changed=False,
+    )
+
+
+def _buttons(view):
+    return [item for item in view.walk_children() if isinstance(item, discord.ui.Button)]
+
+
+def test_public_panel_is_persistent_v2_with_one_four_button_row():
+    view = RefugePublicPanelView(_snapshot())
+    assert isinstance(view, discord.ui.LayoutView)
+    assert view.timeout is None
+    buttons = _buttons(view)
+    assert [button.label for button in buttons] == [
+        "Explorer",
+        "Mon empreinte",
+        "Chronologie",
+        "Chantier",
+    ]
+    assert [button.custom_id for button in buttons] == [
+        "refuge:panel:explore",
+        "refuge:panel:footprint",
+        "refuge:panel:timeline",
+        "refuge:panel:construction",
+    ]
+    rows = [item for item in view.walk_children() if isinstance(item, discord.ui.ActionRow)]
+    assert len(rows) == 1
+    assert len(rows[0].children) == 4
+
+
+def test_public_panel_uses_attachment_media_gallery():
+    view = RefugePublicPanelView(_snapshot())
+    galleries = [
+        item for item in view.walk_children() if isinstance(item, discord.ui.MediaGallery)
+    ]
+    assert len(galleries) == 1
+    assert len(galleries[0].items) == 1
+    assert galleries[0].items[0].media.url == f"attachment://{REFUGE_MAP_FILENAME}"
+
+
+def test_callback_registration_view_is_persistent_and_has_same_custom_ids():
+    public = RefugePublicPanelView(_snapshot())
+    controls = RefugePublicControlsView()
+    assert controls.timeout is None
+    assert controls.is_persistent()
+    assert [button.custom_id for button in _buttons(public)] == [
+        button.custom_id for button in _buttons(controls)
+    ]
+
+
+def test_pending_views_are_ephemeral_sized_layouts():
+    view = RefugePendingActionView("footprint")
+    assert isinstance(view, discord.ui.LayoutView)
+    assert view.timeout == 120
+    text = "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+    assert "Mon empreinte" in text
+    assert "privée" in text

--- a/ui/refuge_panel_view.py
+++ b/ui/refuge_panel_view.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from typing import Final, Literal
+
+import discord
+
+from services.refuge_panel import RefugePanelSnapshot
+
+
+REFUGE_PANEL_ACCENT = discord.Colour(0xD08A47)
+REFUGE_MAP_FILENAME: Final[str] = "refuge-map.png"
+RefugePanelAction = Literal["explore", "footprint", "timeline", "construction"]
+
+_ACTION_COPY: Final[dict[str, tuple[str, str, str]]] = {
+    "explore": (
+        "🔎 Explorer",
+        "L’exploration détaillée des lieux du Refuge sera activée dans la prochaine évolution.",
+        "Le panneau public est déjà prêt à accueillir cette navigation.",
+    ),
+    "footprint": (
+        "👤 Mon empreinte",
+        "Ton empreinte personnelle sera consultable ici dans une vue privée.",
+        "Elle ne sera jamais affichée publiquement sur le panneau du Refuge.",
+    ),
+    "timeline": (
+        "🕰️ Chronologie",
+        "Les archives mensuelles du Refuge seront consultables depuis ce bouton.",
+        "Les saisons passées deviendront des chapitres permanents de son histoire.",
+    ),
+    "construction": (
+        "🏗️ Chantier",
+        "Les votes et le suivi des constructions apparaîtront ici lorsqu’un chantier sera ouvert.",
+        "Aucune action artificielle ne sera nécessaire pour accélérer une construction.",
+    ),
+}
+
+
+def _roman(level: int) -> str:
+    values = {1: "I", 2: "II", 3: "III", 4: "IV", 5: "V"}
+    return values.get(max(1, min(5, int(level))), str(int(level)))
+
+
+class RefugePendingActionView(discord.ui.LayoutView):
+    """Small ephemeral V2 response used until REFUGE-009/010/011 land."""
+
+    def __init__(self, action: RefugePanelAction) -> None:
+        super().__init__(timeout=120)
+        title, primary, secondary = _ACTION_COPY[action]
+        container = discord.ui.Container(accent_colour=REFUGE_PANEL_ACCENT)
+        container.add_item(discord.ui.TextDisplay(f"## {title}"))
+        container.add_item(discord.ui.Separator())
+        container.add_item(discord.ui.TextDisplay(f"{primary}\n\n-# {secondary}"))
+        self.add_item(container)
+
+
+class RefugePanelButton(discord.ui.Button):
+    """Persistent public control; detailed action content lands in later stages."""
+
+    def __init__(
+        self,
+        *,
+        action: RefugePanelAction,
+        label: str,
+        emoji: str,
+        style: discord.ButtonStyle,
+    ) -> None:
+        super().__init__(
+            label=label,
+            emoji=emoji,
+            style=style,
+            custom_id=f"refuge:panel:{action}",
+        )
+        self.action = action
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        await interaction.response.send_message(
+            view=RefugePendingActionView(self.action),
+            ephemeral=True,
+        )
+
+
+def refuge_controls_row() -> discord.ui.ActionRow:
+    return discord.ui.ActionRow(
+        RefugePanelButton(
+            action="explore",
+            label="Explorer",
+            emoji="🔎",
+            style=discord.ButtonStyle.primary,
+        ),
+        RefugePanelButton(
+            action="footprint",
+            label="Mon empreinte",
+            emoji="👤",
+            style=discord.ButtonStyle.secondary,
+        ),
+        RefugePanelButton(
+            action="timeline",
+            label="Chronologie",
+            emoji="🕰️",
+            style=discord.ButtonStyle.secondary,
+        ),
+        RefugePanelButton(
+            action="construction",
+            label="Chantier",
+            emoji="🏗️",
+            style=discord.ButtonStyle.success,
+        ),
+    )
+
+
+class RefugePublicControlsView(discord.ui.LayoutView):
+    """Callback-only persistent registration used across bot restarts."""
+
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+        self.add_item(refuge_controls_row())
+
+
+class RefugePublicPanelView(discord.ui.LayoutView):
+    """Permanent public Components V2 panel for the living Refuge."""
+
+    def __init__(self, snapshot: RefugePanelSnapshot) -> None:
+        super().__init__(timeout=None)
+        container = discord.ui.Container(accent_colour=REFUGE_PANEL_ACCENT)
+        container.add_item(
+            discord.ui.TextDisplay(
+                f"## 🏕️ LE REFUGE — {snapshot.season_label}\n"
+                "Un monde façonné par l’activité réelle de la communauté."
+            )
+        )
+
+        gallery = discord.ui.MediaGallery()
+        gallery.add_item(
+            media=f"attachment://{REFUGE_MAP_FILENAME}",
+            description=f"Carte actuelle du Refuge — {snapshot.season_label}",
+        )
+        container.add_item(gallery)
+        container.add_item(discord.ui.Separator())
+
+        casino_state = "Ouvert" if snapshot.casino_is_open else "Fermé"
+        summary_lines = [
+            "### État du Refuge",
+            (
+                f"🔥 **{snapshot.fire_name} · niveau {_roman(snapshot.fire_level)}** "
+                f"— {snapshot.fire_intensity_name}"
+            ),
+            f"🏆 **{snapshot.hall_name} · niveau {_roman(snapshot.hall_level)}**",
+            (
+                f"🎰 **{snapshot.casino_name} · niveau {_roman(snapshot.casino_level)}** "
+                f"— {snapshot.casino_fortune_name} · {casino_state}"
+            ),
+            f"🏗️ **{snapshot.construction_label}**",
+        ]
+        if snapshot.latest_event_label:
+            summary_lines.append(f"🌌 Dernière trace : **{snapshot.latest_event_label}**")
+        container.add_item(discord.ui.TextDisplay("\n".join(summary_lines)))
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "-# Le Refuge ne se réinitialise pas : ses évolutions deviennent son histoire."
+            )
+        )
+        container.add_item(refuge_controls_row())
+        self.add_item(container)
+
+
+__all__ = [
+    "REFUGE_MAP_FILENAME",
+    "REFUGE_PANEL_ACCENT",
+    "RefugePanelButton",
+    "RefugePendingActionView",
+    "RefugePublicControlsView",
+    "RefugePublicPanelView",
+    "refuge_controls_row",
+]


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-008 — panneau public Components V2 du Refuge** : exposer le monde déjà construit par REFUGE-001→007 dans un unique panneau Discord permanent, mobile-first et à faible fréquence d’édition.

## Panneau public
Le panneau affiche :
- `🏕️ LE REFUGE — <mois année>` ;
- la carte Pillow 1280×720 générée par le renderer final actuel ;
- Feu : niveau, nom et intensité ;
- Hall : niveau et nom ;
- Casino : niveau, Fortune et état ouvert/fermé ;
- état du Chantier s’il existe, sinon `Aucun chantier actif` ;
- dernière trace historique connue lorsqu’elle existe.

Le monde reste la source de vérité : aucun calcul de progression n’est placé dans l’UI.

## Components V2 / mobile
`RefugePublicPanelView` est un `discord.ui.LayoutView(timeout=None)` avec un `Container`, une `MediaGallery` et exactement **4 boutons sur une seule ActionRow** :
- `🔎 Explorer`
- `👤 Mon empreinte`
- `🕰️ Chronologie`
- `🏗️ Chantier`

Les `custom_id` sont fixes et les callbacks sont enregistrés comme vue persistante afin de survivre aux redémarrages du bot.

Le contenu détaillé de ces interactions appartient toujours aux étapes prévues :
- REFUGE-009 : Explorer + Mon empreinte ;
- REFUGE-010 : Chantier ;
- REFUGE-011 : Chronologie.

Dans REFUGE-008, chaque bouton répond déjà proprement par une **vue Components V2 éphémère** expliquant la fonctionnalité à venir. Il n’y a donc ni bouton mort ni nouvelle commande artificielle.

## Image et composition
La carte est envoyée comme pièce jointe `refuge-map.png` et affichée par `MediaGallery` via `attachment://refuge-map.png`.

La composition utilisée reste celle validée :
`terrain → Feu → Hall → Casino`.

REFUGE-008 ne modifie aucun renderer existant.

## Agrégation métier
Nouveau `RefugePanelService` sans dépendance Discord :
1. évalue le Feu ;
2. évalue le Hall ;
3. évalue le Casino ;
4. construit un read model prêt à afficher ;
5. calcule une signature visuelle et une signature de résumé.

L’évaluation est volontairement séquentielle parce que les trois systèmes partagent `RefugeWorldStore` et doivent observer les écritures précédentes.

## Faible churn / rafraîchissement
Le panneau n’est jamais édité à chaque message ou événement Discord.

`REFUGE_PANEL_REFRESH_SECONDS` vaut **60 s par défaut** avec minimum 30 s.

À chaque cycle :
- message absent → création + rendu PNG ;
- signature visuelle modifiée → nouveau PNG + résumé ;
- résumé seul modifié → mise à jour Components V2 en réutilisant l’image existante ;
- aucune modification → **aucun appel d’édition Discord**.

Après redémarrage, le message existant est récupéré grâce aux `channel_id/message_id` déjà prévus dans `RefugeWorldState.panel`.

## Salon configurable — aucune publication arbitraire
Nouvelle variable d’environnement :
`REFUGE_PANEL_CHANNEL_ID`

Valeur par défaut : `0`.

Si elle n’est pas renseignée, le cog se charge sans erreur mais **ne publie rien**. REFUGE-008 ne choisit donc jamais arbitrairement un salon existant.

Si l’ID est modifié plus tard, le bot tente de retirer l’ancien panneau qu’il avait lui-même référencé avant de publier le nouveau. L’échec de cette suppression reste best-effort et ne bloque pas le nouveau panneau.

## Persistance
Aucun nouveau schéma.

Le panneau réutilise `RefugePanelState(channel_id, message_id)` créé dès REFUGE-001 dans `refuge_world.json`.

Le cog est découvert automatiquement par le chargeur `pkgutil` existant : aucune modification de `bot.py` ou `config.py` n’est nécessaire.

## Fichiers
Uniquement 6 nouveaux fichiers :
- `services/refuge_panel.py`
- `ui/refuge_panel_view.py`
- `cogs/refuge_panel.py`
- `tests/test_refuge_panel_service.py`
- `tests/test_refuge_panel_view.py`
- `tests/test_refuge_panel_cog.py`

Aucun fichier existant n’est modifié.

## Tests ajoutés
Les tests couvrent notamment :
- agrégation Feu/Hall/Casino ;
- saison `Août 2026` ;
- Chantier absent/actif ;
- dernière trace historique déterministe ;
- rendu délégué au renderer final ;
- `LayoutView` persistant ;
- les 4 boutons et leurs `custom_id` ;
- une seule ActionRow de 4 boutons ;
- MediaGallery vers `attachment://refuge-map.png` ;
- vue persistante de callbacks après restart ;
- politique create/render/summary/none ;
- détection d’un déplacement du panneau vers un autre salon.

## Validation effectuée
- les nouveaux fichiers Python ont été contrôlés syntaxiquement ;
- le diff final est `behind_by=0` contre le main validé REFUGE-007 ;
- APIs `LayoutView`, `Container`, `MediaGallery`, `attachment://` et édition de pièces jointes recoupées avec la documentation officielle discord.py compatible avec la contrainte du dépôt `discord.py>=2.7,<3`.

La suite pytest réelle du dépôt **n’est pas déclarée comme passée** : `discord.py` n’est pas installé dans le runtime ChatGPT et l’installation réseau n’y est pas disponible.

## Hors périmètre
Aucune modification de :
- XP ;
- vocal communautaire ;
- succès ;
- Feu ;
- Hall ;
- Casino ou ses probabilités/récompenses ;
- objectifs communautaires ;
- moteur Chantier ;
- snapshots/Chronologie ;
- conditions des événements secrets ;
- commandes Discord existantes.

La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.