### PR TITLE
feat: automate Refuge community goals

### DIFF
--- a/cogs/community_goals.py
+++ b/cogs/community_goals.py
@@ -199,6 +199,7 @@ class CommunityGoalsCog(commands.Cog):
         await self._evaluate_goals()
         active_goals = await community_goal_store.list_goals(status=ACTIVE_STATUS)
         completed = await community_goal_store.list_goals(status="completed")
+        automation_state = await community_goal_store.get_automation_state()
 
         display_goals: list[CommunityGoalDisplay] = []
         for goal in active_goals:
@@ -217,6 +218,16 @@ class CommunityGoalsCog(commands.Cog):
             except (TypeError, ValueError):
                 deadline = "échéance inconnue"
 
+            automation_note = None
+            if goal.get("source") == "automatic":
+                metadata = goal.get("metadata", {})
+                difficulty = (
+                    str(metadata.get("difficulty_label") or "Variable")
+                    if isinstance(metadata, dict)
+                    else "Variable"
+                )
+                automation_note = f"🤖 Objectif automatique · difficulté **{difficulty}**"
+
             display_goals.append(
                 CommunityGoalDisplay(
                     title=str(goal.get("title") or metric.label),
@@ -231,6 +242,7 @@ class CommunityGoalsCog(commands.Cog):
                         if goal.get("reward_text")
                         else None
                     ),
+                    automation_note=automation_note,
                 )
             )
 
@@ -243,9 +255,26 @@ class CommunityGoalsCog(commands.Cog):
                 continue
             recent_completed.append(str(goal.get("title") or metric.label))
 
+        if active_goals:
+            automation_status = "🤖 Automatisation en pause tant qu’un objectif est actif."
+        else:
+            next_goal_at = automation_state.get("next_goal_at")
+            try:
+                parsed = datetime.fromisoformat(str(next_goal_at))
+                next_timestamp = int(parsed.timestamp())
+            except (TypeError, ValueError):
+                next_timestamp = 0
+            if next_timestamp > 0:
+                automation_status = (
+                    f"🤖 Prochain tirage automatique : <t:{next_timestamp}:R>."
+                )
+            else:
+                automation_status = "🤖 Automatisation prête pour le prochain tirage."
+
         view = CommunityGoalsView(
             active_goals=tuple(display_goals),
             completed_titles=tuple(recent_completed),
+            automation_status=automation_status,
         )
         await interaction.response.send_message(view=view)
 

--- a/cogs/community_goals.py
+++ b/cogs/community_goals.py
@@ -9,6 +9,7 @@ from discord import app_commands
 from discord.ext import commands, tasks
 
 from config import ANNOUNCE_CHANNEL_ID
+from services.community_goal_automation import community_goal_automation_service
 from storage.community_goal_store import ACTIVE_STATUS, community_goal_store
 from storage.season_store import season_store
 from ui.community_goals_view import CommunityGoalDisplay, CommunityGoalsView
@@ -27,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 
 class CommunityGoalsCog(commands.Cog):
-    """Staff-created collective objectives backed by seasonal activity data."""
+    """Collective objectives backed by real seasonal activity data."""
 
     def __init__(self, bot: commands.Bot) -> None:
         self.bot = bot
@@ -58,20 +59,26 @@ class CommunityGoalsCog(commands.Cog):
             int(goal.get("target", 0)),
         )
 
-    async def _announce_completion(
-        self,
-        goal: dict[str, Any],
-        progress: int,
-    ) -> None:
+    async def _announcement_channel(self) -> discord.TextChannel | discord.Thread | None:
         if ANNOUNCE_CHANNEL_ID <= 0:
-            return
+            return None
         channel = self.bot.get_channel(ANNOUNCE_CHANNEL_ID)
         if channel is None:
             try:
                 channel = await self.bot.fetch_channel(ANNOUNCE_CHANNEL_ID)
             except discord.HTTPException:
-                return
+                return None
         if not isinstance(channel, (discord.TextChannel, discord.Thread)):
+            return None
+        return channel
+
+    async def _announce_completion(
+        self,
+        goal: dict[str, Any],
+        progress: int,
+    ) -> None:
+        channel = await self._announcement_channel()
+        if channel is None:
             return
 
         metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(str(goal.get("metric_key", "")))
@@ -92,6 +99,38 @@ class CommunityGoalsCog(commands.Cog):
             await channel.send(embed=embed)
         except discord.HTTPException:
             logger.warning("Impossible d'annoncer l'objectif communautaire atteint")
+
+    async def _announce_automatic_goal(self, goal: dict[str, Any]) -> None:
+        channel = await self._announcement_channel()
+        if channel is None:
+            return
+        metric = COMMUNITY_GOAL_METRICS_BY_KEY.get(str(goal.get("metric_key", "")))
+        if metric is None:
+            return
+
+        metadata = goal.get("metadata", {})
+        if not isinstance(metadata, dict):
+            metadata = {}
+        difficulty = str(metadata.get("difficulty_label") or "Variable")
+        try:
+            duration_days = max(1, int(metadata.get("duration_days", 1)))
+        except (TypeError, ValueError):
+            duration_days = 1
+        target = max(1, int(goal.get("target", 1)))
+        title = str(goal.get("title") or metric.label)
+        embed = discord.Embed(
+            title="🎯 Un nouvel objectif apparaît au Refuge",
+            description=(
+                f"### {metric.emoji} {title}\n"
+                f"Cible : **{format_goal_value(metric.key, target)}**\n"
+                f"Difficulté : **{difficulty}** · Durée : **{duration_days} jour(s)**\n\n"
+                "-# La cible a été calibrée sur l'activité réelle de la saison actuelle."
+            ),
+        )
+        try:
+            await channel.send(embed=embed)
+        except discord.HTTPException:
+            logger.warning("Impossible d'annoncer l'objectif communautaire automatique")
 
     async def _evaluate_goals(self) -> None:
         active_goals = await community_goal_store.list_goals(status=ACTIVE_STATUS)
