### PR TITLE
feat: add Refuge Explorer and footprint

### DIFF
--- a/services/refuge_exploration.py
+++ b/services/refuge_exploration.py
@@ -1,0 +1,583 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Final, Mapping, Sequence
+
+from models.refuge_world import RefugeBuildingState, RefugeHistoricalEvent, RefugeWorldState
+from services.member_profile import (
+    MemberProfileService,
+    MemberProfileSnapshot,
+    member_profile_service,
+)
+from services.refuge_casino import (
+    CASINO_LEVEL_NAMES,
+    CASINO_MAX_LEVEL,
+    RefugeCasinoConfig,
+)
+from services.refuge_fire import FIRE_LEVEL_NAMES, FIRE_MAX_LEVEL, RefugeFireConfig
+from services.refuge_hall import HALL_LEVEL_NAMES, HALL_MAX_LEVEL, RefugeHallConfig
+from services.refuge_panel import (
+    RefugePanelService,
+    RefugePanelSnapshot,
+    construction_label,
+    event_label,
+    refuge_panel_service,
+)
+from storage.refuge_world_store import RefugeWorldStore, refuge_world_store
+from utils.achievements import ACHIEVEMENT_BY_ID
+from utils.seasons import season_id_for, season_label
+from utils.timezones import PARIS_TZ
+
+
+EXPLORER_ZONE_ORDER: Final[tuple[str, ...]] = (
+    "fire",
+    "hall",
+    "casino",
+    "construction",
+    "monuments",
+    "mysteries",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeExplorerZoneSnapshot:
+    zone_id: str
+    title: str
+    emoji: str
+    details: tuple[str, ...]
+    history: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeExplorerSnapshot:
+    zones: tuple[RefugeExplorerZoneSnapshot, ...]
+
+    def get_zone(self, zone_id: str) -> RefugeExplorerZoneSnapshot:
+        normalized = str(zone_id).strip().lower()
+        for zone in self.zones:
+            if zone.zone_id == normalized:
+                return zone
+        raise KeyError(normalized)
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeFootprintTrace:
+    occurred_at: str
+    label: str
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeFootprintSnapshot:
+    user_id: int
+    season_id: str
+    season_label: str
+    level: int
+    xp: int
+    season_xp: int
+    season_messages: int
+    season_voice_seconds: int
+    season_casino_net: int
+    achievements_unlocked: int
+    achievements_total: int
+    achievement_names: tuple[str, ...]
+    casino_bets: int
+    casino_net: int
+    historical_traces: tuple[RefugeFootprintTrace, ...]
+
+
+def _aware_utc(at: datetime | None = None) -> datetime:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _format_date(value: object) -> str:
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        return "date inconnue"
+    return parsed.astimezone(PARIS_TZ).strftime("%d/%m/%Y")
+
+
+def _format_duration(seconds: int) -> str:
+    total = max(0, int(seconds))
+    hours, remainder = divmod(total, 3600)
+    minutes = remainder // 60
+    if hours > 0:
+        return f"{hours} h {minutes:02d}"
+    return f"{minutes} min"
+
+
+def _format_number(value: int) -> str:
+    return f"{int(value):,}".replace(",", " ")
+
+
+def _roman(level: int) -> str:
+    values = {1: "I", 2: "II", 3: "III", 4: "IV", 5: "V"}
+    normalized = max(1, min(5, int(level)))
+    return values[normalized]
+
+
+def _building(state: RefugeWorldState, building_id: str) -> RefugeBuildingState | None:
+    return next(
+        (item for item in state.buildings if item.building_id == building_id),
+        None,
+    )
+
+
+def _history_for_building(
+    state: RefugeWorldState,
+    building_id: str,
+    *,
+    limit: int = 4,
+) -> tuple[str, ...]:
+    matching = [
+        event
+        for event in state.events
+        if str(event.data.get("building_id", "")).strip() == building_id
+    ]
+    matching.sort(
+        key=lambda event: (
+            _parse_timestamp(event.occurred_at)
+            or datetime.min.replace(tzinfo=timezone.utc),
+            event.event_id,
+        ),
+        reverse=True,
+    )
+    rows: list[str] = []
+    for event in matching[: max(0, int(limit))]:
+        label = event_label(event) or "Un événement a marqué ce lieu"
+        rows.append(f"{_format_date(event.occurred_at)} · {label}")
+    return tuple(rows)
+
+
+def _next_milestone_line(
+    *,
+    level: int,
+    max_level: int,
+    thresholds: Sequence[int],
+    level_names: Mapping[int, str],
+    formatter,
+) -> str:
+    current_level = max(1, min(int(max_level), int(level)))
+    if current_level >= int(max_level):
+        return "Prochain palier : niveau maximal atteint."
+    values = tuple(int(value) for value in thresholds)
+    if len(values) != int(max_level) - 1:
+        return "Prochain palier : seuil non calibré."
+    target = values[current_level - 1]
+    next_name = level_names.get(current_level + 1, f"niveau {current_level + 1}")
+    return f"Prochain palier : {next_name} à {formatter(target)}."
+
+
+def _sequence_count(value: object) -> int:
+    return len(value) if isinstance(value, (list, tuple)) else 0
+
+
+def _hall_showcase_name(building: RefugeBuildingState | None) -> str | None:
+    if building is None:
+        return None
+    showcase = building.state.get("rare_showcase")
+    if not isinstance(showcase, Mapping):
+        return None
+    achievement_id = str(showcase.get("achievement_id", "")).strip()
+    if not achievement_id:
+        return None
+    definition = ACHIEVEMENT_BY_ID.get(achievement_id)
+    if definition is None:
+        return achievement_id
+    return f"{definition.emoji} {definition.name}"
+
+
+def _build_fire_zone(
+    *,
+    panel: RefugePanelSnapshot,
+    config: RefugeFireConfig,
+) -> RefugeExplorerZoneSnapshot:
+    state = panel.state
+    building = _building(state, "fire")
+    details = (
+        f"Niveau permanent : {_roman(panel.fire_level)} — {panel.fire_name}.",
+        f"Intensité récente : {panel.fire_intensity_name}.",
+        f"Présent depuis : {_format_date(building.unlocked_at if building else None)}.",
+        _next_milestone_line(
+            level=panel.fire_level,
+            max_level=FIRE_MAX_LEVEL,
+            thresholds=config.level_thresholds_seconds,
+            level_names=FIRE_LEVEL_NAMES,
+            formatter=_format_duration,
+        ),
+    )
+    return RefugeExplorerZoneSnapshot(
+        zone_id="fire",
+        title="Le Feu",
+        emoji="🔥",
+        details=details,
+        history=_history_for_building(state, "fire"),
+    )
+
+
+def _build_hall_zone(
+    *,
+    panel: RefugePanelSnapshot,
+    config: RefugeHallConfig,
+) -> RefugeExplorerZoneSnapshot:
+    state = panel.state
+    building = _building(state, "hall")
+    details = [
+        f"Niveau permanent : {_roman(panel.hall_level)} — {panel.hall_name}.",
+        f"Présent depuis : {_format_date(building.unlocked_at if building else None)}.",
+        _next_milestone_line(
+            level=panel.hall_level,
+            max_level=HALL_MAX_LEVEL,
+            thresholds=config.level_thresholds_points,
+            level_names=HALL_LEVEL_NAMES,
+            formatter=lambda value: f"{_format_number(value)} pts",
+        ),
+    ]
+    if building is not None:
+        plaque_count = _sequence_count(building.state.get("season_plaques"))
+        gallery_count = _sequence_count(building.state.get("gallery_markers"))
+        if plaque_count:
+            details.insert(1, f"Plaques saisonnières inscrites : {plaque_count}.")
+        if gallery_count:
+            details.insert(1, f"Traces de galerie : {gallery_count}.")
+    showcase = _hall_showcase_name(building)
+    if showcase:
+        details.insert(1, f"Vitrine rare actuelle : {showcase}.")
+    return RefugeExplorerZoneSnapshot(
+        zone_id="hall",
+        title="Le Hall",
+        emoji="🏆",
+        details=tuple(details),
+        history=_history_for_building(state, "hall"),
+    )
+
+
+def _build_casino_zone(
+    *,
+    panel: RefugePanelSnapshot,
+    config: RefugeCasinoConfig,
+) -> RefugeExplorerZoneSnapshot:
+    state = panel.state
+    building = _building(state, "casino")
+    open_name = "Ouvert" if panel.casino_is_open else "Fermé"
+    details = [
+        f"Niveau permanent : {_roman(panel.casino_level)} — {panel.casino_name}.",
+        f"Fortune actuelle : {panel.casino_fortune_name}.",
+        f"État : {open_name}.",
+        f"Présent depuis : {_format_date(building.unlocked_at if building else None)}.",
+        _next_milestone_line(
+            level=panel.casino_level,
+            max_level=CASINO_MAX_LEVEL,
+            thresholds=config.level_thresholds_points,
+            level_names=CASINO_LEVEL_NAMES,
+            formatter=lambda value: f"{_format_number(value)} pts",
+        ),
+    ]
+    if building is not None:
+        jackpot = building.state.get("last_jackpot")
+        if isinstance(jackpot, Mapping):
+            try:
+                tier = int(jackpot.get("tier", 0))
+            except (TypeError, ValueError):
+                tier = 0
+            if tier in {500, 1000}:
+                details.insert(3, f"Dernier jackpot observé : {tier} XP.")
+    return RefugeExplorerZoneSnapshot(
+        zone_id="casino",
+        title="Le Casino",
+        emoji="🎰",
+        details=tuple(details),
+        history=_history_for_building(state, "casino"),
+    )
+
+
+def _build_construction_zone(state: RefugeWorldState) -> RefugeExplorerZoneSnapshot:
+    construction = state.active_construction
+    if construction is None:
+        return RefugeExplorerZoneSnapshot(
+            zone_id="construction",
+            title="Le Chantier",
+            emoji="🏗️",
+            details=(
+                "Aucun chantier actif.",
+                "Le droit de bâtir s’ouvre uniquement après un accomplissement collectif validé.",
+            ),
+        )
+
+    details = [construction_label(state)]
+    if construction.opened_at:
+        details.append(f"Ouvert le : {_format_date(construction.opened_at)}.")
+    if construction.started_at:
+        details.append(f"Construction commencée le : {_format_date(construction.started_at)}.")
+    if construction.completes_at:
+        details.append(f"Échéance prévue : {_format_date(construction.completes_at)}.")
+    details.append("La progression dépend du temps écoulé, jamais d’actions répétitives.")
+    return RefugeExplorerZoneSnapshot(
+        zone_id="construction",
+        title="Le Chantier",
+        emoji="🏗️",
+        details=tuple(details),
+    )
+
+
+def _build_monuments_zone() -> RefugeExplorerZoneSnapshot:
+    return RefugeExplorerZoneSnapshot(
+        zone_id="monuments",
+        title="Les Monuments",
+        emoji="🗿",
+        details=(
+            "Aucun monument communautaire n’est encore inscrit dans le Refuge.",
+            "Cette section accueillera uniquement des constructions permanentes réellement obtenues par la communauté.",
+        ),
+    )
+
+
+def _secret_events(state: RefugeWorldState) -> tuple[RefugeHistoricalEvent, ...]:
+    events = [
+        event
+        for event in state.events
+        if str(event.event_type).endswith("secret_discovered")
+    ]
+    events.sort(
+        key=lambda event: (
+            _parse_timestamp(event.occurred_at)
+            or datetime.min.replace(tzinfo=timezone.utc),
+            event.event_id,
+        ),
+        reverse=True,
+    )
+    return tuple(events)
+
+
+def _build_mysteries_zone(state: RefugeWorldState) -> RefugeExplorerZoneSnapshot:
+    discovered = _secret_events(state)
+    if not discovered:
+        details = (
+            "Aucun mystère n’a encore été révélé.",
+            "Seules les découvertes déjà réalisées apparaissent ici : aucune condition cachée n’est dévoilée.",
+        )
+        history: tuple[str, ...] = ()
+    else:
+        details = (
+            f"Mystères révélés : {_format_number(len(discovered))}.",
+            "Seules les découvertes déjà réalisées sont visibles ici.",
+        )
+        history = tuple(
+            f"{_format_date(event.occurred_at)} · {event_label(event) or 'Mystère découvert'}"
+            for event in discovered
+        )
+    return RefugeExplorerZoneSnapshot(
+        zone_id="mysteries",
+        title="Les Mystères",
+        emoji="🌌",
+        details=details,
+        history=history,
+    )
+
+
+def build_explorer_snapshot(
+    *,
+    panel: RefugePanelSnapshot,
+    fire_config: RefugeFireConfig,
+    hall_config: RefugeHallConfig,
+    casino_config: RefugeCasinoConfig,
+) -> RefugeExplorerSnapshot:
+    zones = (
+        _build_fire_zone(panel=panel, config=fire_config),
+        _build_hall_zone(panel=panel, config=hall_config),
+        _build_casino_zone(panel=panel, config=casino_config),
+        _build_construction_zone(panel.state),
+        _build_monuments_zone(),
+        _build_mysteries_zone(panel.state),
+    )
+    if tuple(zone.zone_id for zone in zones) != EXPLORER_ZONE_ORDER:
+        raise RuntimeError("Refuge explorer zone order is inconsistent")
+    return RefugeExplorerSnapshot(zones=zones)
+
+
+def _user_id(value: object) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _achievement_label(achievement_id: object) -> str:
+    definition = ACHIEVEMENT_BY_ID.get(str(achievement_id))
+    if definition is None:
+        return str(achievement_id)
+    return f"{definition.emoji} {definition.name}"
+
+
+def _personal_history_traces(
+    *,
+    user_id: int,
+    state: RefugeWorldState,
+    limit: int = 6,
+) -> tuple[RefugeFootprintTrace, ...]:
+    traces: list[RefugeFootprintTrace] = []
+    seen: set[tuple[str, str]] = set()
+
+    def add(occurred_at: object, label: str) -> None:
+        timestamp = str(occurred_at or "").strip()
+        text = str(label).strip()
+        if not timestamp or not text:
+            return
+        key = (timestamp, text)
+        if key in seen:
+            return
+        seen.add(key)
+        traces.append(RefugeFootprintTrace(occurred_at=timestamp, label=text))
+
+    for event in state.events:
+        if _user_id(event.data.get("user_id")) != int(user_id):
+            continue
+        add(event.occurred_at, event_label(event) or "Une trace personnelle a marqué le Refuge")
+
+    hall = _building(state, "hall")
+    if hall is not None:
+        firsts = hall.state.get("historical_firsts", ())
+        if isinstance(firsts, (list, tuple)):
+            for item in firsts:
+                if not isinstance(item, Mapping):
+                    continue
+                if _user_id(item.get("user_id")) != int(user_id):
+                    continue
+                add(
+                    item.get("unlocked_at"),
+                    f"Première historique au Hall · {_achievement_label(item.get('achievement_id'))}",
+                )
+
+        markers = hall.state.get("gallery_markers", ())
+        if isinstance(markers, (list, tuple)):
+            for item in markers:
+                if not isinstance(item, Mapping):
+                    continue
+                if _user_id(item.get("user_id")) != int(user_id):
+                    continue
+                achievement_id = item.get("achievement_id")
+                if achievement_id:
+                    label = f"Trace inscrite au Hall · {_achievement_label(achievement_id)}"
+                else:
+                    label = "Trace personnelle inscrite dans la galerie du Hall"
+                add(item.get("occurred_at"), label)
+
+    traces.sort(
+        key=lambda item: (
+            _parse_timestamp(item.occurred_at)
+            or datetime.min.replace(tzinfo=timezone.utc),
+            item.label,
+        ),
+        reverse=True,
+    )
+    return tuple(traces[: max(0, int(limit))])
+
+
+def build_footprint_snapshot(
+    *,
+    profile: MemberProfileSnapshot,
+    state: RefugeWorldState,
+) -> RefugeFootprintSnapshot:
+    achievement_names = tuple(
+        _achievement_label(achievement_id)
+        for achievement_id in profile.achievement_ids
+    )
+    return RefugeFootprintSnapshot(
+        user_id=profile.user_id,
+        season_id=profile.season_id,
+        season_label=season_label(profile.season_id),
+        level=profile.level,
+        xp=profile.xp,
+        season_xp=profile.season_xp,
+        season_messages=profile.season_messages,
+        season_voice_seconds=profile.season_voice_seconds,
+        season_casino_net=profile.season_casino_net,
+        achievements_unlocked=profile.achievements_unlocked,
+        achievements_total=profile.achievements_total,
+        achievement_names=achievement_names,
+        casino_bets=profile.casino_bets,
+        casino_net=profile.casino_net,
+        historical_traces=_personal_history_traces(
+            user_id=profile.user_id,
+            state=state,
+        ),
+    )
+
+
+class RefugeExplorationService:
+    """Read-only orchestration for Explorer and Mon empreinte."""
+
+    def __init__(
+        self,
+        *,
+        panel_service: RefugePanelService = refuge_panel_service,
+        member_profile_service_: MemberProfileService = member_profile_service,
+        world_store: RefugeWorldStore = refuge_world_store,
+    ) -> None:
+        self.panel_service = panel_service
+        self.member_profile_service = member_profile_service_
+        self.world_store = world_store
+
+    async def get_explorer(
+        self,
+        *,
+        at: datetime | None = None,
+    ) -> RefugeExplorerSnapshot:
+        now = _aware_utc(at)
+        panel = await self.panel_service.evaluate(at=now)
+        return build_explorer_snapshot(
+            panel=panel,
+            fire_config=RefugeFireConfig.from_env(),
+            hall_config=RefugeHallConfig.from_env(),
+            casino_config=RefugeCasinoConfig.from_env(),
+        )
+
+    async def get_footprint(
+        self,
+        user_id: int,
+        *,
+        at: datetime | None = None,
+    ) -> RefugeFootprintSnapshot:
+        now = _aware_utc(at)
+        current_season = season_id_for(now)
+        profile, state = await asyncio.gather(
+            self.member_profile_service.get_snapshot(
+                int(user_id),
+                season_id=current_season,
+            ),
+            self.world_store.get_state(),
+        )
+        return build_footprint_snapshot(profile=profile, state=state)
+
+
+refuge_exploration_service = RefugeExplorationService()
+
+
+__all__ = [
+    "EXPLORER_ZONE_ORDER",
+    "RefugeExplorerSnapshot",
+    "RefugeExplorerZoneSnapshot",
+    "RefugeExplorationService",
+    "RefugeFootprintSnapshot",
+    "RefugeFootprintTrace",
+    "build_explorer_snapshot",
+    "build_footprint_snapshot",
+    "refuge_exploration_service",
+]

--- a/tests/test_refuge_exploration.py
+++ b/tests/test_refuge_exploration.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from models.refuge_world import (
+    RefugeBuildingState,
+    RefugeHistoricalEvent,
+    RefugeWorldState,
+)
+from rendering.refuge_world import RefugeRenderContext
+from services.member_profile import MemberProfileSnapshot
+from services.refuge_casino import RefugeCasinoConfig
+from services.refuge_exploration import (
+    EXPLORER_ZONE_ORDER,
+    build_explorer_snapshot,
+    build_footprint_snapshot,
+)
+from services.refuge_fire import RefugeFireConfig
+from services.refuge_hall import RefugeHallConfig
+from services.refuge_panel import RefugePanelSnapshot
+
+
+def _state(*, with_secret: bool = False) -> RefugeWorldState:
+    events = []
+    if with_secret:
+        events.append(
+            RefugeHistoricalEvent(
+                event_id="fire:secret:night_of_stars",
+                event_type="fire_secret_discovered",
+                occurred_at="2026-08-09T12:00:00+00:00",
+                data={
+                    "building_id": "fire",
+                    "secret_id": "night_of_stars",
+                    "name": "La Nuit des Étoiles",
+                },
+            )
+        )
+    return RefugeWorldState(
+        created_at="2026-08-01T00:00:00+00:00",
+        buildings=(
+            RefugeBuildingState(
+                building_id="fire",
+                level=1,
+                unlocked_at="2026-08-01T00:00:00+00:00",
+            ),
+            RefugeBuildingState(
+                building_id="hall",
+                level=1,
+                unlocked_at="2026-08-01T00:00:00+00:00",
+            ),
+            RefugeBuildingState(
+                building_id="casino",
+                level=1,
+                unlocked_at="2026-08-01T00:00:00+00:00",
+            ),
+        ),
+        events=tuple(events),
+    )
+
+
+def _panel(state: RefugeWorldState) -> RefugePanelSnapshot:
+    return RefugePanelSnapshot(
+        state=state,
+        context=RefugeRenderContext(season="summer", daypart="day"),
+        season_id="2026-08",
+        season_label="Août 2026",
+        fire_level=1,
+        fire_name="L’Étincelle",
+        fire_intensity="normal",
+        fire_intensity_name="Vivant",
+        hall_level=1,
+        hall_name="Cabane des Souvenirs",
+        casino_level=1,
+        casino_name="Baraque de Jeux",
+        casino_fortune="stable",
+        casino_fortune_name="Stable",
+        casino_is_open=True,
+        construction_label="Aucun chantier actif",
+        latest_event_id=None,
+        latest_event_label=None,
+        visual_signature="visual",
+        summary_signature="summary",
+        changed=False,
+    )
+
+
+def test_explorer_has_exact_six_validated_zones_and_no_default_thresholds():
+    snapshot = build_explorer_snapshot(
+        panel=_panel(_state()),
+        fire_config=RefugeFireConfig(),
+        hall_config=RefugeHallConfig(),
+        casino_config=RefugeCasinoConfig(),
+    )
+
+    assert tuple(zone.zone_id for zone in snapshot.zones) == EXPLORER_ZONE_ORDER
+    assert "seuil non calibré" in " ".join(snapshot.get_zone("fire").details)
+    assert "seuil non calibré" in " ".join(snapshot.get_zone("hall").details)
+    assert "seuil non calibré" in " ".join(snapshot.get_zone("casino").details)
+    assert snapshot.get_zone("construction").details[0] == "Aucun chantier actif."
+
+
+def test_explorer_uses_configured_next_milestone_without_inventing_progress():
+    snapshot = build_explorer_snapshot(
+        panel=_panel(_state()),
+        fire_config=RefugeFireConfig(
+            level_thresholds_seconds=(3600, 7200, 10800, 14400)
+        ),
+        hall_config=RefugeHallConfig(level_thresholds_points=(10, 20, 30, 40)),
+        casino_config=RefugeCasinoConfig(level_thresholds_points=(10, 20, 30, 40)),
+    )
+
+    fire_text = " ".join(snapshot.get_zone("fire").details)
+    assert "Le Campement à 1 h 00" in fire_text
+    assert "/" not in fire_text
+
+
+def test_mysteries_reveal_only_discovered_secret_names():
+    snapshot = build_explorer_snapshot(
+        panel=_panel(_state(with_secret=True)),
+        fire_config=RefugeFireConfig(),
+        hall_config=RefugeHallConfig(),
+        casino_config=RefugeCasinoConfig(),
+    )
+
+    text = " ".join(snapshot.get_zone("mysteries").history)
+    assert "La Nuit des Étoiles" in text
+    assert "Le Premier Visiteur" not in text
+    assert "Le Cercle complet" not in text
+
+
+def test_footprint_ignores_rank_fields_and_keeps_only_personal_history():
+    profile = MemberProfileSnapshot(
+        user_id=42,
+        xp=1250,
+        level=7,
+        achievements_unlocked=2,
+        achievements_total=9,
+        achievement_ids=("casino_1_bet", "level_5"),
+        season_id="2026-08",
+        season_xp=310,
+        season_xp_rank=1,
+        season_messages=54,
+        season_messages_rank=1,
+        season_voice_seconds=7200,
+        season_voice_rank=1,
+        season_casino_net=-25,
+        season_casino_rank=1,
+        casino_bets=12,
+        casino_wagered=500,
+        casino_winnings=450,
+        casino_net=-50,
+    )
+    state = RefugeWorldState(
+        buildings=(
+            RefugeBuildingState(
+                building_id="hall",
+                level=1,
+                state={
+                    "historical_firsts": [
+                        {
+                            "achievement_id": "level_5",
+                            "user_id": 42,
+                            "unlocked_at": "2026-08-03T12:00:00+00:00",
+                        }
+                    ]
+                },
+            ),
+        ),
+        events=(
+            RefugeHistoricalEvent(
+                event_id="casino:jackpot:mine",
+                event_type="casino_jackpot_observed",
+                occurred_at="2026-08-08T12:00:00+00:00",
+                data={"building_id": "casino", "tier": 500, "user_id": 42},
+            ),
+            RefugeHistoricalEvent(
+                event_id="casino:jackpot:other",
+                event_type="casino_jackpot_observed",
+                occurred_at="2026-08-09T12:00:00+00:00",
+                data={"building_id": "casino", "tier": 1000, "user_id": 99},
+            ),
+        ),
+    )
+
+    footprint = build_footprint_snapshot(profile=profile, state=state)
+
+    assert not hasattr(footprint, "season_xp_rank")
+    assert not hasattr(footprint, "season_messages_rank")
+    assert not hasattr(footprint, "season_voice_rank")
+    assert not hasattr(footprint, "season_casino_rank")
+    assert footprint.season_xp == 310
+    assert footprint.season_messages == 54
+    assert footprint.season_voice_seconds == 7200
+    assert any(
+        "Jackpot machine à sous · 500 XP" in trace.label
+        for trace in footprint.historical_traces
+    )
+    assert any(
+        "Première historique au Hall" in trace.label
+        for trace in footprint.historical_traces
+    )
+    assert all("1000 XP" not in trace.label for trace in footprint.historical_traces)
+    assert "🎲 Premier pari" in footprint.achievement_names
+    assert "🥉 Membre Bronze" in footprint.achievement_names

--- a/tests/test_refuge_exploration_view.py
+++ b/tests/test_refuge_exploration_view.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import discord
+
+from services.refuge_exploration import (
+    RefugeExplorerSnapshot,
+    RefugeExplorerZoneSnapshot,
+    RefugeFootprintSnapshot,
+    RefugeFootprintTrace,
+)
+from ui.refuge_exploration_view import (
+    RefugeExplorerSelect,
+    RefugeExplorerView,
+    RefugeFootprintView,
+)
+
+
+def _explorer_snapshot() -> RefugeExplorerSnapshot:
+    zones = (
+        RefugeExplorerZoneSnapshot("fire", "Le Feu", "🔥", ("Feu vivant.",)),
+        RefugeExplorerZoneSnapshot("hall", "Le Hall", "🏆", ("Hall calme.",)),
+        RefugeExplorerZoneSnapshot("casino", "Le Casino", "🎰", ("Casino stable.",)),
+        RefugeExplorerZoneSnapshot("construction", "Le Chantier", "🏗️", ("Aucun chantier actif.",)),
+        RefugeExplorerZoneSnapshot("monuments", "Les Monuments", "🗿", ("Aucun monument.",)),
+        RefugeExplorerZoneSnapshot(
+            "mysteries",
+            "Les Mystères",
+            "🌌",
+            ("Un mystère révélé.",),
+            ("09/08/2026 · La Nuit des Étoiles",),
+        ),
+    )
+    return RefugeExplorerSnapshot(zones=zones)
+
+
+def _text(view: discord.ui.LayoutView) -> str:
+    return "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+
+
+def test_explorer_is_private_sized_v2_with_one_six_option_select():
+    view = RefugeExplorerView(_explorer_snapshot(), owner_user_id=42)
+    assert isinstance(view, discord.ui.LayoutView)
+    assert view.timeout == 300
+    selects = [
+        item for item in view.walk_children() if isinstance(item, RefugeExplorerSelect)
+    ]
+    assert len(selects) == 1
+    assert [option.value for option in selects[0].options] == [
+        "fire",
+        "hall",
+        "casino",
+        "construction",
+        "monuments",
+        "mysteries",
+    ]
+    assert "Le Feu" in _text(view)
+
+
+def test_explorer_switches_zone_without_creating_another_surface():
+    view = RefugeExplorerView(_explorer_snapshot(), owner_user_id=42)
+    view.show_zone("mysteries")
+    text = _text(view)
+    assert "Les Mystères" in text
+    assert "La Nuit des Étoiles" in text
+    assert "conditions restent invisibles" in text
+    selects = [item for item in view.walk_children() if isinstance(item, discord.ui.Select)]
+    assert len(selects) == 1
+
+
+def test_footprint_displays_activity_without_rank_or_importance_score():
+    snapshot = RefugeFootprintSnapshot(
+        user_id=42,
+        season_id="2026-08",
+        season_label="Août 2026",
+        level=7,
+        xp=1250,
+        season_xp=310,
+        season_messages=54,
+        season_voice_seconds=7200,
+        season_casino_net=-25,
+        achievements_unlocked=2,
+        achievements_total=9,
+        achievement_names=("🥉 Membre Bronze", "🎲 Premier pari"),
+        casino_bets=12,
+        casino_net=-50,
+        historical_traces=(
+            RefugeFootprintTrace(
+                occurred_at="2026-08-08T12:00:00+00:00",
+                label="Jackpot machine à sous · 500 XP",
+            ),
+        ),
+    )
+    view = RefugeFootprintView(snapshot, display_name="Kevin")
+    text = _text(view)
+    assert "MON EMPREINTE" in text
+    assert "Août 2026" in text
+    assert "54" in text
+    assert "2 h 00" in text
+    assert "Jackpot machine à sous · 500 XP" in text
+    assert "#1" not in text
+    assert "score d’importance" not in text.lower()
+    assert "aucune comparaison d’importance" in text.lower()

--- a/tests/test_refuge_panel_view.py
+++ b/tests/test_refuge_panel_view.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import discord
+import pytest
 
 from models.refuge_world import RefugeWorldState
 from rendering.refuge_world import RefugeRenderContext
@@ -85,14 +86,22 @@ def test_callback_registration_view_is_persistent_and_has_same_custom_ids():
     ]
 
 
