### PR TITLE
feat: add Refuge construction

### DIFF
--- a/cogs/refuge_construction.py
+++ b/cogs/refuge_construction.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from discord.ext import commands, tasks
+
+from services.refuge_construction import refuge_construction_service
+
+
+logger = logging.getLogger(__name__)
+
+
+class RefugeConstructionCog(commands.Cog):
+    """Reconcile completed community goals and advance the active chantier."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def cog_load(self) -> None:
+        # This first sync establishes the prospective REFUGE-010 activation marker
+        # before future community goals can become eligible build rights.
+        try:
+            await refuge_construction_service.sync()
+        except Exception:
+            logger.exception("[refuge] initialisation du Chantier échouée")
+        if not self.advance_construction.is_running():
+            self.advance_construction.start()
+
+    def cog_unload(self) -> None:
+        self.advance_construction.cancel()
+
+    @tasks.loop(minutes=1)
+    async def advance_construction(self) -> None:
+        try:
+            await refuge_construction_service.sync()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("[refuge] avancement du Chantier échoué")
+
+    @advance_construction.before_loop
+    async def before_advance_construction(self) -> None:
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RefugeConstructionCog(bot))
+
+
+__all__ = ["RefugeConstructionCog"]

--- a/rendering/__init__.py
+++ b/rendering/__init__.py
@@ -6,6 +6,12 @@ from .refuge_casino import (
     casino_scene_signature,
     refuge_casino_renderer,
 )
+from .refuge_construction import (
+    REFUGE_CONSTRUCTION_RENDERER_VERSION,
+    RefugeConstructionRenderer,
+    construction_scene_signature,
+    refuge_construction_renderer,
+)
 from .refuge_fire import (
     REFUGE_FIRE_RENDERER_VERSION,
     RefugeFireRenderer,
@@ -31,18 +37,22 @@ from .refuge_world import (
 __all__ = [
     "REFUGE_CANVAS_SIZE",
     "REFUGE_CASINO_RENDERER_VERSION",
+    "REFUGE_CONSTRUCTION_RENDERER_VERSION",
     "REFUGE_FIRE_RENDERER_VERSION",
     "REFUGE_HALL_RENDERER_VERSION",
     "RefugeCasinoRenderer",
+    "RefugeConstructionRenderer",
     "RefugeFireRenderer",
     "RefugeHallRenderer",
     "RefugeRenderContext",
     "RefugeWorldRenderer",
     "casino_scene_signature",
+    "construction_scene_signature",
     "daypart_for_hour",
     "fire_scene_signature",
     "hall_scene_signature",
     "refuge_casino_renderer",
+    "refuge_construction_renderer",
     "refuge_fire_renderer",
     "refuge_hall_renderer",
     "refuge_world_renderer",

--- a/rendering/refuge_construction.py
+++ b/rendering/refuge_construction.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import json
+from typing import Final
+
+from PIL import Image, ImageDraw
+
+from models.refuge_world import RefugeBuildingState, RefugeWorldState
+from rendering.refuge_casino import (
+    RefugeCasinoRenderer,
+    casino_scene_signature,
+    refuge_casino_renderer,
+)
+from rendering.refuge_world import RefugeRenderContext
+from services.refuge_construction import (
+    CONSTRUCTION_STATUS_BUILDING,
+    CONSTRUCTION_STATUS_TIE_BREAK,
+    CONSTRUCTION_STATUS_VOTING,
+)
+
+
+REFUGE_CONSTRUCTION_RENDERER_VERSION: Final[int] = 1
+CONSTRUCTION_SITE_CENTER: Final[tuple[int, int]] = (646, 616)
+MONUMENT_CENTERS: Final[dict[str, tuple[int, int]]] = {
+    "monument:star_observatory": (666, 292),
+    "monument:memory_garden": (824, 350),
+    "monument:lantern_tower": (492, 340),
+}
+
+
+def _shade(color: tuple[int, int, int], factor: float) -> tuple[int, int, int]:
+    return tuple(max(0, min(255, int(round(channel * factor)))) for channel in color)
+
+
+def _palette(context: RefugeRenderContext) -> dict[str, tuple[int, int, int]]:
+    wood = (125, 89, 58)
+    stone = (142, 139, 128)
+    grass = (66, 113, 64)
+    gold = (222, 178, 74)
+    canvas = (201, 184, 145)
+    if context.daypart == "night":
+        wood = _shade(wood, 0.63)
+        stone = _shade(stone, 0.66)
+        grass = _shade(grass, 0.62)
+        canvas = _shade(canvas, 0.68)
+    elif context.daypart == "sunset":
+        wood = (137, 85, 58)
+        gold = (235, 159, 74)
+    if context.season == "winter":
+        grass = (111, 125, 116)
+    elif context.season == "autumn":
+        grass = (117, 91, 54)
+    return {
+        "wood": wood,
+        "wood_dark": _shade(wood, 0.68),
+        "stone": stone,
+        "stone_dark": _shade(stone, 0.72),
+        "grass": grass,
+        "gold": gold,
+        "canvas": canvas,
+        "ink": (46, 43, 39),
+        "rope": (166, 137, 84),
+        "light": (246, 213, 113),
+        "water": (75, 127, 146),
+        "flower": (176, 94, 107),
+    }
+
+
+def _monument(state: RefugeWorldState, building_id: str) -> RefugeBuildingState | None:
+    return next(
+        (building for building in state.buildings if building.building_id == building_id),
+        None,
+    )
+
+
+def construction_scene_signature(
+    state: RefugeWorldState,
+    context: RefugeRenderContext,
+) -> str:
+    active = state.active_construction
+    monuments = [
+        building.to_dict()
+        for building in state.buildings
+        if building.building_id.startswith("monument:")
+    ]
+    payload = {
+        "base": casino_scene_signature(state, context),
+        "renderer_version": REFUGE_CONSTRUCTION_RENDERER_VERSION,
+        "active_construction": active.to_dict() if active is not None else None,
+        "monuments": sorted(monuments, key=lambda item: str(item.get("building_id", ""))),
+    }
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _draw_observatory(
+    draw: ImageDraw.ImageDraw,
+    center: tuple[int, int],
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    draw.ellipse((x - 52, y + 8, x + 52, y + 28), fill=palette["stone_dark"])
+    draw.rectangle((x - 38, y - 28, x + 38, y + 13), fill=palette["stone"])
+    draw.pieslice((x - 42, y - 67, x + 42, y + 5), 180, 360, fill=palette["canvas"])
+    draw.line((x + 2, y - 43, x + 38, y - 73), fill=palette["wood_dark"], width=8)
+    draw.ellipse((x + 31, y - 80, x + 48, y - 65), fill=palette["stone_dark"])
+    draw.ellipse((x - 5, y - 46, x + 7, y - 34), fill=palette["gold"])
+
+
+def _draw_memory_garden(
+    draw: ImageDraw.ImageDraw,
+    center: tuple[int, int],
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    draw.ellipse((x - 64, y - 19, x + 64, y + 28), fill=palette["grass"])
+    draw.ellipse((x - 31, y - 11, x + 31, y + 18), fill=palette["water"])
+    draw.arc((x - 40, y - 68, x + 40, y + 8), 180, 360, fill=palette["stone"], width=8)
+    for dx, dy in ((-47, 2), (-30, -15), (39, -9), (52, 7), (23, 10)):
+        draw.ellipse((x + dx - 5, y + dy - 5, x + dx + 5, y + dy + 5), fill=palette["flower"])
+
+
+def _draw_lantern_tower(
+    draw: ImageDraw.ImageDraw,
+    center: tuple[int, int],
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = center
+    draw.ellipse((x - 45, y + 10, x + 45, y + 27), fill=palette["stone_dark"])
+    draw.polygon(
+        ((x - 29, y + 12), (x - 21, y - 72), (x + 21, y - 72), (x + 29, y + 12)),
+        fill=palette["stone"],
+    )
+    draw.polygon(((x - 34, y - 72), (x, y - 98), (x + 34, y - 72)), fill=palette["wood_dark"])
+    for dx in (-18, 18):
+        draw.line((x + dx, y - 57, x + dx, y - 32), fill=palette["wood_dark"], width=3)
+        draw.rectangle((x + dx - 7, y - 35, x + dx + 7, y - 20), fill=palette["gold"])
+        draw.rectangle((x + dx - 4, y - 32, x + dx + 4, y - 23), fill=palette["light"])
+
+
+def _draw_completed_monuments(
+    draw: ImageDraw.ImageDraw,
+    state: RefugeWorldState,
+    *,
+    context: RefugeRenderContext,
+) -> None:
+    palette = _palette(context)
+    for building_id, center in MONUMENT_CENTERS.items():
+        if _monument(state, building_id) is None:
+            continue
+        if building_id.endswith("star_observatory"):
+            _draw_observatory(draw, center, palette)
+        elif building_id.endswith("memory_garden"):
+            _draw_memory_garden(draw, center, palette)
+        elif building_id.endswith("lantern_tower"):
+            _draw_lantern_tower(draw, center, palette)
+
+
+def _draw_vote_site(
+    draw: ImageDraw.ImageDraw,
+    *,
+    tie_break: bool,
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    x, y = CONSTRUCTION_SITE_CENTER
+    draw.ellipse((x - 87, y - 7, x + 87, y + 27), fill=palette["stone_dark"])
+    draw.rectangle((x - 55, y - 17, x + 55, y + 2), fill=palette["wood"])
+    draw.line((x - 45, y + 2, x - 45, y + 21), fill=palette["wood_dark"], width=5)
+    draw.line((x + 45, y + 2, x + 45, y + 21), fill=palette["wood_dark"], width=5)
+    draw.rectangle((x - 28, y - 48, x + 28, y - 19), fill=palette["canvas"])
+    draw.line((x - 19, y - 39, x + 18, y - 30), fill=palette["ink"], width=2)
+    draw.line((x - 15, y - 28, x + 12, y - 41), fill=palette["ink"], width=2)
+    flag = palette["flower"] if tie_break else palette["gold"]
+    draw.line((x + 63, y - 2, x + 63, y - 53), fill=palette["wood_dark"], width=4)
+    draw.polygon(((x + 65, y - 52), (x + 91, y - 43), (x + 65, y - 34)), fill=flag)
+
+
+def _draw_build_site(
+    draw: ImageDraw.ImageDraw,
+    state: RefugeWorldState,
+    *,
+    palette: dict[str, tuple[int, int, int]],
+) -> None:
+    construction = state.active_construction
+    if construction is None:
+        return
+    x, y = CONSTRUCTION_SITE_CENTER
+    try:
+        stage = max(0, min(3, int(construction.data.get("visual_stage", 0))))
+    except (TypeError, ValueError):
+        stage = 0
+
+    draw.ellipse((x - 92, y - 8, x + 92, y + 29), fill=palette["stone_dark"])
+    draw.rectangle((x - 62, y - 8, x + 62, y + 8), fill=palette["stone"])
+    heights = (18, 38, 58, 78)
+    height = heights[stage]
+    for dx in (-54, 54):
+        draw.line((x + dx, y + 6, x + dx, y - height), fill=palette["wood"], width=5)
+    for offset in range(0, height + 1, 20):
+        draw.line((x - 58, y - offset, x + 58, y - offset), fill=palette["wood"], width=4)
+    draw.line((x - 54, y, x + 54, y - height), fill=palette["rope"], width=3)
+    draw.line((x + 54, y, x - 54, y - height), fill=palette["rope"], width=3)
+    if stage >= 1:
+        draw.rectangle((x - 31, y - 30, x + 31, y + 4), fill=palette["canvas"])
+    if stage >= 2:
+        draw.rectangle((x - 25, y - 53, x + 25, y - 29), fill=palette["stone"])
+    if stage >= 3:
+        draw.polygon(((x - 31, y - 53), (x, y - 77), (x + 31, y - 53)), fill=palette["wood_dark"])
+
+
+def draw_refuge_construction(
+    draw: ImageDraw.ImageDraw,
+    state: RefugeWorldState,
+    *,
+    context: RefugeRenderContext,
+) -> None:
+    _draw_completed_monuments(draw, state, context=context)
+    construction = state.active_construction
+    if construction is None:
+        return
+    palette = _palette(context)
+    if construction.status == CONSTRUCTION_STATUS_VOTING:
+        _draw_vote_site(draw, tie_break=False, palette=palette)
+    elif construction.status == CONSTRUCTION_STATUS_TIE_BREAK:
+        _draw_vote_site(draw, tie_break=True, palette=palette)
+    elif construction.status == CONSTRUCTION_STATUS_BUILDING:
+        _draw_build_site(draw, state, palette=palette)
+
+
+class RefugeConstructionRenderer:
+    """Compose terrain, Fire, Hall, Casino, Chantier and permanent monuments."""
+
+    def __init__(
+        self,
+        base_renderer: RefugeCasinoRenderer = refuge_casino_renderer,
+    ) -> None:
+        self.base_renderer = base_renderer
+
+    def render_png(
+        self,
+        state: RefugeWorldState,
+        *,
+        context: RefugeRenderContext | None = None,
+    ) -> bytes:
+        render_context = context or RefugeRenderContext.from_datetime()
+        base_png = self.base_renderer.render_png(state, context=render_context)
+        image = Image.open(io.BytesIO(base_png)).convert("RGB")
+        draw = ImageDraw.Draw(image)
+        draw_refuge_construction(draw, state, context=render_context)
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG", optimize=False, compress_level=9)
+        return buffer.getvalue()
+
+    async def render_png_async(
+        self,
+        state: RefugeWorldState,
+        *,
+        context: RefugeRenderContext | None = None,
+    ) -> bytes:
+        return await asyncio.to_thread(self.render_png, state, context=context)
+
+
+refuge_construction_renderer = RefugeConstructionRenderer()
+
+
+__all__ = [
+    "CONSTRUCTION_SITE_CENTER",
+    "MONUMENT_CENTERS",
+    "REFUGE_CONSTRUCTION_RENDERER_VERSION",
+    "RefugeConstructionRenderer",
+    "construction_scene_signature",
+    "draw_refuge_construction",
+    "refuge_construction_renderer",
+]

--- a/services/refuge_construction.py
+++ b/services/refuge_construction.py
@@ -1,0 +1,812 @@
+from __future__ import annotations
+
+import os
+import secrets
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Final, Mapping, Sequence
+
+from models.refuge_world import (
+    RefugeBuildingState,
+    RefugeConstructionState,
+    RefugeHistoricalEvent,
+    RefugeWorldState,
+)
+from services.refuge_world_coordination import refuge_world_mutation_lock
+from storage.community_goal_store import CommunityGoalStore, community_goal_store
+from storage.refuge_world_store import RefugeWorldStore, refuge_world_store
+
+
+CONSTRUCTION_TIE_EXTENSION_HOURS: Final[int] = 24
+CONSTRUCTION_STATUS_VOTING: Final[str] = "voting"
+CONSTRUCTION_STATUS_TIE_BREAK: Final[str] = "tie_break"
+CONSTRUCTION_STATUS_BUILDING: Final[str] = "building"
+
+_CONSTRUCTION_ENABLED_AT_KEY: Final[str] = "construction_enabled_at"
+_CONSTRUCTION_PENDING_GOALS_KEY: Final[str] = "construction_pending_goals"
+_CONSTRUCTION_CONSUMED_GOALS_KEY: Final[str] = "construction_consumed_goal_ids"
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeConstructionProject:
+    project_id: str
+    name: str
+    emoji: str
+    description: str
+    building_id: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "project_id": self.project_id,
+            "name": self.name,
+            "emoji": self.emoji,
+            "description": self.description,
+            "building_id": self.building_id,
+        }
+
+
+CONSTRUCTION_PROJECTS: Final[tuple[RefugeConstructionProject, ...]] = (
+    RefugeConstructionProject(
+        project_id="star_observatory",
+        name="Observatoire des Étoiles",
+        emoji="🔭",
+        description="Un observatoire permanent tourné vers le ciel du Refuge.",
+        building_id="monument:star_observatory",
+    ),
+    RefugeConstructionProject(
+        project_id="memory_garden",
+        name="Jardin des Souvenirs",
+        emoji="🌿",
+        description="Un jardin permanent dédié aux traces laissées par la communauté.",
+        building_id="monument:memory_garden",
+    ),
+    RefugeConstructionProject(
+        project_id="lantern_tower",
+        name="Tour des Lanternes",
+        emoji="🏮",
+        description="Une tour permanente dont les lanternes veillent sur le Refuge.",
+        building_id="monument:lantern_tower",
+    ),
+)
+PROJECT_BY_ID: Final[dict[str, RefugeConstructionProject]] = {
+    project.project_id: project for project in CONSTRUCTION_PROJECTS
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeConstructionConfig:
+    vote_hours: int = 72
+    build_hours: int = 168
+
+    @classmethod
+    def from_env(cls) -> "RefugeConstructionConfig":
+        return cls(
+            vote_hours=_env_positive_int("REFUGE_CONSTRUCTION_VOTE_HOURS", 72),
+            build_hours=_env_positive_int("REFUGE_CONSTRUCTION_BUILD_HOURS", 168),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeConstructionOption:
+    project_id: str
+    name: str
+    emoji: str
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeConstructionSnapshot:
+    active: bool
+    status: str | None
+    construction_id: str | None
+    source_goal_id: str | None
+    source_goal_title: str | None
+    options: tuple[RefugeConstructionOption, ...]
+    allowed_project_ids: tuple[str, ...]
+    user_vote: str | None
+    project_id: str | None
+    project_name: str | None
+    opened_at: str | None
+    closes_at: str | None
+    started_at: str | None
+    completes_at: str | None
+    progress_percent: int
+    winner_method: str | None
+    final_results: tuple[tuple[str, int], ...]
+    completed_monuments: tuple[str, ...]
+
+
+def _env_positive_int(name: str, default: int) -> int:
+    try:
+        value = int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        value = default
+    return max(1, value)
+
+
+def _aware_utc(at: datetime | None = None) -> datetime:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
+
+
+def _iso(at: datetime | None = None) -> str:
+    return _aware_utc(at).isoformat()
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _world_data(state: RefugeWorldState) -> dict[str, Any]:
+    return dict(state.state)
+
+
+def _pending_goals(state: RefugeWorldState) -> list[dict[str, Any]]:
+    raw = state.state.get(_CONSTRUCTION_PENDING_GOALS_KEY, ())
+    if not isinstance(raw, (list, tuple)):
+        return []
+    return [dict(item) for item in raw if isinstance(item, Mapping)]
+
+
+def _consumed_goal_ids(state: RefugeWorldState) -> set[str]:
+    raw = state.state.get(_CONSTRUCTION_CONSUMED_GOALS_KEY, ())
+    if not isinstance(raw, (list, tuple, set, frozenset)):
+        return set()
+    return {str(item) for item in raw if str(item).strip()}
+
+
+def _goal_snapshot(goal: Mapping[str, Any]) -> dict[str, Any] | None:
+    goal_id = str(goal.get("id", "")).strip()
+    completed_at = str(goal.get("completed_at", "")).strip()
+    if not goal_id or not completed_at:
+        return None
+    return {
+        "id": goal_id,
+        "title": str(goal.get("title") or goal.get("metric_key") or "Objectif communautaire"),
+        "metric_key": str(goal.get("metric_key", "")),
+        "completed_at": completed_at,
+        "final_progress": int(goal.get("final_progress") or 0),
+    }
+
+
+def _projects_from_construction(
+    construction: RefugeConstructionState,
+) -> tuple[RefugeConstructionOption, ...]:
+    raw = construction.data.get("projects", ())
+    options: list[RefugeConstructionOption] = []
+    if isinstance(raw, (list, tuple)):
+        for item in raw:
+            if not isinstance(item, Mapping):
+                continue
+            project_id = str(item.get("project_id", "")).strip()
+            name = str(item.get("name", "")).strip()
+            if not project_id or not name:
+                continue
+            options.append(
+                RefugeConstructionOption(
+                    project_id=project_id,
+                    name=name,
+                    emoji=str(item.get("emoji") or "🏗️"),
+                    description=str(item.get("description") or "").strip(),
+                )
+            )
+    return tuple(options)
+
+
+def _votes(construction: RefugeConstructionState) -> dict[str, str]:
+    raw = construction.data.get("votes", {})
+    if not isinstance(raw, Mapping):
+        return {}
+    return {
+        str(user_id): str(project_id)
+        for user_id, project_id in raw.items()
+        if str(user_id).strip() and str(project_id).strip()
+    }
+
+
+def _vote_counts(
+    construction: RefugeConstructionState,
+    project_ids: Sequence[str],
+) -> dict[str, int]:
+    allowed = tuple(dict.fromkeys(str(item) for item in project_ids))
+    counts = {project_id: 0 for project_id in allowed}
+    for project_id in _votes(construction).values():
+        if project_id in counts:
+            counts[project_id] += 1
+    return counts
+
+
+def _leaders(counts: Mapping[str, int]) -> tuple[str, ...]:
+    if not counts:
+        return ()
+    best = max(int(value) for value in counts.values())
+    return tuple(sorted(key for key, value in counts.items() if int(value) == best))
+
+
+def _append_event(
+    state: RefugeWorldState,
+    event: RefugeHistoricalEvent,
+) -> RefugeWorldState:
+    if any(existing.event_id == event.event_id for existing in state.events):
+        return state
+    return replace(state, events=state.events + (event,))
+
+
+def _replace_or_add_building(
+    state: RefugeWorldState,
+    building: RefugeBuildingState,
+) -> RefugeWorldState:
+    items = {item.building_id: item for item in state.buildings}
+    items[building.building_id] = building
+    return replace(
+        state,
+        buildings=tuple(sorted(items.values(), key=lambda item: item.building_id)),
+    )
+
+
+def _completed_monument_names(state: RefugeWorldState) -> tuple[str, ...]:
+    names: list[tuple[str, str]] = []
+    for building in state.buildings:
+        if not building.building_id.startswith("monument:"):
+            continue
+        name = str(building.state.get("project_name") or building.building_id).strip()
+        names.append((building.unlocked_at or "", name))
+    names.sort()
+    return tuple(name for _, name in names)
+
+
+def _construction_progress(
+    construction: RefugeConstructionState,
+    now: datetime,
+) -> int:
+    if construction.status != CONSTRUCTION_STATUS_BUILDING:
+        return 0
+    started = _parse_timestamp(construction.started_at)
+    completes = _parse_timestamp(construction.completes_at)
+    if started is None or completes is None or completes <= started:
+        return 0
+    if now <= started:
+        return 0
+    if now >= completes:
+        return 100
+    ratio = (now - started).total_seconds() / (completes - started).total_seconds()
+    return max(0, min(100, int(ratio * 100)))
+
+
+class RefugeConstructionService:
+    """Turn real completed community goals into one persistent build right."""
+
+    def __init__(
+        self,
+        *,
+        world_store: RefugeWorldStore = refuge_world_store,
+        goal_store: CommunityGoalStore = community_goal_store,
+        chooser: Callable[[Sequence[str]], str] | None = None,
+    ) -> None:
+        self.world_store = world_store
+        self.goal_store = goal_store
+        self._chooser = chooser or secrets.choice
+
+    def _activate(
+        self,
+        state: RefugeWorldState,
+        *,
+        now: datetime,
+    ) -> tuple[RefugeWorldState, bool]:
+        data = _world_data(state)
+        if data.get(_CONSTRUCTION_ENABLED_AT_KEY):
+            return state, False
+        data[_CONSTRUCTION_ENABLED_AT_KEY] = _iso(now)
+        data.setdefault(_CONSTRUCTION_PENDING_GOALS_KEY, [])
+        data.setdefault(_CONSTRUCTION_CONSUMED_GOALS_KEY, [])
+        return replace(state, state=data), True
+
+    def _reconcile_completed(
+        self,
+        state: RefugeWorldState,
+        goals: Sequence[Mapping[str, Any]],
+    ) -> tuple[RefugeWorldState, bool]:
+        enabled_at = _parse_timestamp(state.state.get(_CONSTRUCTION_ENABLED_AT_KEY))
+        if enabled_at is None:
+            return state, False
+
+        pending = _pending_goals(state)
+        queued_ids = {str(item.get("id", "")) for item in pending}
+        consumed = _consumed_goal_ids(state)
+        active_source = (
+            str(state.active_construction.data.get("source_goal_id", ""))
+            if state.active_construction is not None
+            else ""
+        )
+        added = False
+
+        eligible: list[dict[str, Any]] = []
+        for goal in goals:
+            snapshot = _goal_snapshot(goal)
+            if snapshot is None:
+                continue
+            completed_at = _parse_timestamp(snapshot["completed_at"])
+            goal_id = str(snapshot["id"])
+            if completed_at is None or completed_at < enabled_at:
+                continue
+            if goal_id in consumed or goal_id in queued_ids or goal_id == active_source:
+                continue
+            eligible.append(snapshot)
+
+        eligible.sort(key=lambda item: (str(item["completed_at"]), str(item["id"])))
+        if eligible:
+            pending.extend(eligible)
+            added = True
+
+        if not added:
+            return state, False
+        data = _world_data(state)
+        data[_CONSTRUCTION_PENDING_GOALS_KEY] = pending
+        return replace(state, state=data), True
+
+    def _open_next(
+        self,
+        state: RefugeWorldState,
+        *,
+        now: datetime,
+        config: RefugeConstructionConfig,
+    ) -> tuple[RefugeWorldState, bool]:
+        if state.active_construction is not None:
+            return state, False
+        pending = _pending_goals(state)
+        if not pending:
+            return state, False
+
+        goal = pending.pop(0)
+        goal_id = str(goal["id"])
+        construction_id = f"goal:{goal_id}"
+        data = {
+            "source_goal_id": goal_id,
+            "source_goal_title": str(goal.get("title") or "Objectif communautaire"),
+            "source_goal_metric": str(goal.get("metric_key") or ""),
+            "projects": [project.to_dict() for project in CONSTRUCTION_PROJECTS],
+            "votes": {},
+            "winner_method": None,
+            "final_results": {},
+            "tied_project_ids": [],
+        }
+        construction = RefugeConstructionState(
+            construction_id=construction_id,
+            status=CONSTRUCTION_STATUS_VOTING,
+            opened_at=_iso(now),
+            closes_at=_iso(now + timedelta(hours=config.vote_hours)),
+            data=data,
+        )
+
+        world_data = _world_data(state)
+        consumed = _consumed_goal_ids(state)
+        consumed.add(goal_id)
+        world_data[_CONSTRUCTION_PENDING_GOALS_KEY] = pending
+        world_data[_CONSTRUCTION_CONSUMED_GOALS_KEY] = sorted(consumed)
+
+        updated = replace(state, state=world_data, active_construction=construction)
+        updated = _append_event(
+            updated,
+            RefugeHistoricalEvent(
+                event_id=f"construction:{construction_id}:opened",
+                event_type="construction_vote_opened",
+                occurred_at=_iso(now),
+                data={
+                    "construction_id": construction_id,
+                    "source_goal_id": goal_id,
+                    "name": "Un chantier s’est ouvert",
+                },
+            ),
+        )
+        return updated, True
+
+    def _start_building(
+        self,
+        state: RefugeWorldState,
+        construction: RefugeConstructionState,
+        *,
+        winner_id: str,
+        winner_method: str,
+        now: datetime,
+        config: RefugeConstructionConfig,
+    ) -> RefugeWorldState:
+        project = PROJECT_BY_ID.get(winner_id)
+        if project is None:
+            raise RuntimeError(f"unknown construction winner: {winner_id}")
+
+        all_ids = tuple(project.project_id for project in CONSTRUCTION_PROJECTS)
+        counts = _vote_counts(construction, all_ids)
+        data = dict(construction.data)
+        data["winner_method"] = winner_method
+        data["final_results"] = dict(sorted(counts.items()))
+        data["project_name"] = project.name
+        data["project_description"] = project.description
+        data["building_id"] = project.building_id
+
+        active = replace(
+            construction,
+            status=CONSTRUCTION_STATUS_BUILDING,
+            project_id=winner_id,
+            started_at=_iso(now),
+            completes_at=_iso(now + timedelta(hours=config.build_hours)),
+            data=data,
+        )
+        updated = replace(state, active_construction=active)
+        return _append_event(
+            updated,
+            RefugeHistoricalEvent(
+                event_id=f"construction:{construction.construction_id}:started",
+                event_type="construction_started",
+                occurred_at=_iso(now),
+                data={
+                    "construction_id": construction.construction_id,
+                    "project_id": winner_id,
+                    "name": f"Construction lancée · {project.name}",
+                    "winner_method": winner_method,
+                },
+            ),
+        )
+
+    def _resolve_vote(
+        self,
+        state: RefugeWorldState,
+        construction: RefugeConstructionState,
+        *,
+        now: datetime,
+        config: RefugeConstructionConfig,
+    ) -> RefugeWorldState:
+        all_ids = tuple(project.project_id for project in CONSTRUCTION_PROJECTS)
+
+        if construction.status == CONSTRUCTION_STATUS_VOTING:
+            counts = _vote_counts(construction, all_ids)
+            leaders = _leaders(counts)
+            if len(leaders) == 1:
+                return self._start_building(
+                    state,
+                    construction,
+                    winner_id=leaders[0],
+                    winner_method="vote",
+                    now=now,
+                    config=config,
+                )
+
+            data = dict(construction.data)
+            data["tied_project_ids"] = list(leaders)
+            extended = replace(
+                construction,
+                status=CONSTRUCTION_STATUS_TIE_BREAK,
+                closes_at=_iso(now + timedelta(hours=CONSTRUCTION_TIE_EXTENSION_HOURS)),
+                data=data,
+            )
+            updated = replace(state, active_construction=extended)
+            return _append_event(
+                updated,
+                RefugeHistoricalEvent(
+                    event_id=f"construction:{construction.construction_id}:tie",
+                    event_type="construction_vote_tied",
+                    occurred_at=_iso(now),
+                    data={
+                        "construction_id": construction.construction_id,
+                        "project_ids": list(leaders),
+                        "extension_hours": CONSTRUCTION_TIE_EXTENSION_HOURS,
+                        "name": "Le vote du chantier est à égalité",
+                    },
+                ),
+            )
+
+        tied_raw = construction.data.get("tied_project_ids", ())
+        tied_ids = (
+            tuple(
+                project_id
+                for project_id in (str(item) for item in tied_raw)
+                if project_id in PROJECT_BY_ID
+            )
+            if isinstance(tied_raw, (list, tuple))
+            else ()
+        )
+        if not tied_ids:
+            tied_ids = all_ids
+
+        counts = _vote_counts(construction, tied_ids)
+        leaders = _leaders(counts)
+        if len(leaders) == 1:
+            winner_id = leaders[0]
+            method = "tie_extension_vote"
+        else:
+            winner_id = str(self._chooser(leaders))
+            if winner_id not in leaders:
+                raise RuntimeError("tie chooser returned an ineligible project")
+            method = "random_tie"
+
+        return self._start_building(
+            state,
+            construction,
+            winner_id=winner_id,
+            winner_method=method,
+            now=now,
+            config=config,
+        )
+
+    def _complete_building(
+        self,
+        state: RefugeWorldState,
+        construction: RefugeConstructionState,
+        *,
+        now: datetime,
+    ) -> RefugeWorldState:
+        project = PROJECT_BY_ID.get(str(construction.project_id or ""))
+        if project is None:
+            raise RuntimeError("construction completion has no supported project")
+
+        building = RefugeBuildingState(
+            building_id=project.building_id,
+            level=1,
+            unlocked_at=_iso(now),
+            state={
+                "project_id": project.project_id,
+                "project_name": project.name,
+                "description": project.description,
+                "construction_id": construction.construction_id,
+                "source_goal_id": construction.data.get("source_goal_id"),
+            },
+        )
+        updated = _replace_or_add_building(state, building)
+        updated = replace(updated, active_construction=None)
+        return _append_event(
+            updated,
+            RefugeHistoricalEvent(
+                event_id=f"construction:{construction.construction_id}:completed",
+                event_type="construction_completed",
+                occurred_at=_iso(now),
+                data={
+                    "construction_id": construction.construction_id,
+                    "project_id": project.project_id,
+                    "building_id": project.building_id,
+                    "source_goal_id": construction.data.get("source_goal_id"),
+                    "winner_method": construction.data.get("winner_method"),
+                    "name": f"{project.name} a été inauguré",
+                },
+            ),
+        )
+
+    def _advance(
+        self,
+        state: RefugeWorldState,
+        *,
+        now: datetime,
+        config: RefugeConstructionConfig,
+    ) -> tuple[RefugeWorldState, bool]:
+        changed = False
+        while True:
+            if state.active_construction is None:
+                state, opened = self._open_next(state, now=now, config=config)
+                changed = changed or opened
+                return state, changed
+
+            construction = state.active_construction
+            if construction.status in {
+                CONSTRUCTION_STATUS_VOTING,
+                CONSTRUCTION_STATUS_TIE_BREAK,
+            }:
+                closes_at = _parse_timestamp(construction.closes_at)
+                if closes_at is None or now < closes_at:
+                    return state, changed
+                state = self._resolve_vote(state, construction, now=now, config=config)
+                changed = True
+                continue
+
+            if construction.status == CONSTRUCTION_STATUS_BUILDING:
+                completes_at = _parse_timestamp(construction.completes_at)
+                if completes_at is None or now < completes_at:
+                    return state, changed
+                state = self._complete_building(state, construction, now=now)
+                changed = True
+                continue
+
+            return state, changed
+
+    async def sync(
+        self,
+        *,
+        at: datetime | None = None,
+        config: RefugeConstructionConfig | None = None,
+    ) -> RefugeConstructionSnapshot:
+        now = _aware_utc(at)
+        resolved_config = config or RefugeConstructionConfig.from_env()
+        completed_goals = await self.goal_store.list_goals(status="completed")
+
+        async with refuge_world_mutation_lock():
+            state = await self.world_store.initialize(created_at=now)
+            changed = False
+
+            state, activated = self._activate(state, now=now)
+            changed = changed or activated
+            state, reconciled = self._reconcile_completed(state, completed_goals)
+            changed = changed or reconciled
+            state, advanced = self._advance(state, now=now, config=resolved_config)
+            changed = changed or advanced
+
+            if changed:
+                state = await self.world_store.save_state(state)
+
+            return self._snapshot(state, user_id=None, now=now)
+
+    async def get_snapshot(
+        self,
+        user_id: int | None = None,
+        *,
+        at: datetime | None = None,
+        config: RefugeConstructionConfig | None = None,
+    ) -> RefugeConstructionSnapshot:
+        now = _aware_utc(at)
+        await self.sync(at=now, config=config)
+        async with refuge_world_mutation_lock():
+            state = await self.world_store.get_state()
+            return self._snapshot(state, user_id=user_id, now=now)
+
+    async def cast_vote(
+        self,
+        user_id: int,
+        project_id: str,
+        *,
+        at: datetime | None = None,
+        config: RefugeConstructionConfig | None = None,
+    ) -> RefugeConstructionSnapshot:
+        now = _aware_utc(at)
+        resolved_config = config or RefugeConstructionConfig.from_env()
+        await self.sync(at=now, config=resolved_config)
+
+        normalized_user_id = int(user_id)
+        if normalized_user_id <= 0:
+            raise ValueError("user_id must be positive")
+
+        async with refuge_world_mutation_lock():
+            state = await self.world_store.get_state()
+            construction = state.active_construction
+            if construction is None or construction.status not in {
+                CONSTRUCTION_STATUS_VOTING,
+                CONSTRUCTION_STATUS_TIE_BREAK,
+            }:
+                raise ValueError("construction vote is not open")
+
+            options = _projects_from_construction(construction)
+            option_ids = tuple(option.project_id for option in options)
+            if construction.status == CONSTRUCTION_STATUS_TIE_BREAK:
+                raw_tied = construction.data.get("tied_project_ids", ())
+                allowed = (
+                    tuple(
+                        item
+                        for item in (str(value) for value in raw_tied)
+                        if item in option_ids
+                    )
+                    if isinstance(raw_tied, (list, tuple))
+                    else ()
+                )
+            else:
+                allowed = option_ids
+
+            normalized_project_id = str(project_id).strip()
+            if normalized_project_id not in allowed:
+                raise ValueError("project is not eligible for this vote")
+
+            data = dict(construction.data)
+            votes = _votes(construction)
+            votes[str(normalized_user_id)] = normalized_project_id
+            data["votes"] = votes
+            updated = replace(
+                state,
+                active_construction=replace(construction, data=data),
+            )
+            updated = await self.world_store.save_state(updated)
+            return self._snapshot(updated, user_id=normalized_user_id, now=now)
+
+    def _snapshot(
+        self,
+        state: RefugeWorldState,
+        *,
+        user_id: int | None,
+        now: datetime,
+    ) -> RefugeConstructionSnapshot:
+        construction = state.active_construction
+        completed = _completed_monument_names(state)
+        if construction is None:
+            return RefugeConstructionSnapshot(
+                active=False,
+                status=None,
+                construction_id=None,
+                source_goal_id=None,
+                source_goal_title=None,
+                options=(),
+                allowed_project_ids=(),
+                user_vote=None,
+                project_id=None,
+                project_name=None,
+                opened_at=None,
+                closes_at=None,
+                started_at=None,
+                completes_at=None,
+                progress_percent=0,
+                winner_method=None,
+                final_results=(),
+                completed_monuments=completed,
+            )
+
+        options = _projects_from_construction(construction)
+        option_ids = tuple(option.project_id for option in options)
+        if construction.status == CONSTRUCTION_STATUS_TIE_BREAK:
+            raw_tied = construction.data.get("tied_project_ids", ())
+            allowed = (
+                tuple(
+                    item
+                    for item in (str(value) for value in raw_tied)
+                    if item in option_ids
+                )
+                if isinstance(raw_tied, (list, tuple))
+                else ()
+            )
+        elif construction.status == CONSTRUCTION_STATUS_VOTING:
+            allowed = option_ids
+        else:
+            allowed = ()
+
+        votes = _votes(construction)
+        user_vote = votes.get(str(user_id)) if user_id is not None else None
+        if user_vote not in allowed and construction.status == CONSTRUCTION_STATUS_TIE_BREAK:
+            user_vote = None
+
+        raw_results = construction.data.get("final_results", {})
+        final_results = (
+            tuple(sorted((str(key), int(value)) for key, value in raw_results.items()))
+            if isinstance(raw_results, Mapping)
+            else ()
+        )
+
+        return RefugeConstructionSnapshot(
+            active=True,
+            status=construction.status,
+            construction_id=construction.construction_id,
+            source_goal_id=str(construction.data.get("source_goal_id") or "") or None,
+            source_goal_title=str(construction.data.get("source_goal_title") or "") or None,
+            options=options,
+            allowed_project_ids=allowed,
+            user_vote=user_vote,
+            project_id=construction.project_id,
+            project_name=str(construction.data.get("project_name") or "") or None,
+            opened_at=construction.opened_at,
+            closes_at=construction.closes_at,
+            started_at=construction.started_at,
+            completes_at=construction.completes_at,
+            progress_percent=_construction_progress(construction, now),
+            winner_method=str(construction.data.get("winner_method") or "") or None,
+            final_results=final_results,
+            completed_monuments=completed,
+        )
+
+
+refuge_construction_service = RefugeConstructionService()
+
+
+__all__ = [
+    "CONSTRUCTION_PROJECTS",
+    "CONSTRUCTION_STATUS_BUILDING",
+    "CONSTRUCTION_STATUS_TIE_BREAK",
+    "CONSTRUCTION_STATUS_VOTING",
+    "CONSTRUCTION_TIE_EXTENSION_HOURS",
+    "PROJECT_BY_ID",
+    "RefugeConstructionConfig",
+    "RefugeConstructionOption",
+    "RefugeConstructionProject",
+    "RefugeConstructionService",
+    "RefugeConstructionSnapshot",
+    "refuge_construction_service",
+]

--- a/services/refuge_construction.py
+++ b/services/refuge_construction.py
@@ -432,6 +432,7 @@ class RefugeConstructionService:
         data["project_name"] = project.name
         data["project_description"] = project.description
         data["building_id"] = project.building_id
+        data["visual_stage"] = 0
 
         active = replace(
             construction,
@@ -607,7 +608,21 @@ class RefugeConstructionService:
 
             if construction.status == CONSTRUCTION_STATUS_BUILDING:
                 completes_at = _parse_timestamp(construction.completes_at)
-                if completes_at is None or now < completes_at:
+                if completes_at is None:
+                    return state, changed
+                if now < completes_at:
+                    progress = _construction_progress(construction, now)
+                    visual_stage = min(3, max(0, progress // 25))
+                    try:
+                        previous_stage = int(construction.data.get("visual_stage", 0))
+                    except (TypeError, ValueError):
+                        previous_stage = 0
+                    if visual_stage != previous_stage:
+                        data = dict(construction.data)
+                        data["visual_stage"] = visual_stage
+                        construction = replace(construction, data=data)
+                        state = replace(state, active_construction=construction)
+                        changed = True
                     return state, changed
                 state = self._complete_building(state, construction, now=now)
                 changed = True

--- a/services/refuge_exploration_runtime.py
+++ b/services/refuge_exploration_runtime.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from services.refuge_exploration import (
+    RefugeExplorerSnapshot,
+    RefugeExplorerZoneSnapshot,
+    RefugeExplorationService,
+    RefugeFootprintSnapshot,
+    refuge_exploration_service,
+)
+from storage.refuge_world_store import RefugeWorldStore, refuge_world_store
+from utils.timezones import PARIS_TZ
+
+
+def _format_date(value: object) -> str:
+    if not value:
+        return "date inconnue"
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return "date inconnue"
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(PARIS_TZ).strftime("%d/%m/%Y")
+
+
+def _monuments_zone(state) -> RefugeExplorerZoneSnapshot:
+    monuments = [
+        building
+        for building in state.buildings
+        if building.building_id.startswith("monument:") and int(building.level) > 0
+    ]
+    monuments.sort(key=lambda item: (item.unlocked_at or "", item.building_id))
+
+    if not monuments:
+        return RefugeExplorerZoneSnapshot(
+            zone_id="monuments",
+            title="Les Monuments",
+            emoji="🗿",
+            details=(
+                "Aucun monument communautaire n’est encore inscrit dans le Refuge.",
+                "Cette section accueille uniquement des constructions permanentes réellement obtenues par la communauté.",
+            ),
+        )
+
+    history: list[str] = []
+    for building in reversed(monuments):
+        name = str(
+            building.state.get("project_name") or building.building_id
+        ).strip()
+        description = str(building.state.get("description") or "").strip()
+        row = f"{_format_date(building.unlocked_at)} · {name}"
+        if description:
+            row += f" — {description}"
+        history.append(row)
+
+    return RefugeExplorerZoneSnapshot(
+        zone_id="monuments",
+        title="Les Monuments",
+        emoji="🗿",
+        details=(
+            f"Constructions permanentes : {len(monuments)}.",
+            "Chaque monument provient d’un chantier réellement remporté par la communauté.",
+        ),
+        history=tuple(history),
+    )
+
+
+class RefugeExplorationRuntimeService:
+    """Enrich REFUGE-009 exploration with construction-owned monument history."""
+
+    def __init__(
+        self,
+        *,
+        exploration_service: RefugeExplorationService = refuge_exploration_service,
+        world_store: RefugeWorldStore = refuge_world_store,
+    ) -> None:
+        self.exploration_service = exploration_service
+        self.world_store = world_store
+
+    async def get_explorer(self, *, at=None) -> RefugeExplorerSnapshot:
+        snapshot = await self.exploration_service.get_explorer(at=at)
+        state = await self.world_store.get_state()
+        replacement = _monuments_zone(state)
+        zones = tuple(
+            replacement if zone.zone_id == "monuments" else zone
+            for zone in snapshot.zones
+        )
+        return RefugeExplorerSnapshot(zones=zones)
+
+    async def get_footprint(self, user_id: int, *, at=None) -> RefugeFootprintSnapshot:
+        return await self.exploration_service.get_footprint(user_id, at=at)
+
+
+refuge_exploration_runtime_service = RefugeExplorationRuntimeService()
+
+
+__all__ = [
+    "RefugeExplorationRuntimeService",
+    "refuge_exploration_runtime_service",
+]

--- a/services/refuge_panel.py
+++ b/services/refuge_panel.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import json
 from dataclasses import dataclass
@@ -8,15 +7,16 @@ from datetime import datetime, timezone
 from typing import Final, Mapping
 
 from models.refuge_world import RefugeHistoricalEvent, RefugeWorldState
-from rendering.refuge_casino import (
-    RefugeCasinoRenderer,
-    casino_scene_signature,
-    refuge_casino_renderer,
+from rendering.refuge_construction import (
+    RefugeConstructionRenderer,
+    construction_scene_signature,
+    refuge_construction_renderer,
 )
 from rendering.refuge_world import RefugeRenderContext
 from services.refuge_casino import RefugeCasinoService, refuge_casino_service
 from services.refuge_fire import RefugeFireService, refuge_fire_service
 from services.refuge_hall import RefugeHallService, refuge_hall_service
+from services.refuge_world_coordination import refuge_world_mutation_lock
 from utils.seasons import season_id_for, season_label
 
 
@@ -133,6 +133,14 @@ def event_label(event: RefugeHistoricalEvent | None) -> str | None:
         return "Une nouvelle trace est entrée au Hall"
     if event.event_type.endswith("secret_discovered"):
         return "Un mystère du Refuge a été découvert"
+    if event.event_type == "construction_vote_opened":
+        return "Un nouveau chantier s’est ouvert"
+    if event.event_type == "construction_vote_tied":
+        return "Le vote du chantier est à égalité"
+    if event.event_type == "construction_started":
+        return "Une construction a commencé"
+    if event.event_type == "construction_completed":
+        return "Un monument a été inauguré"
     return "Un nouvel événement a marqué le Refuge"
 
 
@@ -155,17 +163,16 @@ class RefugePanelService:
         fire_service: RefugeFireService = refuge_fire_service,
         hall_service: RefugeHallService = refuge_hall_service,
         casino_service: RefugeCasinoService = refuge_casino_service,
-        renderer: RefugeCasinoRenderer = refuge_casino_renderer,
+        renderer: RefugeConstructionRenderer = refuge_construction_renderer,
     ) -> None:
         self.fire_service = fire_service
         self.hall_service = hall_service
         self.casino_service = casino_service
         self.renderer = renderer
-        self._lock = asyncio.Lock()
 
     async def evaluate(self, *, at: datetime | None = None) -> RefugePanelSnapshot:
         now = _aware_utc(at)
-        async with self._lock:
+        async with refuge_world_mutation_lock():
             # Sequential evaluation is intentional: all three services share
             # RefugeWorldStore and each stage must observe the previous write.
             fire = await self.fire_service.evaluate(at=now)
@@ -182,7 +189,7 @@ class RefugePanelService:
                 fire.intensity,
                 fire.intensity.capitalize(),
             )
-            visual_signature = casino_scene_signature(state, context)
+            visual_signature = construction_scene_signature(state, context)
             summary_payload = {
                 "season_id": current_season,
                 "fire_level": fire.level,

--- a/services/refuge_world_coordination.py
+++ b/services/refuge_world_coordination.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import asyncio
+import weakref
+
+
+_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+    weakref.WeakKeyDictionary()
+)
+
+
+def refuge_world_mutation_lock() -> asyncio.Lock:
+    """Return one loop-local lock shared by Refuge world orchestrators."""
+
+    loop = asyncio.get_running_loop()
+    lock = _locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _locks[loop] = lock
+    return lock
+
+
+__all__ = ["refuge_world_mutation_lock"]

--- a/tests/test_refuge_construction.py
+++ b/tests/test_refuge_construction.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services.refuge_construction import (
+    CONSTRUCTION_STATUS_BUILDING,
+    CONSTRUCTION_STATUS_TIE_BREAK,
+    CONSTRUCTION_STATUS_VOTING,
+    RefugeConstructionConfig,
+    RefugeConstructionService,
+)
+from storage.community_goal_store import CommunityGoalStore
+from storage.refuge_world_store import RefugeWorldStore
+
+
+UTC = timezone.utc
+CONFIG = RefugeConstructionConfig(vote_hours=72, build_hours=168)
+
+
+async def _complete_goal(
+    store: CommunityGoalStore,
+    *,
+    at: datetime,
+    title: str,
+    metric_key: str = "messages",
+) -> dict:
+    created = await store.create_goal(
+        metric_key=metric_key,
+        target=10,
+        baseline_total=0,
+        created_by=42,
+        created_at=at - timedelta(minutes=1),
+        ends_at=at + timedelta(days=2),
+        title=title,
+    )
+    finished = await store.finish_goal(
+        str(created["id"]),
+        status="completed",
+        final_progress=10,
+        at=at,
+    )
+    assert finished is not None
+    return finished
+
+
+@pytest.mark.asyncio
+async def test_construction_is_prospective_and_opens_from_new_completed_goal(tmp_path):
+    goal_store = CommunityGoalStore(tmp_path / "goals.json")
+    world_store = RefugeWorldStore(tmp_path / "world.json")
+    service = RefugeConstructionService(
+        world_store=world_store,
+        goal_store=goal_store,
+        chooser=lambda choices: choices[0],
+    )
+    t0 = datetime(2026, 8, 9, 12, 0, tzinfo=UTC)
+
+    await _complete_goal(
+        goal_store,
+        at=t0 - timedelta(hours=1),
+        title="Ancien objectif",
+    )
+    initial = await service.sync(at=t0, config=CONFIG)
+    assert initial.active is False
+
+    goal = await _complete_goal(
+        goal_store,
+        at=t0 + timedelta(minutes=5),
+        title="Nouvel objectif",
+    )
+    opened = await service.sync(at=t0 + timedelta(minutes=5), config=CONFIG)
+
+    assert opened.active is True
+    assert opened.status == CONSTRUCTION_STATUS_VOTING
+    assert opened.source_goal_id == goal["id"]
+    assert opened.source_goal_title == "Nouvel objectif"
+    assert len(opened.options) == 3
+    assert opened.allowed_project_ids == (
+        "star_observatory",
+        "memory_garden",
+        "lantern_tower",
+    )
+    assert opened.final_results == ()
+
+    world = await world_store.get_state()
+    assert world.active_construction is not None
+    assert any(
+        event.event_type == "construction_vote_opened"
+        for event in world.events
+    )
+
+
+@pytest.mark.asyncio
+async def test_one_member_one_changeable_vote_and_hidden_live_results(tmp_path):
+    goal_store = CommunityGoalStore(tmp_path / "goals.json")
+    world_store = RefugeWorldStore(tmp_path / "world.json")
+    service = RefugeConstructionService(
+        world_store=world_store,
+        goal_store=goal_store,
+        chooser=lambda choices: choices[0],
+    )
+    t0 = datetime(2026, 8, 9, 12, 0, tzinfo=UTC)
+    await service.sync(at=t0, config=CONFIG)
+    await _complete_goal(goal_store, at=t0 + timedelta(minutes=1), title="Objectif")
+    opened_at = t0 + timedelta(minutes=1)
+    await service.sync(at=opened_at, config=CONFIG)
+
+    await service.cast_vote(
+        100,
+        "star_observatory",
+        at=opened_at + timedelta(minutes=1),
+        config=CONFIG,
+    )
+    changed = await service.cast_vote(
+        100,
+        "memory_garden",
+        at=opened_at + timedelta(minutes=2),
+        config=CONFIG,
+    )
+    await service.cast_vote(
+        200,
+        "memory_garden",
+        at=opened_at + timedelta(minutes=3),
+        config=CONFIG,
+    )
+
+    assert changed.user_vote == "memory_garden"
+    assert changed.final_results == ()
+
+    state = await world_store.get_state()
+    assert state.active_construction is not None
+    votes = state.active_construction.data["votes"]
+    assert votes == {"100": "memory_garden", "200": "memory_garden"}
+
+
+@pytest.mark.asyncio
+async def test_vote_winner_builds_only_with_elapsed_time_and_becomes_permanent(tmp_path):
+    goal_store = CommunityGoalStore(tmp_path / "goals.json")
+    world_store = RefugeWorldStore(tmp_path / "world.json")
+    service = RefugeConstructionService(
+        world_store=world_store,
+        goal_store=goal_store,
+        chooser=lambda choices: choices[0],
+    )
+    t0 = datetime(2026, 8, 9, 12, 0, tzinfo=UTC)
+    await service.sync(at=t0, config=CONFIG)
+    goal_at = t0 + timedelta(minutes=1)
+    await _complete_goal(goal_store, at=goal_at, title="Objectif")
+    await service.sync(at=goal_at, config=CONFIG)
+    await service.cast_vote(1, "memory_garden", at=goal_at + timedelta(hours=1), config=CONFIG)
+    await service.cast_vote(2, "memory_garden", at=goal_at + timedelta(hours=2), config=CONFIG)
+    await service.cast_vote(3, "star_observatory", at=goal_at + timedelta(hours=3), config=CONFIG)
+
+    vote_close = goal_at + timedelta(hours=72)
+    building = await service.sync(at=vote_close, config=CONFIG)
+
+    assert building.status == CONSTRUCTION_STATUS_BUILDING
+    assert building.project_id == "memory_garden"
+    assert building.project_name == "Jardin des Souvenirs"
+    assert building.winner_method == "vote"
+    assert dict(building.final_results) == {
+        "lantern_tower": 0,
+        "memory_garden": 2,
+        "star_observatory": 1,
+    }
+    assert building.progress_percent == 0
+
+    halfway = await service.sync(
+        at=vote_close + timedelta(hours=84),
+        config=CONFIG,
+    )
+    assert halfway.status == CONSTRUCTION_STATUS_BUILDING
+    assert 49 <= halfway.progress_percent <= 50
+    state = await world_store.get_state()
+    assert state.active_construction is not None
+    assert state.active_construction.data["visual_stage"] == 2
+
+    completed = await service.sync(
+        at=vote_close + timedelta(hours=168),
+        config=CONFIG,
+    )
+    assert completed.active is False
+    assert "Jardin des Souvenirs" in completed.completed_monuments
+
+    state = await world_store.get_state()
+    monument = next(
+        building
+        for building in state.buildings
+        if building.building_id == "monument:memory_garden"
+    )
+    assert monument.level == 1
+    assert monument.state["project_name"] == "Jardin des Souvenirs"
+    assert any(
+        event.event_type == "construction_completed"
+        and event.data.get("project_id") == "memory_garden"
+        for event in state.events
+    )
+
+
+@pytest.mark.asyncio
+async def test_tie_extends_24_hours_then_uses_explicit_random_resolution(tmp_path):
+    goal_store = CommunityGoalStore(tmp_path / "goals.json")
+    world_store = RefugeWorldStore(tmp_path / "world.json")
+    chosen: list[tuple[str, ...]] = []
+
+    def choose(options):
+        values = tuple(options)
+        chosen.append(values)
+        return values[0]
+
+    service = RefugeConstructionService(
+        world_store=world_store,
+        goal_store=goal_store,
+        chooser=choose,
+    )
+    t0 = datetime(2026, 8, 9, 12, 0, tzinfo=UTC)
+    await service.sync(at=t0, config=CONFIG)
+    goal_at = t0 + timedelta(minutes=1)
+    await _complete_goal(goal_store, at=goal_at, title="Objectif")
+    await service.sync(at=goal_at, config=CONFIG)
+    await service.cast_vote(1, "star_observatory", at=goal_at + timedelta(hours=1), config=CONFIG)
+    await service.cast_vote(2, "memory_garden", at=goal_at + timedelta(hours=2), config=CONFIG)
+
+    tied = await service.sync(
+        at=goal_at + timedelta(hours=72),
+        config=CONFIG,
+    )
+    assert tied.status == CONSTRUCTION_STATUS_TIE_BREAK
+    assert set(tied.allowed_project_ids) == {"memory_garden", "star_observatory"}
+    assert chosen == []
+
+    resolved = await service.sync(
+        at=goal_at + timedelta(hours=96),
+        config=CONFIG,
+    )
+    assert resolved.status == CONSTRUCTION_STATUS_BUILDING
+    assert resolved.winner_method == "random_tie"
+    assert resolved.project_id == "memory_garden"
+    assert chosen == [("memory_garden", "star_observatory")]
+
+    state = await world_store.get_state()
+    assert any(event.event_type == "construction_vote_tied" for event in state.events)
+    started = next(event for event in state.events if event.event_type == "construction_started")
+    assert started.data["winner_method"] == "random_tie"
+
+
+@pytest.mark.asyncio
+async def test_completed_goals_queue_without_replacing_active_construction(tmp_path):
+    goal_store = CommunityGoalStore(tmp_path / "goals.json")
+    world_store = RefugeWorldStore(tmp_path / "world.json")
+    service = RefugeConstructionService(
+        world_store=world_store,
+        goal_store=goal_store,
+        chooser=lambda choices: choices[0],
+    )
+    t0 = datetime(2026, 8, 9, 12, 0, tzinfo=UTC)
+    await service.sync(at=t0, config=CONFIG)
+
+    first_at = t0 + timedelta(minutes=1)
+    first = await _complete_goal(goal_store, at=first_at, title="Premier")
+    opened = await service.sync(at=first_at, config=CONFIG)
+    assert opened.source_goal_id == first["id"]
+
+    second_at = t0 + timedelta(minutes=2)
+    second = await _complete_goal(goal_store, at=second_at, title="Deuxième")
+    still_first = await service.sync(at=second_at, config=CONFIG)
+    assert still_first.source_goal_id == first["id"]
+
+    state = await world_store.get_state()
+    queued = state.state["construction_pending_goals"]
+    assert [item["id"] for item in queued] == [second["id"]]

--- a/tests/test_refuge_construction_renderer.py
+++ b/tests/test_refuge_construction_renderer.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+from models.refuge_world import (
+    RefugeBuildingState,
+    RefugeConstructionState,
+    RefugeWorldState,
+)
+from rendering.refuge_construction import RefugeConstructionRenderer
+from rendering.refuge_world import REFUGE_CANVAS_SIZE, RefugeRenderContext
+
+
+class _BaseRenderer:
+    def render_png(self, state, *, context=None):
+        image = Image.new("RGB", REFUGE_CANVAS_SIZE, (70, 95, 72))
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG", compress_level=9)
+        return buffer.getvalue()
+
+
+def _render(state):
+    renderer = RefugeConstructionRenderer(base_renderer=_BaseRenderer())
+    context = RefugeRenderContext(season="summer", daypart="day")
+    return renderer.render_png(state, context=context)
+
+
+def test_construction_renderer_is_deterministic_and_keeps_canvas_contract():
+    state = RefugeWorldState(
+        active_construction=RefugeConstructionState(
+            construction_id="goal:abc",
+            status="voting",
+            opened_at="2026-08-09T12:00:00+00:00",
+            closes_at="2026-08-12T12:00:00+00:00",
+            data={"projects": [], "votes": {}},
+        )
+    )
+
+    first = _render(state)
+    second = _render(state)
+
+    assert first == second
+    image = Image.open(io.BytesIO(first))
+    assert image.size == REFUGE_CANVAS_SIZE
+    assert image.mode == "RGB"
+
+
+def test_vote_tie_and_building_stages_have_distinct_visual_outputs():
+    voting = RefugeWorldState(
+        active_construction=RefugeConstructionState(
+            construction_id="goal:abc",
+            status="voting",
+            data={},
+        )
+    )
+    tie = RefugeWorldState(
+        active_construction=RefugeConstructionState(
+            construction_id="goal:abc",
+            status="tie_break",
+            data={"tied_project_ids": ["a", "b"]},
+        )
+    )
+    building_0 = RefugeWorldState(
+        active_construction=RefugeConstructionState(
+            construction_id="goal:abc",
+            status="building",
+            project_id="memory_garden",
+            data={"visual_stage": 0},
+        )
+    )
+    building_2 = RefugeWorldState(
+        active_construction=RefugeConstructionState(
+            construction_id="goal:abc",
+            status="building",
+            project_id="memory_garden",
+            data={"visual_stage": 2},
+        )
+    )
+
+    outputs = {_render(voting), _render(tie), _render(building_0), _render(building_2)}
+    assert len(outputs) == 4
+
+
+def test_each_permanent_monument_changes_the_world_visual():
+    states = []
+    for building_id, name in (
+        ("monument:star_observatory", "Observatoire des Étoiles"),
+        ("monument:memory_garden", "Jardin des Souvenirs"),
+        ("monument:lantern_tower", "Tour des Lanternes"),
+    ):
+        states.append(
+            RefugeWorldState(
+                buildings=(
+                    RefugeBuildingState(
+                        building_id=building_id,
+                        level=1,
+                        unlocked_at="2026-08-19T12:00:00+00:00",
+                        state={"project_name": name},
+                    ),
+                )
+            )
+        )
+
+    assert len({_render(state) for state in states}) == 3

--- a/tests/test_refuge_construction_view.py
+++ b/tests/test_refuge_construction_view.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import discord
+
+from services.refuge_construction import (
+    RefugeConstructionOption,
+    RefugeConstructionSnapshot,
+)
+from ui.refuge_construction_view import RefugeConstructionView
+
+
+OPTIONS = (
+    RefugeConstructionOption(
+        "star_observatory",
+        "Observatoire des Étoiles",
+        "🔭",
+        "Observer le ciel.",
+    ),
+    RefugeConstructionOption(
+        "memory_garden",
+        "Jardin des Souvenirs",
+        "🌿",
+        "Conserver les traces.",
+    ),
+    RefugeConstructionOption(
+        "lantern_tower",
+        "Tour des Lanternes",
+        "🏮",
+        "Veiller sur le Refuge.",
+    ),
+)
+
+
+def _snapshot(**overrides):
+    values = {
+        "active": True,
+        "status": "voting",
+        "construction_id": "goal:abc",
+        "source_goal_id": "abc",
+        "source_goal_title": "100 heures ensemble",
+        "options": OPTIONS,
+        "allowed_project_ids": tuple(option.project_id for option in OPTIONS),
+        "user_vote": None,
+        "project_id": None,
+        "project_name": None,
+        "opened_at": "2026-08-09T12:00:00+00:00",
+        "closes_at": "2026-08-12T12:00:00+00:00",
+        "started_at": None,
+        "completes_at": None,
+        "progress_percent": 0,
+        "winner_method": None,
+        "final_results": (),
+        "completed_monuments": (),
+    }
+    values.update(overrides)
+    return RefugeConstructionSnapshot(**values)
+
+
+def _text(view):
+    return "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+
+
+def _selects(view):
+    return [
+        item for item in view.walk_children()
+        if isinstance(item, discord.ui.Select)
+    ]
+
+
+def test_voting_view_has_three_projects_and_hides_live_results():
+    view = RefugeConstructionView(_snapshot(), owner_user_id=42)
+
+    selects = _selects(view)
+    assert len(selects) == 1
+    assert [option.value for option in selects[0].options] == [
+        "star_observatory",
+        "memory_garden",
+        "lantern_tower",
+    ]
+    text = _text(view)
+    assert "résultats intermédiaires restent masqués" in text
+    assert "Résultats finaux" not in text
+    assert "100 heures ensemble" in text
+
+
+def test_tie_break_view_exposes_only_tied_finalists_without_scores():
+    view = RefugeConstructionView(
+        _snapshot(
+            status="tie_break",
+            allowed_project_ids=("star_observatory", "memory_garden"),
+        ),
+        owner_user_id=42,
+    )
+
+    select = _selects(view)[0]
+    assert {option.value for option in select.options} == {
+        "star_observatory",
+        "memory_garden",
+    }
+    text = _text(view)
+    assert "Prolongation pour égalité" in text
+    assert "24 h" in text
+    assert "Résultats finaux" not in text
+
+
+def test_building_view_reveals_final_results_and_time_progress_only():
+    view = RefugeConstructionView(
+        _snapshot(
+            status="building",
+            allowed_project_ids=(),
+            project_id="memory_garden",
+            project_name="Jardin des Souvenirs",
+            started_at="2026-08-12T12:00:00+00:00",
+            completes_at="2026-08-19T12:00:00+00:00",
+            progress_percent=50,
+            winner_method="random_tie",
+            final_results=(
+                ("lantern_tower", 1),
+                ("memory_garden", 4),
+                ("star_observatory", 4),
+            ),
+        ),
+        owner_user_id=42,
+    )
+
+    assert _selects(view) == []
+    text = _text(view)
+    assert "50%" in text
+    assert "temps écoulé" in text
+    assert "tirage au sort après égalité persistante" in text
+    assert "Résultats finaux" in text
+
+
+def test_inactive_view_lists_existing_permanent_monuments_without_vote_control():
+    view = RefugeConstructionView(
+        _snapshot(
+            active=False,
+            status=None,
+            construction_id=None,
+            source_goal_id=None,
+            source_goal_title=None,
+            options=(),
+            allowed_project_ids=(),
+            project_id=None,
+            project_name=None,
+            opened_at=None,
+            closes_at=None,
+            started_at=None,
+            completes_at=None,
+            completed_monuments=("Observatoire des Étoiles",),
+        ),
+        owner_user_id=42,
+    )
+
+    assert _selects(view) == []
+    text = _text(view)
+    assert "Aucun chantier actif" in text
+    assert "Observatoire des Étoiles" in text

--- a/tests/test_refuge_exploration_runtime.py
+++ b/tests/test_refuge_exploration_runtime.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from models.refuge_world import RefugeBuildingState, RefugeWorldState
+from services.refuge_exploration import (
+    RefugeExplorerSnapshot,
+    RefugeExplorerZoneSnapshot,
+)
+from services.refuge_exploration_runtime import RefugeExplorationRuntimeService
+
+
+class _Exploration:
+    async def get_explorer(self, *, at=None):
+        return RefugeExplorerSnapshot(
+            zones=(
+                RefugeExplorerZoneSnapshot("fire", "Le Feu", "🔥", ("Feu",)),
+                RefugeExplorerZoneSnapshot("hall", "Le Hall", "🏆", ("Hall",)),
+                RefugeExplorerZoneSnapshot("casino", "Le Casino", "🎰", ("Casino",)),
+                RefugeExplorerZoneSnapshot("construction", "Le Chantier", "🏗️", ("Chantier",)),
+                RefugeExplorerZoneSnapshot(
+                    "monuments",
+                    "Les Monuments",
+                    "🗿",
+                    ("Aucun monument communautaire n’est encore inscrit dans le Refuge.",),
+                ),
+                RefugeExplorerZoneSnapshot("mysteries", "Les Mystères", "🌌", ("Mystères",)),
+            )
+        )
+
+    async def get_footprint(self, user_id, *, at=None):
+        return (user_id, at)
+
+
+class _WorldStore:
+    def __init__(self, state):
+        self.state = state
+
+    async def get_state(self):
+        return self.state
+
+
+async def test_runtime_replaces_static_monument_zone_with_persisted_buildings():
+    state = RefugeWorldState(
+        buildings=(
+            RefugeBuildingState(
+                building_id="monument:memory_garden",
+                level=1,
+                unlocked_at="2026-08-19T12:00:00+00:00",
+                state={
+                    "project_name": "Jardin des Souvenirs",
+                    "description": "Un jardin permanent.",
+                },
+            ),
+        )
+    )
+    service = RefugeExplorationRuntimeService(
+        exploration_service=_Exploration(),
+        world_store=_WorldStore(state),
+    )
+
+    snapshot = await service.get_explorer()
+    monuments = snapshot.get_zone("monuments")
+
+    assert "Constructions permanentes : 1." in monuments.details
+    assert any("Jardin des Souvenirs" in row for row in monuments.history)
+    assert any("19/08/2026" in row for row in monuments.history)
+    assert tuple(zone.zone_id for zone in snapshot.zones) == (
+        "fire",
+        "hall",
+        "casino",
+        "construction",
+        "monuments",
+        "mysteries",
+    )
+
+
+async def test_runtime_keeps_empty_monument_copy_until_real_construction_exists():
+    service = RefugeExplorationRuntimeService(
+        exploration_service=_Exploration(),
+        world_store=_WorldStore(RefugeWorldState()),
+    )
+
+    snapshot = await service.get_explorer()
+    monuments = snapshot.get_zone("monuments")
+
+    assert monuments.history == ()
+    assert "Aucun monument communautaire" in monuments.details[0]

--- a/tests/test_refuge_panel_view.py
+++ b/tests/test_refuge_panel_view.py
@@ -86,22 +86,17 @@ def test_callback_registration_view_is_persistent_and_has_same_custom_ids():
     ]
 
 
-def test_only_timeline_and_construction_remain_pending_after_refuge_009():
-    for action, expected in (
-        ("timeline", "Chronologie"),
-        ("construction", "Chantier"),
-    ):
-        view = RefugePendingActionView(action)
-        assert isinstance(view, discord.ui.LayoutView)
-        assert view.timeout == 120
-        text = "\n".join(
-            item.content
-            for item in view.walk_children()
-            if isinstance(item, discord.ui.TextDisplay)
-        )
-        assert expected in text
+def test_only_timeline_remains_pending_after_refuge_010():
+    view = RefugePendingActionView("timeline")
+    assert isinstance(view, discord.ui.LayoutView)
+    assert view.timeout == 120
+    text = "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+    assert "Chronologie" in text
 
-    with pytest.raises(ValueError):
-        RefugePendingActionView("explore")
-    with pytest.raises(ValueError):
-        RefugePendingActionView("footprint")
+    for action in ("explore", "footprint", "construction"):
+        with pytest.raises(ValueError):
+            RefugePendingActionView(action)

--- a/ui/refuge_construction_view.py
+++ b/ui/refuge_construction_view.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import discord
+
+from services.refuge_construction import (
+    CONSTRUCTION_STATUS_BUILDING,
+    CONSTRUCTION_STATUS_TIE_BREAK,
+    CONSTRUCTION_STATUS_VOTING,
+    PROJECT_BY_ID,
+    RefugeConstructionSnapshot,
+    refuge_construction_service,
+)
+
+
+REFUGE_CONSTRUCTION_ACCENT = discord.Colour(0xB77B42)
+
+
+def _discord_time(value: str | None, style: str = "R") -> str:
+    if not value:
+        return "échéance inconnue"
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return "échéance inconnue"
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return f"<t:{int(parsed.timestamp())}:{style}>"
+
+
+def _progress_bar(percent: int, width: int = 10) -> str:
+    normalized = max(0, min(100, int(percent)))
+    filled = min(width, max(0, int(normalized * width / 100)))
+    return "█" * filled + "░" * (width - filled)
+
+
+def _winner_method_label(method: str | None) -> str:
+    return {
+        "vote": "majorité au vote",
+        "tie_extension_vote": "majorité après prolongation",
+        "random_tie": "tirage au sort après égalité persistante",
+    }.get(str(method or ""), "résultat du vote")
+
+
+class RefugeConstructionVoteSelect(discord.ui.Select):
+    def __init__(self, snapshot: RefugeConstructionSnapshot) -> None:
+        option_by_id = {option.project_id: option for option in snapshot.options}
+        options: list[discord.SelectOption] = []
+        for project_id in snapshot.allowed_project_ids:
+            project = option_by_id.get(project_id)
+            if project is None:
+                continue
+            options.append(
+                discord.SelectOption(
+                    label=project.name,
+                    value=project.project_id,
+                    emoji=project.emoji,
+                    description=project.description[:100] or None,
+                    default=snapshot.user_vote == project.project_id,
+                )
+            )
+        super().__init__(
+            custom_id="refuge:construction:vote",
+            placeholder="Choisir le projet du Refuge",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, RefugeConstructionView):
+            return
+        await interaction.response.defer()
+        try:
+            snapshot = await refuge_construction_service.cast_vote(
+                interaction.user.id,
+                self.values[0],
+            )
+        except ValueError:
+            snapshot = await refuge_construction_service.get_snapshot(interaction.user.id)
+        view.refresh(snapshot)
+        await interaction.edit_original_response(view=view)
+
+
+class RefugeConstructionView(discord.ui.LayoutView):
+    """Private construction vote/status surface. Live vote totals stay hidden."""
+
+    def __init__(
+        self,
+        snapshot: RefugeConstructionSnapshot,
+        *,
+        owner_user_id: int,
+    ) -> None:
+        super().__init__(timeout=300)
+        self.owner_user_id = int(owner_user_id)
+        self.snapshot = snapshot
+        self.refresh(snapshot)
+
+    async def interaction_check(self, interaction: discord.Interaction, /) -> bool:
+        if interaction.user.id == self.owner_user_id:
+            return True
+        await interaction.response.send_message(
+            "Ce bulletin privé appartient à la personne qui l’a ouvert.",
+            ephemeral=True,
+        )
+        return False
+
+    def refresh(self, snapshot: RefugeConstructionSnapshot) -> None:
+        self.snapshot = snapshot
+        self.clear_items()
+        container = discord.ui.Container(accent_colour=REFUGE_CONSTRUCTION_ACCENT)
+        container.add_item(
+            discord.ui.TextDisplay(
+                "## 🏗️ LE CHANTIER\n"
+                "Chaque droit de bâtir vient d’un objectif communautaire réellement réussi."
+            )
+        )
+        container.add_item(discord.ui.Separator())
+
+        if not snapshot.active:
+            lines = [
+                "### Aucun chantier actif",
+                "Le prochain vote s’ouvrira lorsqu’un nouvel objectif communautaire sera validé.",
+                "Aucune action répétitive ne peut accélérer l’ouverture d’un chantier.",
+            ]
+            container.add_item(discord.ui.TextDisplay("\n".join(lines)))
+        elif snapshot.status in {CONSTRUCTION_STATUS_VOTING, CONSTRUCTION_STATUS_TIE_BREAK}:
+            self._add_vote(container, snapshot)
+        elif snapshot.status == CONSTRUCTION_STATUS_BUILDING:
+            self._add_building(container, snapshot)
+        else:
+            container.add_item(
+                discord.ui.TextDisplay(
+                    "Le chantier existe, mais son état actuel n’est pas encore affichable."
+                )
+            )
+
+        if snapshot.completed_monuments:
+            container.add_item(discord.ui.Separator())
+            container.add_item(
+                discord.ui.TextDisplay(
+                    "### 🗿 Constructions permanentes\n"
+                    + "\n".join(f"• {name}" for name in snapshot.completed_monuments)
+                )
+            )
+
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "-# Un membre = un vote. Tu peux modifier ton choix tant que le scrutin reste ouvert."
+            )
+        )
+        self.add_item(container)
+
+    def _add_vote(
+        self,
+        container: discord.ui.Container,
+        snapshot: RefugeConstructionSnapshot,
+    ) -> None:
+        if snapshot.status == CONSTRUCTION_STATUS_TIE_BREAK:
+            heading = "### ⚖️ Prolongation pour égalité"
+            intro = (
+                "Le premier scrutin s’est terminé à égalité. "
+                "Seuls les projets encore ex æquo restent éligibles pendant 24 h."
+            )
+        else:
+            heading = "### 🗳️ Vote communautaire"
+            intro = "Choisis le projet qui deviendra une construction permanente du Refuge."
+
+        source = snapshot.source_goal_title or "Objectif communautaire réussi"
+        lines = [
+            heading,
+            f"Origine : **{source}**",
+            f"Clôture : **{_discord_time(snapshot.closes_at)}**",
+            intro,
+            "",
+        ]
+        allowed = set(snapshot.allowed_project_ids)
+        for option in snapshot.options:
+            if option.project_id not in allowed:
+                continue
+            lines.append(f"{option.emoji} **{option.name}** — {option.description}")
+        lines.extend(
+            [
+                "",
+                (
+                    f"Ton vote actuel : **{PROJECT_BY_ID[snapshot.user_vote].name}**"
+                    if snapshot.user_vote in PROJECT_BY_ID
+                    else "Ton vote actuel : **aucun**"
+                ),
+                "🔒 Les résultats intermédiaires restent masqués jusqu’à la clôture.",
+            ]
+        )
+        container.add_item(discord.ui.TextDisplay("\n".join(lines)))
+        if snapshot.allowed_project_ids:
+            container.add_item(discord.ui.Separator())
+            container.add_item(discord.ui.ActionRow(RefugeConstructionVoteSelect(snapshot)))
+
+    def _add_building(
+        self,
+        container: discord.ui.Container,
+        snapshot: RefugeConstructionSnapshot,
+    ) -> None:
+        project_name = snapshot.project_name or "Projet du Refuge"
+        percent = max(0, min(100, int(snapshot.progress_percent)))
+        lines = [
+            f"### 🧱 {project_name}",
+            (
+                f"{_progress_bar(percent)} **{percent}%**\n"
+                f"Inauguration : **{_discord_time(snapshot.completes_at)}**"
+            ),
+            "La progression dépend uniquement du temps écoulé.",
+            "",
+            f"Résolution du vote : **{_winner_method_label(snapshot.winner_method)}**.",
+        ]
+
+        if snapshot.final_results:
+            option_by_id = {option.project_id: option for option in snapshot.options}
+            lines.append("Résultats finaux :")
+            for project_id, count in snapshot.final_results:
+                option = option_by_id.get(project_id)
+                name = option.name if option is not None else project_id
+                lines.append(f"• {name} : **{count}**")
+        container.add_item(discord.ui.TextDisplay("\n".join(lines)))
+
+
+__all__ = [
+    "REFUGE_CONSTRUCTION_ACCENT",
+    "RefugeConstructionView",
+    "RefugeConstructionVoteSelect",
+]

--- a/ui/refuge_panel_view.py
+++ b/ui/refuge_panel_view.py
@@ -5,8 +5,10 @@ from typing import Final, Literal
 
 import discord
 
+from services.refuge_construction import refuge_construction_service
 from services.refuge_exploration import refuge_exploration_service
 from services.refuge_panel import RefugePanelSnapshot
+from ui.refuge_construction_view import RefugeConstructionView
 from ui.refuge_exploration_view import (
     RefugeExplorerView,
     RefugeFootprintView,
@@ -25,11 +27,6 @@ _ACTION_COPY: Final[dict[str, tuple[str, str, str]]] = {
         "Les archives mensuelles du Refuge seront consultables depuis ce bouton.",
         "Les saisons passées deviendront des chapitres permanents de son histoire.",
     ),
-    "construction": (
-        "🏗️ Chantier",
-        "Les votes et le suivi des constructions apparaîtront ici lorsqu’un chantier sera ouvert.",
-        "Aucune action artificielle ne sera nécessaire pour accélérer une construction.",
-    ),
 }
 
 
@@ -39,7 +36,7 @@ def _roman(level: int) -> str:
 
 
 class RefugePendingActionView(discord.ui.LayoutView):
-    """Small ephemeral V2 response for actions scheduled after REFUGE-009."""
+    """Small ephemeral V2 response for actions scheduled after REFUGE-010."""
 
     def __init__(self, action: RefugePanelAction) -> None:
         super().__init__(timeout=120)
@@ -74,7 +71,7 @@ class RefugePanelButton(discord.ui.Button):
         self.action = action
 
     async def callback(self, interaction: discord.Interaction) -> None:
-        if self.action not in {"explore", "footprint"}:
+        if self.action == "timeline":
             await interaction.response.send_message(
                 view=RefugePendingActionView(self.action),
                 ephemeral=True,
@@ -89,7 +86,7 @@ class RefugePanelButton(discord.ui.Button):
                     snapshot,
                     owner_user_id=interaction.user.id,
                 )
-            else:
+            elif self.action == "footprint":
                 snapshot = await refuge_exploration_service.get_footprint(
                     interaction.user.id
                 )
@@ -110,6 +107,14 @@ class RefugePanelButton(discord.ui.Button):
                     snapshot,
                     display_name=display_name,
                     avatar_url=avatar_url,
+                )
+            else:
+                snapshot = await refuge_construction_service.get_snapshot(
+                    interaction.user.id
+                )
+                view = RefugeConstructionView(
+                    snapshot,
+                    owner_user_id=interaction.user.id,
                 )
         except Exception:
             logger.exception(

--- a/ui/refuge_panel_view.py
+++ b/ui/refuge_panel_view.py
@@ -6,7 +6,7 @@ from typing import Final, Literal
 import discord
 
 from services.refuge_construction import refuge_construction_service
-from services.refuge_exploration import refuge_exploration_service
+from services.refuge_exploration_runtime import refuge_exploration_runtime_service
 from services.refuge_panel import RefugePanelSnapshot
 from ui.refuge_construction_view import RefugeConstructionView
 from ui.refuge_exploration_view import (
@@ -81,13 +81,13 @@ class RefugePanelButton(discord.ui.Button):
         await interaction.response.defer(ephemeral=True, thinking=True)
         try:
             if self.action == "explore":
-                snapshot = await refuge_exploration_service.get_explorer()
+                snapshot = await refuge_exploration_runtime_service.get_explorer()
                 view: discord.ui.LayoutView = RefugeExplorerView(
                     snapshot,
                     owner_user_id=interaction.user.id,
                 )
             elif self.action == "footprint":
-                snapshot = await refuge_exploration_service.get_footprint(
+                snapshot = await refuge_exploration_runtime_service.get_footprint(
                     interaction.user.id
                 )
                 avatar = getattr(interaction.user, "display_avatar", None)


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-010 — Chantier** : transformer les objectifs communautaires réellement réussis en droits à bâtir, avec vote privé, résultats intermédiaires masqués, construction fondée uniquement sur le temps écoulé et monument permanent.

## Source de vérité
Le Chantier ne crée aucun nouveau système d’objectif.

Il consomme uniquement les entrées existantes de `community_goals.json` dont le statut est réellement `completed`.

Chaque `goal_id` devient au maximum une fois l’origine d’un droit à bâtir. Les objectifs `expired` ou `cancelled` ne déclenchent rien.

### Activation prospective
REFUGE-010 enregistre une date d’activation lors de son premier démarrage. Les objectifs déjà terminés avant cette date ne sont volontairement pas rejoués afin d’éviter une ouverture massive de chantiers historiques lors du déploiement.

Les nouveaux objectifs réussis après activation sont détectés par réconciliation toutes les minutes. Si plusieurs objectifs sont réussis pendant un chantier actif, ils sont mis en file d’attente et traités ensuite dans l’ordre de réussite.

## Vote
Un chantier ouvert propose exactement trois projets V1 :
- 🔭 **Observatoire des Étoiles** — observatoire permanent tourné vers le ciel du Refuge ;
- 🌿 **Jardin des Souvenirs** — jardin permanent consacré aux traces communautaires ;
- 🏮 **Tour des Lanternes** — tour permanente veillant sur le Refuge.

Le vote est privé via le bouton public `🏗️ Chantier`, sans nouvelle commande.

Règles :
- un membre = un vote ;
- le membre peut modifier son choix tant que le scrutin est ouvert ;
- le stockage conserve seulement son dernier choix ;
- les résultats intermédiaires et le nombre de voix restent cachés pendant le vote ;
- les résultats finaux deviennent visibles une fois le scrutin terminé.

## Durées V1 proposées — à valider avant fusion
Deux valeurs qui n’avaient pas encore été fixées dans le design sont proposées dans cette draft :
- vote normal : **72 h** ;
- construction : **168 h / 7 jours**.

Elles sont configurables par :
- `REFUGE_CONSTRUCTION_VOTE_HOURS` ;
- `REFUGE_CONSTRUCTION_BUILD_HOURS`.

L’égalité suit en revanche la règle déjà validée : **prolongation de 24 h**.

## Égalité
À la clôture normale :
- majorité unique → le gagnant est retenu ;
- égalité → seuls les projets ex æquo restent éligibles pendant 24 h.

Après ces 24 h :
- majorité unique → gagnant par prolongation ;
- égalité persistante → tirage explicite via `secrets.choice` uniquement parmi les projets encore ex æquo.

Le mode de résolution (`vote`, `tie_extension_vote`, `random_tie`) est persisté dans l’état/historique.

## Construction
Le gagnant passe en statut `building`.

La progression dépend exclusivement de `started_at` et `completes_at` : aucune action Discord, aucun clic, aucun message et aucun XP ne peuvent l’accélérer.

Pour éviter des écritures chaque minute, le monde persiste uniquement quatre états visuels d’échafaudage :
- 0 % ;
- 25 % ;
- 50 % ;
- 75 %.

La vue privée peut afficher le pourcentage temporel exact calculé à la lecture.

À échéance, le monument devient un `RefugeBuildingState` permanent `monument:*`, le chantier actif est libéré et un événement `construction_completed` est conservé.

## Carte
Nouvelle composition déterministe :
`terrain → Feu → Hall → Casino → Chantier / Monuments`.

Le pad Chantier reste centré sur `(646, 616)`.

La carte distingue :
- vote normal ;
- prolongation d’égalité ;
- quatre stades d’échafaudage ;
- Observatoire ;
- Jardin ;
- Tour des Lanternes.

Aucune horloge n’est consultée par le renderer : l’état visuel vient uniquement de l’état monde déjà persisté + saison/plage horaire, donc même état = même PNG.

## Explorer
`Explorer → Monuments` n’est plus un écran statique lorsque des constructions existent.

Une couche de lecture REFUGE-010 enrichit le snapshot REFUGE-009 avec les vrais bâtiments `monument:*` persistés : nom, date d’inauguration et description. Aucun second historique n’est créé.

## Components V2
Le `custom_id` public reste inchangé :
`refuge:panel:construction`.

Le bouton ouvre maintenant une vue éphémère privée :
- aucun chantier → état d’attente ;
- vote → trois choix + ton vote + échéance, sans scores ;
- égalité → uniquement les finalistes ;
- construction → pourcentage temporel, inauguration, mode de résolution et résultats finaux.

`Chronologie` reste la seule action encore en attente de REFUGE-011.

## Coordination des écritures
REFUGE-010 ajoute un verrou d’orchestration partagé entre le rafraîchissement du panneau et les mutations du Chantier.

Le but est d’empêcher une évaluation Feu/Hall/Casino et un changement de vote/construction d’écrire simultanément deux versions divergentes de `RefugeWorldState`.

Aucun changement de schéma `refuge_world.json` : `RefugeConstructionState` et `active_construction` existaient déjà depuis REFUGE-001.

## Limite V1 à valider explicitement
Le catalogue de cette draft contient trois **archétypes fixes**. Un futur chantier peut donc reproposer un archétype déjà construit ; dans l’état actuel de la draft, une nouvelle victoire du même archétype réutiliserait son emplacement/identifiant de monument au lieu de créer un quatrième type de lieu.

Cette règle n’était pas définie auparavant : elle est volontairement signalée avant fusion. La draft ne doit être validée que si ces trois projets, les durées 72 h / 7 jours et cette sémantique V1 conviennent.

## Fichiers
- `cogs/refuge_construction.py`
- `rendering/refuge_construction.py`
- `rendering/__init__.py`
- `services/refuge_construction.py`
- `services/refuge_exploration_runtime.py`
- `services/refuge_panel.py`
- `services/refuge_world_coordination.py`
- `ui/refuge_construction_view.py`
- `ui/refuge_panel_view.py`
- tests ciblés REFUGE-010 / panel / Explorer.

Aucun fichier XP, Casino économique, succès, objectif communautaire existant ou modèle de monde n’est modifié.

## Tests ajoutés
Les tests couvrent notamment :
- activation prospective ;
- ancien objectif réussi ignoré ;
- nouvel objectif réussi → vote ;
- exactement trois projets ;
- remplacement du vote d’un même membre ;
- absence de résultats live dans le snapshot/UI ;
- gagnant majoritaire ;
- progression uniquement temporelle ;
- paliers visuels ;
- inauguration permanente ;
- égalité → 24 h ;
- tirage seulement après égalité persistante ;
- file d’attente de plusieurs objectifs ;
- rendu déterministe ;
- distinction vote/égalité/construction ;
- affichage des monuments persistés dans Explorer ;
- maintien des quatre `custom_id` publics ;
- seule Chronologie reste pending.

## Validation disponible
La branche est basée sur le `main` actuel `eda44772ace369f45a11e0982143f7c16e78dbfd` et la comparaison est `ahead_by=16`, `behind_by=0`.

Les deux commits accidentels précédant la branche (`__tmp_probe__` créé vide puis supprimé) ont été contrôlés séparément : GitHub retourne **0 fichier différent** entre le commit REFUGE-009 validé et ce `main`; ils n’ont donc aucun effet sur le contenu du dépôt.

La suite pytest réelle du dépôt n’est **pas déclarée comme passée** dans le runtime ChatGPT. Les tests sont présents dans la branche et les checks GitHub seront inspectés sur le head de la PR.

## Hors périmètre
- aucune récompense XP ;
- aucun farm ;
- aucune modification des objectifs communautaires existants ;
- aucune modification des probabilités/récompenses Casino ;
- aucune Chronologie/snapshot mensuel REFUGE-011 ;
- aucun déclencheur secret REFUGE-012.

La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.