@@ -142,6 +181,9 @@ class CommunityGoalsCog(commands.Cog):
     async def evaluate_community_goals(self) -> None:
         try:
             await self._evaluate_goals()
+            automation = await community_goal_automation_service.sync()
+            if automation.created_goal is not None:
+                await self._announce_automatic_goal(automation.created_goal)
         except Exception:
             logger.exception("Erreur pendant l'évaluation des objectifs communautaires")
 
@@ -255,6 +297,7 @@ class CommunityGoalsCog(commands.Cog):
                 ends_at=now + timedelta(days=int(duree_jours)),
                 title=titre,
                 reward_text=recompense,
+                source="manual",
             )
         except ValueError as exc:
             if "already exists" in str(exc):

--- a/services/community_goal_automation.py
+++ b/services/community_goal_automation.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import os
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Protocol, Sequence
+
+from storage.community_goal_store import CommunityGoalStore, community_goal_store
+from storage.season_store import SeasonStore, season_store
+from utils.community_goals import COMMUNITY_GOAL_METRICS, CommunityGoalMetric
+from utils.seasons import season_id_for
+
+
+DIFFICULTY_MULTIPLIERS: tuple[tuple[str, float], ...] = (
+    ("easy", 0.80),
+    ("normal", 1.00),
+    ("ambitious", 1.20),
+)
+DIFFICULTY_LABELS = {
+    "easy": "Facile",
+    "normal": "Normal",
+    "ambitious": "Ambitieux",
+}
+
+_TITLE_TEMPLATES: dict[str, tuple[str, ...]] = {
+    "xp": (
+        "Élan collectif",
+        "La montée du Refuge",
+        "L’effort commun",
+        "Une poussée d’énergie",
+    ),
+    "messages": (
+        "Le Refuge s’anime",
+        "Les voix du camp",
+        "Chroniques du Refuge",
+        "La place s’éveille",
+    ),
+    "vocal": (
+        "Autour du grand feu",
+        "Les veillées du Refuge",
+        "Le cercle des voix",
+        "Nuits au campement",
+    ),
+    "casino": (
+        "La table est ouverte",
+        "Fièvre au Casino",
+        "Les dés du Refuge",
+        "Une semaine de hasard",
+    ),
+}
+
+_TARGET_GRANULARITY = {
+    "xp": 100,
+    "messages": 10,
+    "vocal": 900,
+    "casino": 5,
+}
+
+
+class RandomSource(Protocol):
+    def choice(self, seq: Sequence[Any]) -> Any: ...
+
+    def randint(self, a: int, b: int) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityGoalAutomationConfig:
+    cooldown_min_hours: int = 12
+    cooldown_max_hours: int = 36
+    duration_min_days: int = 2
+    duration_max_days: int = 5
+    minimum_observation_hours: int = 24
+
+    def __post_init__(self) -> None:
+        if self.cooldown_min_hours < 0:
+            raise ValueError("cooldown_min_hours must be >= 0")
+        if self.cooldown_max_hours < self.cooldown_min_hours:
+            raise ValueError("cooldown_max_hours must be >= cooldown_min_hours")
+        if self.duration_min_days < 1:
+            raise ValueError("duration_min_days must be >= 1")
+        if self.duration_max_days < self.duration_min_days:
+            raise ValueError("duration_max_days must be >= duration_min_days")
+        if self.minimum_observation_hours < 1:
+            raise ValueError("minimum_observation_hours must be >= 1")
+
+    @classmethod
+    def from_env(cls) -> "CommunityGoalAutomationConfig":
+        return cls(
+            cooldown_min_hours=_env_int("REFUGE_AUTO_GOAL_COOLDOWN_MIN_HOURS", 12),
+            cooldown_max_hours=_env_int("REFUGE_AUTO_GOAL_COOLDOWN_MAX_HOURS", 36),
+            duration_min_days=_env_int("REFUGE_AUTO_GOAL_DURATION_MIN_DAYS", 2),
+            duration_max_days=_env_int("REFUGE_AUTO_GOAL_DURATION_MAX_DAYS", 5),
+            minimum_observation_hours=_env_int(
+                "REFUGE_AUTO_GOAL_MIN_OBSERVATION_HOURS", 24
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MetricActivityRate:
+    metric_key: str
+    total: int
+    observed_days: float
+    daily_rate: float
+
+
+@dataclass(frozen=True, slots=True)
+class CommunityGoalAutomationResult:
+    created_goal: dict[str, Any] | None
+    next_goal_at: str | None
+    changed: bool
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return int(raw.strip())
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer") from exc
+
+
+def _aware_utc(at: datetime | None = None) -> datetime:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _sum_season_field(payload: Mapping[str, Any], field: str) -> int:
+    users = payload.get("users", {})
+    if not isinstance(users, Mapping):
+        return 0
+    total = 0
+    for user in users.values():
+        if not isinstance(user, Mapping):
+            continue
+        try:
+            total += int(user.get(field, 0))
+        except (TypeError, ValueError):
+            continue
+    return max(0, total)
+
+
+def _round_target(metric_key: str, raw_target: float) -> int:
+    granularity = max(1, int(_TARGET_GRANULARITY.get(metric_key, 1)))
+    rounded = int(round(max(1.0, raw_target) / granularity)) * granularity
+    return max(granularity, rounded)
+
+
+def _automatic_state(payload: Mapping[str, Any] | None) -> dict[str, Any]:
+    source = payload if isinstance(payload, Mapping) else {}
+    recent = source.get("recent_metric_keys", ())
+    recent_keys = (
+        [str(item) for item in recent if str(item)]
+        if isinstance(recent, (list, tuple))
+        else []
+    )
+    return {
+        "enabled_at": str(source.get("enabled_at") or "") or None,
+        "next_goal_at": str(source.get("next_goal_at") or "") or None,
+        "recent_metric_keys": recent_keys[-3:],
+        "had_active_goal": bool(source.get("had_active_goal", False)),
+        "last_generated_at": str(source.get("last_generated_at") or "") or None,
+        "last_goal_id": str(source.get("last_goal_id") or "") or None,
+    }
+
+
+class CommunityGoalAutomationService:
+    """Generate one adaptive random community goal when the Refuge is idle."""
+
+    def __init__(
+        self,
+        *,
+        goal_store: CommunityGoalStore = community_goal_store,
+        season_store_: SeasonStore = season_store,
+        random_source: RandomSource | None = None,
+    ) -> None:
+        self.goal_store = goal_store
+        self.season_store = season_store_
+        self.random = random_source or secrets.SystemRandom()
+
+    async def _activity_rates(
+        self,
+        *,
+        at: datetime,
+        config: CommunityGoalAutomationConfig,
+    ) -> dict[str, MetricActivityRate]:
+        current_season_id = season_id_for(at)
+        payload = await self.season_store.get_season(current_season_id)
+        if not isinstance(payload, Mapping):
+            return {}
+
+        started_at = _parse_timestamp(payload.get("started_at"))
+        if started_at is None:
+            tracking_started = await self.season_store.tracking_started_at()
+            started_at = _parse_timestamp(tracking_started)
+        if started_at is None:
+            return {}
+
+        elapsed_hours = max(
+            float(config.minimum_observation_hours),
+            (at - started_at).total_seconds() / 3600.0,
+        )
+        observed_days = elapsed_hours / 24.0
+        rates: dict[str, MetricActivityRate] = {}
+        for metric in COMMUNITY_GOAL_METRICS:
+            total = _sum_season_field(payload, metric.season_field)
+            if total <= 0:
+                continue
+            daily_rate = total / observed_days
+            if daily_rate <= 0:
+                continue
+            rates[metric.key] = MetricActivityRate(
+                metric_key=metric.key,
+                total=total,
+                observed_days=observed_days,
+                daily_rate=daily_rate,
+            )
+        return rates
+
+    def _choose_metric(
+        self,
+        rates: Mapping[str, MetricActivityRate],
+        recent_metric_keys: Sequence[str],
+    ) -> CommunityGoalMetric | None:
+        eligible = [metric for metric in COMMUNITY_GOAL_METRICS if metric.key in rates]
+        if not eligible:
+            return None
+        if len(eligible) > 1 and recent_metric_keys:
+            last = str(recent_metric_keys[-1])
+            without_last = [metric for metric in eligible if metric.key != last]
+            if without_last:
+                eligible = without_last
+        return self.random.choice(tuple(eligible))
+
+    def _schedule_next(
+        self,
+        *,
+        now: datetime,
+        config: CommunityGoalAutomationConfig,
+    ) -> datetime:
+        delay = self.random.randint(
+            config.cooldown_min_hours,
+            config.cooldown_max_hours,
+        )
+        return now + timedelta(hours=delay)
+
+    async def sync(
+        self,
+        *,
+        at: datetime | None = None,
+        config: CommunityGoalAutomationConfig | None = None,
+    ) -> CommunityGoalAutomationResult:
+        now = _aware_utc(at)
+        cfg = config or CommunityGoalAutomationConfig.from_env()
+        stored = _automatic_state(await self.goal_store.get_automation_state())
+        changed = False
+
+        if stored["enabled_at"] is None:
+            stored["enabled_at"] = now.isoformat()
+            changed = True
+
+        active_goals = await self.goal_store.list_goals(status="active")
+        if active_goals:
+            if not stored["had_active_goal"] or stored["next_goal_at"] is not None:
+                stored["had_active_goal"] = True
+                stored["next_goal_at"] = None
+                changed = True
+            if changed:
+                await self.goal_store.set_automation_state(stored)
+            return CommunityGoalAutomationResult(None, None, changed)
+
+        if stored["had_active_goal"]:
+            stored["had_active_goal"] = False
+            stored["next_goal_at"] = self._schedule_next(now=now, config=cfg).isoformat()
+            changed = True
+            await self.goal_store.set_automation_state(stored)
+            return CommunityGoalAutomationResult(
+                None,
+                stored["next_goal_at"],
+                True,
+            )
+
+        due_at = _parse_timestamp(stored["next_goal_at"])
+        if due_at is None:
+            due_at = self._schedule_next(now=now, config=cfg)
+            stored["next_goal_at"] = due_at.isoformat()
+            changed = True
+            await self.goal_store.set_automation_state(stored)
+            return CommunityGoalAutomationResult(None, due_at.isoformat(), True)
+
+        if now < due_at:
+            return CommunityGoalAutomationResult(None, due_at.isoformat(), changed)
+
+        rates = await self._activity_rates(at=now, config=cfg)
+        metric = self._choose_metric(rates, stored["recent_metric_keys"])
+        if metric is None:
+            # No measurable activity yet: retry after another random cooldown
+            # instead of inventing a target from an arbitrary floor.
+            next_at = self._schedule_next(now=now, config=cfg)
+            stored["next_goal_at"] = next_at.isoformat()
+            await self.goal_store.set_automation_state(stored)
+            return CommunityGoalAutomationResult(None, next_at.isoformat(), True)
+
+        duration_days = self.random.randint(cfg.duration_min_days, cfg.duration_max_days)
+        difficulty_key, multiplier = self.random.choice(DIFFICULTY_MULTIPLIERS)
+        rate = rates[metric.key]
+        target = _round_target(
+            metric.key,
+            rate.daily_rate * float(duration_days) * float(multiplier),
+        )
+        templates = _TITLE_TEMPLATES.get(metric.key, (metric.label,))
+        title = str(self.random.choice(templates))
+        baseline_total = await self._all_time_metric_total(metric)
+
+        try:
+            created = await self.goal_store.create_goal(
+                metric_key=metric.key,
+                target=target,
+                baseline_total=baseline_total,
+                created_by=0,
+                created_at=now,
+                ends_at=now + timedelta(days=duration_days),
+                title=title,
+                reward_text=None,
+                source="automatic",
+                metadata={
+                    "difficulty": difficulty_key,
+                    "difficulty_label": DIFFICULTY_LABELS[difficulty_key],
+                    "duration_days": duration_days,
+                    "daily_rate": round(rate.daily_rate, 4),
+                    "observed_days": round(rate.observed_days, 4),
+                    "multiplier": multiplier,
+                },
+                require_no_active=True,
+            )
+        except ValueError as exc:
+            # A manual goal may have appeared between the idle check and the
+            # atomic create. Treat that race as a normal pause, never as an
+            # automation failure.
+            if "active goal" not in str(exc):
+                raise
+            stored["had_active_goal"] = True
+            stored["next_goal_at"] = None
+            await self.goal_store.set_automation_state(stored)
+            return CommunityGoalAutomationResult(None, None, True)
+
+        recent = [*stored["recent_metric_keys"], metric.key][-3:]
+        stored["recent_metric_keys"] = recent
+        stored["last_generated_at"] = now.isoformat()
+        stored["last_goal_id"] = str(created.get("id") or "") or None
+        stored["had_active_goal"] = True
+        stored["next_goal_at"] = None
+        await self.goal_store.set_automation_state(stored)
+        return CommunityGoalAutomationResult(created, None, True)
+
+    async def _all_time_metric_total(self, metric: CommunityGoalMetric) -> int:
+        total = 0
+        for season_id in await self.season_store.list_seasons():
+            payload = await self.season_store.get_season(season_id)
+            if isinstance(payload, Mapping):
+                total += _sum_season_field(payload, metric.season_field)
+        return max(0, total)
+
+
+community_goal_automation_service = CommunityGoalAutomationService()
+
+
+__all__ = [
+    "DIFFICULTY_LABELS",
+    "DIFFICULTY_MULTIPLIERS",
+    "CommunityGoalAutomationConfig",
+    "CommunityGoalAutomationResult",
+    "CommunityGoalAutomationService",
+    "MetricActivityRate",
+    "community_goal_automation_service",
+]

--- a/storage/community_goal_store.py
+++ b/storage/community_goal_store.py
@@ -6,7 +6,7 @@ import weakref
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 
 from config import DATA_DIR
 from utils.persistence import atomic_write_json_async, read_json_safe
@@ -17,13 +17,23 @@ ACTIVE_STATUS = "active"
 TERMINAL_STATUSES = frozenset({"completed", "expired", "cancelled"})
 
 
+def _automation_copy(value: Any) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    return {str(key): deepcopy(item) for key, item in value.items()}
+
+
 class CommunityGoalStore:
-    """Persist staff-created community goals and their lifecycle."""
+    """Persist community goals, lifecycle and lightweight automation state."""
 
     def __init__(self, path: str | Path = COMMUNITY_GOALS_FILE) -> None:
         self.path = Path(path)
         self._loaded = False
-        self._data: dict[str, Any] = {"schema_version": 1, "goals": {}}
+        self._data: dict[str, Any] = {
+            "schema_version": 1,
+            "goals": {},
+            "automation": {},
+        }
         self._locks: weakref.WeakKeyDictionary[
             asyncio.AbstractEventLoop, asyncio.Lock
         ] = weakref.WeakKeyDictionary()
@@ -41,6 +51,7 @@ class CommunityGoalStore:
             return
         raw = await asyncio.to_thread(read_json_safe, self.path, {})
         goals: dict[str, Any] = {}
+        automation: dict[str, Any] = {}
         if isinstance(raw, dict):
             raw_goals = raw.get("goals", {})
             if isinstance(raw_goals, dict):
@@ -49,7 +60,12 @@ class CommunityGoalStore:
                     for goal_id, payload in raw_goals.items()
                     if isinstance(payload, dict)
                 }
-        self._data = {"schema_version": 1, "goals": goals}
+            automation = _automation_copy(raw.get("automation"))
+        self._data = {
+            "schema_version": 1,
+            "goals": goals,
+            "automation": automation,
+        }
         self._loaded = True
 
     async def create_goal(
@@ -63,6 +79,9 @@ class CommunityGoalStore:
         title: str | None = None,
         reward_text: str | None = None,
         created_at: datetime | None = None,
+        source: str = "manual",
+        metadata: Mapping[str, Any] | None = None,
+        require_no_active: bool = False,
     ) -> dict[str, Any]:
         now = created_at or datetime.now(timezone.utc)
         if now.tzinfo is None:
@@ -75,15 +94,22 @@ class CommunityGoalStore:
         if int(target) <= 0:
             raise ValueError("target must be positive")
 
+        normalized_source = str(source).strip().lower() or "manual"
+        if normalized_source not in {"manual", "automatic"}:
+            raise ValueError("unsupported goal source")
+
         async with self._get_lock():
             await self._load_locked()
             goals = self._data["goals"]
-            for payload in goals.values():
-                if (
-                    isinstance(payload, dict)
-                    and payload.get("status") == ACTIVE_STATUS
-                    and payload.get("metric_key") == metric_key
-                ):
+            active_payloads = [
+                payload
+                for payload in goals.values()
+                if isinstance(payload, dict) and payload.get("status") == ACTIVE_STATUS
+            ]
+            if require_no_active and active_payloads:
+                raise ValueError("an active goal already exists")
+            for payload in active_payloads:
+                if payload.get("metric_key") == metric_key:
                     raise ValueError("an active goal already exists for this metric")
 
             goal_id = uuid.uuid4().hex[:10]
@@ -97,6 +123,8 @@ class CommunityGoalStore:
                 "ends_at": end.astimezone(timezone.utc).isoformat(),
                 "title": str(title).strip() if title else None,
                 "reward_text": str(reward_text).strip() if reward_text else None,
+                "source": normalized_source,
+                "metadata": _automation_copy(metadata),
                 "status": ACTIVE_STATUS,
                 "completed_at": None,
                 "expired_at": None,
@@ -146,6 +174,22 @@ class CommunityGoalStore:
             payload[f"{status}_at"] = timestamp
             await atomic_write_json_async(self.path, self._data)
             return deepcopy(payload)
+
+    async def get_automation_state(self) -> dict[str, Any]:
+        async with self._get_lock():
+            await self._load_locked()
+            return _automation_copy(self._data.get("automation"))
+
+    async def set_automation_state(
+        self,
+        state: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        normalized = _automation_copy(state)
+        async with self._get_lock():
+            await self._load_locked()
+            self._data["automation"] = normalized
+            await atomic_write_json_async(self.path, self._data)
+            return _automation_copy(normalized)
 
 
 community_goal_store = CommunityGoalStore()

--- a/tests/test_community_goal_automation.py
+++ b/tests/test_community_goal_automation.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Sequence
+
+import pytest
+
+from services.community_goal_automation import (
+    CommunityGoalAutomationConfig,
+    CommunityGoalAutomationService,
+)
+from storage.community_goal_store import CommunityGoalStore
+from storage.season_store import SeasonStore
+
+
+class FirstRandom:
+    def choice(self, seq: Sequence[Any]) -> Any:
+        return seq[0]
+
+    def randint(self, a: int, b: int) -> int:
+        return a
+
+
+async def _record_messages(
+    store: SeasonStore,
+    *,
+    at: datetime,
+    amount: int,
+) -> None:
+    await store.record(1, at=at, messages=amount)
+
+
+def _config(**overrides: int) -> CommunityGoalAutomationConfig:
+    values = {
+        "cooldown_min_hours": 0,
+        "cooldown_max_hours": 0,
+        "duration_min_days": 2,
+        "duration_max_days": 2,
+        "minimum_observation_hours": 24,
+    }
+    values.update(overrides)
+    return CommunityGoalAutomationConfig(**values)
+
+
+@pytest.mark.asyncio
+async def test_first_sync_only_schedules_then_due_sync_creates_adaptive_goal(tmp_path: Path):
+    goals = CommunityGoalStore(tmp_path / "goals.json")
+    seasons = SeasonStore(tmp_path / "seasons.json")
+    now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+    await _record_messages(
+        seasons,
+        at=now - timedelta(days=2),
+        amount=2000,
+    )
+
+    service = CommunityGoalAutomationService(
+        goal_store=goals,
+        season_store_=seasons,
+        random_source=FirstRandom(),
+    )
+
+    first = await service.sync(at=now, config=_config())
+    assert first.created_goal is None
+    assert first.next_goal_at == now.isoformat()
+
+    second = await service.sync(at=now, config=_config())
+    assert second.created_goal is not None
+    created = second.created_goal
+    assert created["metric_key"] == "messages"
+    assert created["source"] == "automatic"
+    assert created["created_by"] == 0
+    assert created["target"] == 1600
+    assert created["metadata"]["difficulty"] == "easy"
+    assert created["metadata"]["difficulty_label"] == "Facile"
+    assert created["metadata"]["duration_days"] == 2
+    assert created["metadata"]["multiplier"] == 0.8
+
+
+@pytest.mark.asyncio
+async def test_category_without_measured_activity_is_never_invented(tmp_path: Path):
+    goals = CommunityGoalStore(tmp_path / "goals.json")
+    seasons = SeasonStore(tmp_path / "seasons.json")
+    now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+    service = CommunityGoalAutomationService(
+        goal_store=goals,
+        season_store_=seasons,
+        random_source=FirstRandom(),
+    )
+
+    await service.sync(at=now, config=_config())
+    result = await service.sync(at=now, config=_config())
+
+    assert result.created_goal is None
+    assert await goals.list_goals() == []
+    assert result.next_goal_at == now.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_generator_waits_until_all_active_goals_are_finished(tmp_path: Path):
+    goals = CommunityGoalStore(tmp_path / "goals.json")
+    seasons = SeasonStore(tmp_path / "seasons.json")
+    now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+    await _record_messages(seasons, at=now - timedelta(days=2), amount=2000)
+    manual = await goals.create_goal(
+        metric_key="messages",
+        target=100,
+        baseline_total=0,
+        created_by=42,
+        created_at=now,
+        ends_at=now + timedelta(days=1),
+    )
+    service = CommunityGoalAutomationService(
+        goal_store=goals,
+        season_store_=seasons,
+        random_source=FirstRandom(),
+    )
+
+    active = await service.sync(at=now, config=_config())
+    assert active.created_goal is None
+    assert active.next_goal_at is None
+
+    await goals.finish_goal(
+        manual["id"],
+        status="completed",
+        final_progress=100,
+        at=now + timedelta(hours=2),
+    )
+    after_finish = await service.sync(at=now + timedelta(hours=2), config=_config())
+    assert after_finish.created_goal is None
+    assert after_finish.next_goal_at == (now + timedelta(hours=2)).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_last_category_is_avoided_when_another_measured_metric_exists(tmp_path: Path):
+    goals = CommunityGoalStore(tmp_path / "goals.json")
+    seasons = SeasonStore(tmp_path / "seasons.json")
+    now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+    await seasons.record(
+        1,
+        at=now - timedelta(days=2),
+        xp_earned=4000,
+        messages=2000,
+    )
+    await goals.set_automation_state(
+        {
+            "enabled_at": (now - timedelta(days=3)).isoformat(),
+            "next_goal_at": now.isoformat(),
+            "recent_metric_keys": ["xp"],
+            "had_active_goal": False,
+        }
+    )
+    service = CommunityGoalAutomationService(
+        goal_store=goals,
+        season_store_=seasons,
+        random_source=FirstRandom(),
+    )
+
+    result = await service.sync(at=now, config=_config())
+
+    assert result.created_goal is not None
+    assert result.created_goal["metric_key"] == "messages"
+
+
+@pytest.mark.asyncio
+async def test_random_cooldown_and_duration_use_configured_bounds(tmp_path: Path):
+    goals = CommunityGoalStore(tmp_path / "goals.json")
+    seasons = SeasonStore(tmp_path / "seasons.json")
+    now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+    service = CommunityGoalAutomationService(
+        goal_store=goals,
+        season_store_=seasons,
+        random_source=FirstRandom(),
+    )
+    cfg = _config(
+        cooldown_min_hours=12,
+        cooldown_max_hours=36,
+        duration_min_days=2,
+        duration_max_days=5,
+    )
+
+    result = await service.sync(at=now, config=cfg)
+
+    assert result.next_goal_at == (now + timedelta(hours=12)).isoformat()
+
+
+@pytest.mark.asyncio
+async def test_automation_state_survives_store_reload(tmp_path: Path):
+    path = tmp_path / "goals.json"
+    store = CommunityGoalStore(path)
+    state = {
+        "enabled_at": "2026-08-09T12:00:00+00:00",
+        "next_goal_at": "2026-08-10T12:00:00+00:00",
+        "recent_metric_keys": ["xp", "messages"],
+        "had_active_goal": False,
+    }
+    await store.set_automation_state(state)
+
+    reloaded = CommunityGoalStore(path)
+    assert await reloaded.get_automation_state() == state

--- a/tests/test_community_goal_store_automation.py
+++ b/tests/test_community_goal_store_automation.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from storage.community_goal_store import CommunityGoalStore
+
+
+@pytest.mark.asyncio
+async def test_automatic_goal_metadata_is_persisted(tmp_path: Path):
+    path = tmp_path / "goals.json"
+    store = CommunityGoalStore(path)
+    now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+
+    created = await store.create_goal(
+        metric_key="messages",
+        target=1600,
+        baseline_total=5000,
+        created_by=0,
+        created_at=now,
+        ends_at=now + timedelta(days=2),
+        title="Le Refuge s’anime",
+        source="automatic",
+        metadata={"difficulty": "easy", "duration_days": 2},
+        require_no_active=True,
+    )
+
+    assert created["source"] == "automatic"
+    assert created["metadata"] == {"difficulty": "easy", "duration_days": 2}
+
+    reloaded = CommunityGoalStore(path)
+    goals = await reloaded.list_goals(status="active")
+    assert len(goals) == 1
+    assert goals[0]["source"] == "automatic"
+    assert goals[0]["metadata"]["difficulty"] == "easy"
+
+
+@pytest.mark.asyncio
+async def test_require_no_active_rejects_even_a_different_metric(tmp_path: Path):
+    store = CommunityGoalStore(tmp_path / "goals.json")
+    now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+    await store.create_goal(
+        metric_key="xp",
+        target=1000,
+        baseline_total=0,
+        created_by=42,
+        created_at=now,
+        ends_at=now + timedelta(days=2),
+    )
+
+    with pytest.raises(ValueError, match="active goal"):
+        await store.create_goal(
+            metric_key="messages",
+            target=1000,
+            baseline_total=0,
+            created_by=0,
+            created_at=now,
+            ends_at=now + timedelta(days=2),
+            source="automatic",
+            require_no_active=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_legacy_goal_defaults_to_manual_source_without_breaking_api(tmp_path: Path):
+    store = CommunityGoalStore(tmp_path / "goals.json")
+    now = datetime(2026, 8, 9, 12, 0, tzinfo=timezone.utc)
+
+    goal = await store.create_goal(
+        metric_key="casino",
+        target=100,
+        baseline_total=20,
+        created_by=7,
+        created_at=now,
+        ends_at=now + timedelta(days=3),
+    )
+
+    assert goal["source"] == "manual"
+    assert goal["metadata"] == {}

--- a/tests/test_community_goals_view.py
+++ b/tests/test_community_goals_view.py
@@ -32,9 +32,11 @@ def test_community_goals_view_renders_active_and_recent_goals() -> None:
                 progress_bar="█████░░░░░",
                 deadline="<t:1786406400:R>",
                 reward_text="Badge collectif",
+                automation_note="🤖 Objectif automatique · difficulté **Normal**",
             ),
         ),
         completed_titles=("Objectif vocal", "Objectif XP"),
+        automation_status="🤖 Automatisation en pause tant qu’un objectif est actif.",
     )
 
     assert isinstance(view, discord.ui.LayoutView)