-def test_pending_views_are_ephemeral_sized_layouts():
-    view = RefugePendingActionView("footprint")
-    assert isinstance(view, discord.ui.LayoutView)
-    assert view.timeout == 120
-    text = "\n".join(
-        item.content
-        for item in view.walk_children()
-        if isinstance(item, discord.ui.TextDisplay)
-    )
-    assert "Mon empreinte" in text
-    assert "privée" in text
+def test_only_timeline_and_construction_remain_pending_after_refuge_009():
+    for action, expected in (
+        ("timeline", "Chronologie"),
+        ("construction", "Chantier"),
+    ):
+        view = RefugePendingActionView(action)
+        assert isinstance(view, discord.ui.LayoutView)
+        assert view.timeout == 120
+        text = "\n".join(
+            item.content
+            for item in view.walk_children()
+            if isinstance(item, discord.ui.TextDisplay)
+        )
+        assert expected in text
+
+    with pytest.raises(ValueError):
+        RefugePendingActionView("explore")
+    with pytest.raises(ValueError):
+        RefugePendingActionView("footprint")

--- a/ui/refuge_exploration_view.py
+++ b/ui/refuge_exploration_view.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import discord
+
+from services.refuge_exploration import (
+    EXPLORER_ZONE_ORDER,
+    RefugeExplorerSnapshot,
+    RefugeFootprintSnapshot,
+)
+from utils.timezones import PARIS_TZ
+
+
+REFUGE_EXPLORATION_ACCENT = discord.Colour(0xD08A47)
+
+
+def _format_number(value: int) -> str:
+    return f"{int(value):,}".replace(",", " ")
+
+
+def _format_signed_xp(value: int) -> str:
+    return f"{int(value):+d} XP"
+
+
+def _format_duration(seconds: int) -> str:
+    total = max(0, int(seconds))
+    hours, remainder = divmod(total, 3600)
+    minutes = remainder // 60
+    if hours:
+        return f"{hours} h {minutes:02d}"
+    return f"{minutes} min"
+
+
+def _format_trace_date(value: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return "Date inconnue"
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(PARIS_TZ).strftime("%d/%m/%Y")
+
+
+class RefugeExplorerSelect(discord.ui.Select):
+    def __init__(
+        self,
+        snapshot: RefugeExplorerSnapshot,
+        *,
+        selected_zone_id: str,
+    ) -> None:
+        options = [
+            discord.SelectOption(
+                label=zone.title,
+                value=zone.zone_id,
+                emoji=zone.emoji,
+                default=zone.zone_id == selected_zone_id,
+            )
+            for zone in snapshot.zones
+        ]
+        super().__init__(
+            custom_id="refuge:explorer:zone",
+            placeholder="Choisir un lieu du Refuge",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, RefugeExplorerView):
+            return
+        view.show_zone(self.values[0])
+        await interaction.response.edit_message(view=view)
+
+
+class RefugeExplorerView(discord.ui.LayoutView):
+    """Private V2 navigator over current Refuge places and discovered history."""
+
+    def __init__(
+        self,
+        snapshot: RefugeExplorerSnapshot,
+        *,
+        owner_user_id: int,
+        initial_zone_id: str = "fire",
+    ) -> None:
+        super().__init__(timeout=300)
+        self.snapshot = snapshot
+        self.owner_user_id = int(owner_user_id)
+        self.selected_zone_id = (
+            initial_zone_id if initial_zone_id in EXPLORER_ZONE_ORDER else "fire"
+        )
+        self.show_zone(self.selected_zone_id)
+
+    async def interaction_check(self, interaction: discord.Interaction, /) -> bool:
+        if interaction.user.id == self.owner_user_id:
+            return True
+        await interaction.response.send_message(
+            "Cette exploration privée appartient à la personne qui l’a ouverte.",
+            ephemeral=True,
+        )
+        return False
+
+    def show_zone(self, zone_id: str) -> None:
+        zone = self.snapshot.get_zone(zone_id)
+        self.selected_zone_id = zone.zone_id
+        self.clear_items()
+
+        container = discord.ui.Container(accent_colour=REFUGE_EXPLORATION_ACCENT)
+        container.add_item(
+            discord.ui.TextDisplay(
+                "## 🔎 EXPLORER LE REFUGE\n"
+                "Observe les lieux tels qu’ils existent réellement aujourd’hui."
+            )
+        )
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                f"### {zone.emoji} {zone.title}\n"
+                + "\n".join(f"• {line}" for line in zone.details)
+            )
+        )
+
+        if zone.history:
+            container.add_item(discord.ui.Separator())
+            container.add_item(
+                discord.ui.TextDisplay(
+                    "### Traces récentes\n"
+                    + "\n".join(f"• {line}" for line in zone.history)
+                )
+            )
+
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.ActionRow(
+                RefugeExplorerSelect(
+                    self.snapshot,
+                    selected_zone_id=self.selected_zone_id,
+                )
+            )
+        )
+        if zone.zone_id == "mysteries":
+            container.add_item(
+                discord.ui.TextDisplay(
+                    "-# Les mystères non découverts et leurs conditions restent invisibles."
+                )
+            )
+        self.add_item(container)
+
+
+class RefugeFootprintView(discord.ui.LayoutView):
+    """Private, non-ranked representation of one member's Refuge footprint."""
+
+    def __init__(
+        self,
+        snapshot: RefugeFootprintSnapshot,
+        *,
+        display_name: str,
+        avatar_url: str | None = None,
+    ) -> None:
+        super().__init__(timeout=300)
+        container = discord.ui.Container(accent_colour=REFUGE_EXPLORATION_ACCENT)
+
+        identity = discord.ui.TextDisplay(
+            "## 👤 MON EMPREINTE\n"
+            f"**{display_name}**\n"
+            "-# Ce que ton activité a réellement laissé dans le Refuge."
+        )
+        if avatar_url:
+            container.add_item(
+                discord.ui.Section(
+                    identity,
+                    accessory=discord.ui.Thumbnail(
+                        avatar_url,
+                        description=f"Avatar de {display_name}",
+                    ),
+                )
+            )
+        else:
+            container.add_item(identity)
+
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                f"### 📅 {snapshot.season_label}\n"
+                f"⚡ XP gagnée : **{_format_number(snapshot.season_xp)} XP**\n"
+                f"💬 Messages : **{_format_number(snapshot.season_messages)}**\n"
+                f"🎧 Vocal : **{_format_duration(snapshot.season_voice_seconds)}**\n"
+                f"🎰 Casino net : **{_format_signed_xp(snapshot.season_casino_net)}**"
+            )
+        )
+
+        container.add_item(discord.ui.Separator())
+        permanent_lines = [
+            "### 🏕️ Traces permanentes",
+            (
+                f"Progression actuelle : **niveau {snapshot.level}** · "
+                f"**{_format_number(snapshot.xp)} XP**"
+            ),
+            (
+                f"Succès débloqués : **{snapshot.achievements_unlocked}/"
+                f"{snapshot.achievements_total}**"
+            ),
+            (
+                f"Casino historique : **{_format_number(snapshot.casino_bets)} paris** · "
+                f"**{_format_signed_xp(snapshot.casino_net)}**"
+            ),
+        ]
+        if snapshot.achievement_names:
+            permanent_lines.append(
+                "Badges : " + " · ".join(snapshot.achievement_names)
+            )
+        else:
+            permanent_lines.append("Badges : aucun succès débloqué pour le moment.")
+        container.add_item(discord.ui.TextDisplay("\n".join(permanent_lines)))
+
+        container.add_item(discord.ui.Separator())
+        if snapshot.historical_traces:
+            trace_lines = ["### 📜 Dans l’histoire du Refuge"]
+            trace_lines.extend(
+                f"• **{_format_trace_date(trace.occurred_at)}** · {trace.label}"
+                for trace in snapshot.historical_traces
+            )
+        else:
+            trace_lines = [
+                "### 📜 Dans l’histoire du Refuge",
+                "Aucune trace nominative permanente n’est encore enregistrée pour toi.",
+            ]
+        container.add_item(discord.ui.TextDisplay("\n".join(trace_lines)))
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "-# Ton empreinte n’est pas un classement : aucune comparaison d’importance entre membres n’est calculée."
+            )
+        )
+        self.add_item(container)
+
+
+class RefugePrivateErrorView(discord.ui.LayoutView):
+    def __init__(self, message: str) -> None:
+        super().__init__(timeout=60)
+        container = discord.ui.Container(accent_colour=discord.Colour.red())
+        container.add_item(discord.ui.TextDisplay("## 🏕️ Le Refuge"))
+        container.add_item(discord.ui.Separator())
+        container.add_item(discord.ui.TextDisplay(str(message)))
+        self.add_item(container)
+
+
+__all__ = [
+    "REFUGE_EXPLORATION_ACCENT",
+    "RefugeExplorerSelect",
+    "RefugeExplorerView",
+    "RefugeFootprintView",
+    "RefugePrivateErrorView",
+]

