### PR TITLE
fix: set default Refuge panel channel

### DIFF
--- a/cogs/refuge_panel.py
+++ b/cogs/refuge_panel.py
@@ -30,7 +30,11 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-REFUGE_PANEL_CHANNEL_ID = max(0, _env_int("REFUGE_PANEL_CHANNEL_ID", 0))
+DEFAULT_REFUGE_PANEL_CHANNEL_ID = 1536027732071161987
+REFUGE_PANEL_CHANNEL_ID = max(
+    0,
+    _env_int("REFUGE_PANEL_CHANNEL_ID", DEFAULT_REFUGE_PANEL_CHANNEL_ID),
+)
 REFUGE_PANEL_REFRESH_SECONDS = max(
     30,
     _env_int("REFUGE_PANEL_REFRESH_SECONDS", 60),
@@ -285,6 +289,7 @@ async def setup(bot: commands.Bot) -> None:
 
 
 __all__ = [
+    "DEFAULT_REFUGE_PANEL_CHANNEL_ID",
     "REFUGE_PANEL_CHANNEL_ID",
     "REFUGE_PANEL_REFRESH_SECONDS",
     "RefugePanelCog",

--- a/tests/test_refuge_panel_cog.py
+++ b/tests/test_refuge_panel_cog.py
@@ -1,8 +1,13 @@
 from cogs.refuge_panel import (
+    DEFAULT_REFUGE_PANEL_CHANNEL_ID,
     panel_reference_needs_retirement,
     panel_refresh_action,
 )
 from models.refuge_world import RefugePanelState
+
+
+def test_default_public_panel_channel_is_refuge_channel():
+    assert DEFAULT_REFUGE_PANEL_CHANNEL_ID == 1536027732071161987
 
 
 def test_refresh_creates_when_message_is_missing():


### PR DESCRIPTION
## Objet
Complément ciblé à **REFUGE-008** pour utiliser automatiquement le salon Discord fourni par l'utilisateur pour le panneau public du Refuge.

## Changement
- ajoute `DEFAULT_REFUGE_PANEL_CHANNEL_ID = 1536027732071161987` dans `cogs/refuge_panel.py` ;
- `REFUGE_PANEL_CHANNEL_ID` utilise désormais cette valeur par défaut ;
- la variable d'environnement `REFUGE_PANEL_CHANNEL_ID` reste prioritaire et peut toujours surcharger le salon plus tard ;
- ajoute un test qui verrouille l'ID par défaut.

## Impact
Après déploiement, aucune variable d'environnement n'est nécessaire pour publier le panneau dans le salon `1536027732071161987`.

Aucun changement sur :
- rendu du Refuge ;
- Feu / Hall / Casino ;
- XP / vocal / succès ;
- logique de rafraîchissement ;
- persistance du panneau ;
- Components V2.

## Diff
Seulement 2 fichiers modifiés :
- `cogs/refuge_panel.py`
- `tests/test_refuge_panel_cog.py`

La PR reste en draft jusqu'à validation explicite.