@@ -51,6 +53,9 @@ def test_community_goals_view_renders_active_and_recent_goals() -> None:
     assert "1000 messages" in text
     assert "<t:1786406400:R>" in text
     assert "Badge collectif" in text
+    assert "Objectif automatique" in text
+    assert "difficulté **Normal**" in text
+    assert "Automatisation en pause" in text
     assert "Derniers objectifs réussis" in text
     assert "Objectif vocal" in text
     assert "Objectif XP" in text
@@ -63,10 +68,15 @@ def test_community_goals_view_renders_active_and_recent_goals() -> None:
 
 
 def test_community_goals_view_handles_no_active_goal() -> None:
-    view = CommunityGoalsView(completed_titles=("Ancien objectif",))
+    view = CommunityGoalsView(
+        completed_titles=("Ancien objectif",),
+        automation_status="🤖 Prochain tirage automatique : <t:1786406400:R>.",
+    )
     text = _container_text(view)
 
     assert "Aucun objectif communautaire actif pour le moment." in text
+    assert "Prochain tirage automatique" in text
+    assert "<t:1786406400:R>" in text
     assert "Ancien objectif" in text
 
 
@@ -83,6 +93,7 @@ def test_community_goals_view_stays_under_components_limit_with_four_goals() -> 
     view = CommunityGoalsView(
         active_goals=(goal, goal, goal, goal),
         completed_titles=("A", "B", "C"),
+        automation_status="🤖 Automatisation active.",
     )
 
     assert sum(1 for _item in view.walk_children()) < 40