--- a/ui/refuge_panel_view.py
+++ b/ui/refuge_panel_view.py
@@ -1,27 +1,25 @@
 from __future__ import annotations
 
+import logging
 from typing import Final, Literal
 
 import discord
 
+from services.refuge_exploration import refuge_exploration_service
 from services.refuge_panel import RefugePanelSnapshot
+from ui.refuge_exploration_view import (
+    RefugeExplorerView,
+    RefugeFootprintView,
+    RefugePrivateErrorView,
+)
 
 
+logger = logging.getLogger(__name__)
 REFUGE_PANEL_ACCENT = discord.Colour(0xD08A47)
 REFUGE_MAP_FILENAME: Final[str] = "refuge-map.png"
 RefugePanelAction = Literal["explore", "footprint", "timeline", "construction"]
 
 _ACTION_COPY: Final[dict[str, tuple[str, str, str]]] = {
-    "explore": (
-        "🔎 Explorer",
-        "L’exploration détaillée des lieux du Refuge sera activée dans la prochaine évolution.",
-        "Le panneau public est déjà prêt à accueillir cette navigation.",
-    ),
-    "footprint": (
-        "👤 Mon empreinte",
-        "Ton empreinte personnelle sera consultable ici dans une vue privée.",
-        "Elle ne sera jamais affichée publiquement sur le panneau du Refuge.",
-    ),
     "timeline": (
         "🕰️ Chronologie",
         "Les archives mensuelles du Refuge seront consultables depuis ce bouton.",
@@ -41,11 +39,14 @@ def _roman(level: int) -> str:
 
 
 class RefugePendingActionView(discord.ui.LayoutView):
-    """Small ephemeral V2 response used until REFUGE-009/010/011 land."""
+    """Small ephemeral V2 response for actions scheduled after REFUGE-009."""
 
     def __init__(self, action: RefugePanelAction) -> None:
         super().__init__(timeout=120)
-        title, primary, secondary = _ACTION_COPY[action]
+        copy = _ACTION_COPY.get(action)
+        if copy is None:
+            raise ValueError(f"Refuge action is already active: {action}")
+        title, primary, secondary = copy
         container = discord.ui.Container(accent_colour=REFUGE_PANEL_ACCENT)
         container.add_item(discord.ui.TextDisplay(f"## {title}"))
         container.add_item(discord.ui.Separator())
@@ -54,7 +55,7 @@ class RefugePendingActionView(discord.ui.LayoutView):
 
 
 class RefugePanelButton(discord.ui.Button):
-    """Persistent public control; detailed action content lands in later stages."""
+    """Persistent public control dispatching to private Refuge surfaces."""
 
     def __init__(
         self,
@@ -73,10 +74,54 @@ class RefugePanelButton(discord.ui.Button):
         self.action = action
 
     async def callback(self, interaction: discord.Interaction) -> None:
-        await interaction.response.send_message(
-            view=RefugePendingActionView(self.action),
-            ephemeral=True,
-        )
+        if self.action not in {"explore", "footprint"}:
+            await interaction.response.send_message(
+                view=RefugePendingActionView(self.action),
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            if self.action == "explore":
+                snapshot = await refuge_exploration_service.get_explorer()
+                view: discord.ui.LayoutView = RefugeExplorerView(
+                    snapshot,
+                    owner_user_id=interaction.user.id,
+                )
+            else:
+                snapshot = await refuge_exploration_service.get_footprint(
+                    interaction.user.id
+                )
+                avatar = getattr(interaction.user, "display_avatar", None)
+                avatar_url = (
+                    str(avatar.url)
+                    if getattr(avatar, "url", None)
+                    else None
+                )
+                display_name = str(
+                    getattr(
+                        interaction.user,
+                        "display_name",
+                        getattr(interaction.user, "name", interaction.user.id),
+                    )
+                )
+                view = RefugeFootprintView(
+                    snapshot,
+                    display_name=display_name,
+                    avatar_url=avatar_url,
+                )
+        except Exception:
+            logger.exception(
+                "[refuge] impossible de charger l'action privée %s pour user=%s",
+                self.action,
+                interaction.user.id,
+            )
+            view = RefugePrivateErrorView(
+                "Impossible de charger cette partie du Refuge pour le moment."
+            )
+
+        await interaction.edit_original_response(view=view)
 
 
 def refuge_controls_row() -> discord.ui.ActionRow:


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-009 — Explorer + Mon empreinte** à partir du panneau public REFUGE-008, sans ajouter de commande, sans nouveau stockage persistant et sans anticiper le moteur Chantier ou la Chronologie.

## Explorer
Le bouton public `🔎 Explorer` ouvre désormais une **vue Components V2 éphémère** avec un seul menu déroulant et exactement les 6 zones validées :
- `🔥 Le Feu`
- `🏆 Le Hall`
- `🎰 Le Casino`
- `🏗️ Le Chantier`
- `🗿 Les Monuments`
- `🌌 Les Mystères`

Chaque zone affiche uniquement des données réellement connues du monde :
- niveau permanent actuel ;
- état dynamique disponible (intensité Feu, Fortune/ouverture Casino, vitrine rare Hall, etc.) ;
- date d’apparition du bâtiment ;
- prochain palier **uniquement à partir des seuils configurés** ;
- dernières traces historiques persistées.

Si les seuils de production ne sont pas calibrés, Explorer affiche explicitement `seuil non calibré` et n’invente aucune progression intermédiaire.

### Mystères
La zone Mystères ne lit que les événements `*_secret_discovered` déjà présents dans `RefugeWorldState.events`.

Les noms ou conditions des secrets non découverts ne sont jamais injectés dans la vue. Si rien n’a encore été découvert, la vue le dit sans révéler combien de secrets existent au total.

### Monuments
Aucun monument n’étant encore créé par le moteur Chantier, la zone n’invente aucun contenu. Elle reste un registre vide destiné aux constructions permanentes réellement obtenues plus tard.

## Mon empreinte
Le bouton public `👤 Mon empreinte` ouvre une vue privée construite à partir des sources existantes :
- `MemberProfileService` pour XP/niveau, activité de la saison, succès et casino ;
- `RefugeWorldState` pour les traces historiques nominatives.

La vue affiche :
- XP gagnée, messages, vocal et casino net de la saison courante ;
- niveau/XP actuels ;
- succès débloqués ;
- activité casino historique ;
- événements persistés où `data.user_id` correspond réellement au membre ;
- premières historiques / marqueurs de galerie du Hall qui référencent réellement ce membre.

### Aucun classement d’importance
Les champs existants `season_xp_rank`, `season_messages_rank`, `season_voice_rank` et `season_casino_rank` ne sont **pas copiés** dans `RefugeFootprintSnapshot`.

Mon empreinte ne produit donc ni rang, ni score comparatif, ni notion d’importance relative entre membres.

## Cohérence de concurrence
Une première version de travail faisait réévaluer directement Feu/Hall/Casino depuis Explorer. Elle a été remplacée avant la PR.

La version finale appelle uniquement `RefugePanelService.evaluate()`, l’orchestrateur déjà sérialisé de REFUGE-008. Explorer ne crée donc pas une deuxième chaîne d’écriture concurrente sur `RefugeWorldStore`.

Les seuils de Feu/Hall/Casino sont ensuite lus en configuration uniquement pour nommer le **prochain** palier, sans recalculer le monde.

## Interactions Discord
Les `custom_id` publics existants restent inchangés :
- `refuge:panel:explore`
- `refuge:panel:footprint`
- `refuge:panel:timeline`
- `refuge:panel:construction`

Les deux actions REFUGE-009 font d’abord `defer(ephemeral=True, thinking=True)` avant lecture des stores, puis éditent la réponse éphémère avec la vue finale.

Chronologie et Chantier restent volontairement sur leur écran d’attente existant :
- REFUGE-010 — Chantier ;
- REFUGE-011 — Chronologie.

## Fichiers
- `services/refuge_exploration.py` — nouveau read model Explorer + Mon empreinte ;
- `ui/refuge_exploration_view.py` — nouvelles vues Components V2 privées ;
- `ui/refuge_panel_view.py` — activation des deux boutons existants ;
- `tests/test_refuge_exploration.py` — nouveaux tests métier/read model ;
- `tests/test_refuge_exploration_view.py` — nouveaux tests UI ;
- `tests/test_refuge_panel_view.py` — attentes REFUGE-008 adaptées aux deux boutons désormais actifs.

Aucun fichier XP, vocal, succès, Casino, renderer, stockage ou bot loader n’est modifié.

## Tests ajoutés
Les tests couvrent notamment :
- ordre exact des 6 zones ;
- absence de seuil arbitraire par défaut ;
- affichage d’un prochain palier configuré sans inventer une progression actuelle ;
- non-divulgation des secrets non découverts ;
- exclusion explicite des quatre rangs du profil dans Mon empreinte ;
- filtrage des événements historiques par `user_id` ;
- rendu V2 avec un seul Select à 6 options ;
- navigation en place dans la même vue éphémère ;
- affichage de l’empreinte sans rang ;
- maintien des 4 custom_id publics ;
- seuls Chronologie et Chantier restent en attente.

## Validation effectuée
- pendant le développement, `main` a avancé avec `1c157f2ed7e8ac03d4ef1007157b4be92710507f` (`fix: set default Refuge panel channel`) ;
- la branche REFUGE-009 a été reconstruite proprement depuis ce nouveau `main`, puis la branche de la draft PR a été mise à jour ;
- comparaison finale : base et merge-base exactes `1c157f2ed7e8ac03d4ef1007157b4be92710507f`, `ahead_by=6`, `behind_by=0` ;
- le correctif concurrent REFUGE-008 est donc conservé et ne fait pas partie du diff REFUGE-009 ;
- revue structurelle des imports et de la chaîne d’orchestration ;
- API `discord.ui.Select` + `ActionRow` vérifiée dans la documentation officielle discord.py ;
- `InteractionResponse.defer(ephemeral=True, thinking=True)` et `Interaction.edit_original_response(view=...)` vérifiés dans la documentation officielle discord.py.

La suite pytest réelle du dépôt **n’est pas déclarée comme passée** : le runtime ChatGPT ne peut pas résoudre `github.com`, donc le clone local de la branche échoue avant checkout. Aucun workflow GitHub Actions n’est déclaré comme réussi tant qu’un run associé au head n’est pas présent.

## Hors périmètre
Aucune modification de :
- XP / niveaux ;
- vocal communautaire ;
- succès ou critères de succès ;
- Feu / Hall / Casino et leurs règles ;
- probabilités/récompenses casino ;
- renderer de la carte ;
- stockage du monde ;
- objectifs communautaires ;
- vote/construction REFUGE-010 ;
- snapshots/Chronologie REFUGE-011 ;
- déclencheurs secrets REFUGE-012.

La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.