@@ -98,6 +109,8 @@ async def test_objectif_communaute_sends_components_v2_view(monkeypatch) -> None
         "ends_at": "2026-08-12T12:00:00+00:00",
         "title": "Semaine active",
         "reward_text": "Badge collectif",
+        "source": "automatic",
+        "metadata": {"difficulty_label": "Ambitieux"},
         "status": "active",
     }
     completed_goal = {
@@ -114,6 +127,9 @@ async def test_objectif_communaute_sends_components_v2_view(monkeypatch) -> None
             if status == "completed":
                 return [completed_goal]
             return []
+
+        async def get_automation_state(self):
+            return {"next_goal_at": None, "had_active_goal": True}
 
     class FakeResponse:
         def __init__(self) -> None:
@@ -152,3 +168,6 @@ async def test_objectif_communaute_sends_components_v2_view(monkeypatch) -> None
     assert "1000 messages" in text
     assert "Badge collectif" in text
     assert "Objectif XP" in text
+    assert "Objectif automatique" in text
+    assert "Ambitieux" in text
+    assert "Automatisation en pause" in text

--- a/ui/community_goals_view.py
+++ b/ui/community_goals_view.py
@@ -23,6 +23,7 @@ class CommunityGoalDisplay:
     progress_bar: str
     deadline: str
     reward_text: str | None = None
+    automation_note: str | None = None
 
 
 class CommunityGoalsView(discord.ui.LayoutView):
@@ -33,6 +34,7 @@ class CommunityGoalsView(discord.ui.LayoutView):
         *,
         active_goals: tuple[CommunityGoalDisplay, ...] = (),
         completed_titles: tuple[str, ...] = (),
+        automation_status: str | None = None,
     ) -> None:
         super().__init__(timeout=None)
 
@@ -63,9 +65,15 @@ class CommunityGoalsView(discord.ui.LayoutView):
                     ),
                     f"⏳ Fin {goal.deadline}",
                 ]
+                if goal.automation_note:
+                    lines.append(goal.automation_note)
                 if goal.reward_text:
                     lines.append(f"🎁 Récompense prévue : **{goal.reward_text}**")
                 container.add_item(discord.ui.TextDisplay("\n".join(lines)))
+
+        if automation_status:
+            container.add_item(discord.ui.Separator())
+            container.add_item(discord.ui.TextDisplay(automation_status))
 
         if completed_titles:
             container.add_item(discord.ui.Separator())


### PR DESCRIPTION
## Objectif
Ajouter **REFUGE-010A — Objectifs communautaires automatiques** avant REFUGE-011, sans supprimer les commandes administrateur existantes et sans modifier XP, Casino, Chantier ou les métriques de progression.

## Principe
Lorsqu’aucun objectif communautaire n’est actif, le bot planifie un prochain tirage automatique après un délai aléatoire. À l’échéance, il génère un objectif à partir des métriques réellement mesurées dans la saison courante.

La catégorie, la durée, la difficulté et le titre sont tirés aléatoirement. La cible n’est pas un nombre aléatoire arbitraire : elle est calculée depuis le rythme moyen observé de la métrique choisie.

## Calibration
La source reste `season_stats.json` / `SeasonStore`.

Pour chaque catégorie mesurable :
- total de la saison courante ;
- durée observée depuis `started_at`, avec un minimum de 24 h pour éviter une extrapolation excessive juste après un démarrage ;
- rythme moyen quotidien = total / jours observés ;
- cible = rythme quotidien × durée tirée × multiplicateur de difficulté ;
- arrondi métier : XP 100, messages 10, vocal 15 min, casino 5 paris.

Une catégorie sans activité mesurable est exclue. Si aucune catégorie n’est exploitable, le générateur reporte son tirage au lieu d’inventer une cible.

## Aléatoire V1 — valeurs proposées à valider
### Fréquence
Après la fin du dernier objectif actif : délai aléatoire **12 à 36 heures**.

Variables :
- `REFUGE_AUTO_GOAL_COOLDOWN_MIN_HOURS`
- `REFUGE_AUTO_GOAL_COOLDOWN_MAX_HOURS`

### Durée
Durée aléatoire **2 à 5 jours**.

Variables :
- `REFUGE_AUTO_GOAL_DURATION_MIN_DAYS`
- `REFUGE_AUTO_GOAL_DURATION_MAX_DAYS`

### Difficulté
Tirage uniforme :
- **Facile** → 80 % du rythme attendu ;
- **Normal** → 100 % ;
- **Ambitieux** → 120 %.

### Observation minimale
`REFUGE_AUTO_GOAL_MIN_OBSERVATION_HOURS=24` par défaut.

## Catégories
Le tirage utilise uniquement les catégories existantes :
- ⭐ XP collective ;
- 💬 Messages ;
- 🎧 Temps vocal ;
- 🎰 Paris casino.

Le générateur évite de reprendre immédiatement la même catégorie lorsqu’une autre catégorie mesurable est disponible.

## Titres
Chaque catégorie possède plusieurs titres déterministes dans le code, choisis aléatoirement. Aucun runtime AI ni appel réseau.

## Priorité aux objectifs manuels
`/objectif_creer` et `/objectif_annuler` restent disponibles.

Le générateur crée automatiquement uniquement avec une garde atomique `require_no_active=True`. Si un objectif manuel apparaît pendant le tirage, l’automatisation abandonne normalement la création et se met en pause.

Après la fin de tous les objectifs actifs, un nouveau cooldown aléatoire commence.

## Persistance
`community_goals.json` reste en schema 1 et conserve maintenant une section légère `automation` :
- activation ;
- prochain tirage ;
- dernières catégories générées ;
- dernier objectif automatique ;
- état de pause lié à un objectif actif.

Les objectifs automatiques ajoutent seulement :
- `source="automatic"` ;
- `metadata` avec difficulté, durée, rythme quotidien observé et multiplicateur.

Les anciens objectifs sans ces champs restent lisibles et la signature historique de `create_goal` reste compatible grâce aux valeurs par défaut.

## Discord
Quand un objectif automatique est créé, il est annoncé dans le même `ANNOUNCE_CHANNEL_ID` que les réussites communautaires.

`/objectif_communaute` affiche désormais :
- 🤖 la difficulté lorsqu’un objectif actif est automatique ;
- l’état de pause de l’automatisation ;
- ou le prochain tirage prévu lorsqu’aucun objectif n’est actif.

Aucune nouvelle commande publique n’est ajoutée.

## Interaction avec REFUGE-010
Un objectif automatique terminé avec statut `completed` est indistinguable d’un objectif manuel réussi pour le Chantier : REFUGE-010 le consomme normalement et ouvre un droit à bâtir.

Un objectif `expired` ou `cancelled` ne déclenche toujours aucun Chantier.

## Fichiers
- `services/community_goal_automation.py` — nouveau générateur adaptatif aléatoire ;
- `storage/community_goal_store.py` — état automation + metadata/source + garde atomique ;
- `cogs/community_goals.py` — exécution chaque minute + annonce + observabilité ;
- `ui/community_goals_view.py` — statut automation ;
- tests ciblés automation/store/vue.

## Tests ajoutés
Couverture prévue :
- premier démarrage planifie sans créer immédiatement ;
- création à échéance ;
- cible calculée depuis le rythme réel ;
- difficulté et durée tirées ;
- catégorie sans activité exclue ;
- objectif manuel met l’automatisation en pause ;
- cooldown après fin ;
- anti-répétition de catégorie ;
- persistance après redémarrage ;
- garde atomique contre création concurrente ;
- metadata automatique ;
- affichage V2 de l’état et de la difficulté.

## Validation disponible
Branche basée sur `main` au commit `7df5d0ea57572dac47949c6ce80508c1f2a7b4ed`.

Le clone local est actuellement impossible depuis le runtime ChatGPT (`Could not resolve host: github.com`), donc la suite pytest réelle n’est pas déclarée comme passée. Les checks GitHub du head seront inspectés avant toute fusion.

Deux fichiers vides accidentels (`__nope__`, `__nope2__`) ont été créés puis supprimés uniquement sur la branche de travail avant la PR ; ils n’ont aucun effet sur le diff final et n’ont jamais touché `main`.

## Hors périmètre
- aucune modification des calculs XP ;
- aucune modification des métriques saisonnières ;
- aucune modification des probabilités/récompenses Casino ;
- aucune modification du vote/construction REFUGE-010 ;
- aucune Chronologie REFUGE-011 ;
- aucun secret REFUGE-012.

La PR reste en **draft** jusqu’à validation explicite des valeurs V1 par l’utilisateur.