### PR TITLE
feat: add Refuge monthly chronology

### DIFF
--- a/cogs/refuge_construction.py
+++ b/cogs/refuge_construction.py
@@ -6,6 +6,7 @@ import logging
 from discord.ext import commands, tasks
 
 from services.refuge_construction import refuge_construction_service
+from services.refuge_timeline import refuge_timeline_service
 
 
 logger = logging.getLogger(__name__)
@@ -18,9 +19,10 @@ class RefugeConstructionCog(commands.Cog):
         self.bot = bot
 
     async def cog_load(self) -> None:
-        # This first sync establishes the prospective REFUGE-010 activation marker
-        # before future community goals can become eligible build rights.
+        # REFUGE-011 archives the previous Paris month before the Chantier can
+        # open, resolve or complete anything in the new month.
         try:
+            await refuge_timeline_service.sync()
             await refuge_construction_service.sync()
         except Exception:
             logger.exception("[refuge] initialisation du Chantier échouée")
@@ -33,6 +35,7 @@ class RefugeConstructionCog(commands.Cog):
     @tasks.loop(minutes=1)
     async def advance_construction(self) -> None:
         try:
+            await refuge_timeline_service.sync()
             await refuge_construction_service.sync()
         except asyncio.CancelledError:
             raise

--- a/cogs/refuge_timeline.py
+++ b/cogs/refuge_timeline.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from discord.ext import commands, tasks
+
+from services.refuge_timeline import refuge_timeline_service
+
+
+logger = logging.getLogger(__name__)
+
+
+class RefugeTimelineCog(commands.Cog):
+    """Keep monthly Refuge chapters synchronized with Paris calendar months."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def cog_load(self) -> None:
+        try:
+            await refuge_timeline_service.sync()
+        except Exception:
+            logger.exception("[refuge] initialisation de la Chronologie échouée")
+        if not self.timeline_rollover.is_running():
+            self.timeline_rollover.start()
+
+    def cog_unload(self) -> None:
+        self.timeline_rollover.cancel()
+
+    @tasks.loop(minutes=1)
+    async def timeline_rollover(self) -> None:
+        try:
+            await refuge_timeline_service.sync()
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("[refuge] rollover de Chronologie échoué")
+
+    @timeline_rollover.before_loop
+    async def before_timeline_rollover(self) -> None:
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RefugeTimelineCog(bot))
+
+
+__all__ = ["RefugeTimelineCog"]

--- a/services/refuge_panel.py
+++ b/services/refuge_panel.py
@@ -16,6 +16,7 @@ from rendering.refuge_world import RefugeRenderContext
 from services.refuge_casino import RefugeCasinoService, refuge_casino_service
 from services.refuge_fire import RefugeFireService, refuge_fire_service
 from services.refuge_hall import RefugeHallService, refuge_hall_service
+from services.refuge_timeline import RefugeTimelineService, refuge_timeline_service
 from services.refuge_world_coordination import refuge_world_mutation_lock
 from utils.seasons import season_id_for, season_label
 
@@ -163,16 +164,22 @@ class RefugePanelService:
         fire_service: RefugeFireService = refuge_fire_service,
         hall_service: RefugeHallService = refuge_hall_service,
         casino_service: RefugeCasinoService = refuge_casino_service,
+        timeline_service: RefugeTimelineService = refuge_timeline_service,
         renderer: RefugeConstructionRenderer = refuge_construction_renderer,
     ) -> None:
         self.fire_service = fire_service
         self.hall_service = hall_service
         self.casino_service = casino_service
+        self.timeline_service = timeline_service
         self.renderer = renderer
 
     async def evaluate(self, *, at: datetime | None = None) -> RefugePanelSnapshot:
         now = _aware_utc(at)
         async with refuge_world_mutation_lock():
+            # REFUGE-011 must archive the previous Paris calendar month before
+            # any current-month progression can mutate the shared world state.
+            await self.timeline_service.sync_under_world_lock(at=now)
+
             # Sequential evaluation is intentional: all three services share
             # RefugeWorldStore and each stage must observe the previous write.
             fire = await self.fire_service.evaluate(at=now)

--- a/services/refuge_timeline.py
+++ b/services/refuge_timeline.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from typing import Final, Mapping
+
+from models.refuge_world import (
+    RefugeHistoricalEvent,
+    RefugePanelState,
+    RefugeWorldSnapshot,
+    RefugeWorldState,
+)
+from rendering.refuge_construction import (
+    RefugeConstructionRenderer,
+    refuge_construction_renderer,
+)
+from rendering.refuge_world import RefugeRenderContext
+from services.refuge_world_coordination import refuge_world_mutation_lock
+from storage.refuge_world_store import RefugeWorldStore, refuge_world_store
+from utils.seasons import season_bounds, season_id_for, season_label
+
+
+TIMELINE_STATE_KEY: Final[str] = "refuge_timeline"
+_TIMELINE_VERSION: Final[int] = 1
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeTimelineChapter:
+    season_id: str
+    label: str
+    captured_at: str
+    state: RefugeWorldState
+    context: RefugeRenderContext
+    chapter_event_count: int
+    chapter_event_labels: tuple[str, ...]
+    building_count: int
+    monument_count: int
+    fire_level: int
+    hall_level: int
+    casino_level: int
+    construction_label: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeTimelineSnapshot:
+    current_season_id: str
+    current_season_label: str
+    chapters: tuple[RefugeTimelineChapter, ...]
+    selected_season_id: str | None
+
+    @property
+    def selected(self) -> RefugeTimelineChapter | None:
+        if self.selected_season_id is None:
+            return None
+        return next(
+            (
+                chapter
+                for chapter in self.chapters
+                if chapter.season_id == self.selected_season_id
+            ),
+            None,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeTimelineSyncResult:
+    state: RefugeWorldState
+    archived_season_id: str | None
+    changed: bool
+
+
+def _aware_utc(at: datetime | None = None) -> datetime:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _timeline_meta(state: RefugeWorldState) -> dict[str, object]:
+    raw = state.state.get(TIMELINE_STATE_KEY, {})
+    source = raw if isinstance(raw, Mapping) else {}
+    return {
+        "version": _TIMELINE_VERSION,
+        "enabled_at": str(source.get("enabled_at") or "") or None,
+        "active_season_id": str(source.get("active_season_id") or "") or None,
+        "last_archived_season_id": (
+            str(source.get("last_archived_season_id") or "") or None
+        ),
+    }
+
+
+def _state_with_meta(
+    state: RefugeWorldState,
+    meta: Mapping[str, object],
+) -> RefugeWorldState:
+    payload = dict(state.state)
+    payload[TIMELINE_STATE_KEY] = dict(meta)
+    return replace(state, state=payload)
+
+
+def _event_ids_at_season_end(
+    events: tuple[RefugeHistoricalEvent, ...],
+    season_id: str,
+) -> tuple[str, ...]:
+    _, season_end = season_bounds(season_id)
+    end_utc = season_end.astimezone(timezone.utc)
+    selected: list[tuple[datetime, str]] = []
+    for event in events:
+        occurred = _parse_timestamp(event.occurred_at)
+        if occurred is None or occurred >= end_utc:
+            continue
+        selected.append((occurred, event.event_id))
+    selected.sort(key=lambda item: (item[0], item[1]))
+    return tuple(event_id for _occurred, event_id in selected)
+
+
+def _snapshot_context(snapshot: RefugeWorldSnapshot) -> RefugeRenderContext:
+    _start, end = season_bounds(snapshot.season_id)
+    final_moment = end - timedelta(microseconds=1)
+    return RefugeRenderContext.from_datetime(final_moment)
+
+
+def _building_level(state: RefugeWorldState, building_id: str) -> int:
+    building = next(
+        (
+            candidate
+            for candidate in state.buildings
+            if candidate.building_id == building_id
+        ),
+        None,
+    )
+    return max(0, int(building.level)) if building is not None else 0
+
+
+def _event_label(event: RefugeHistoricalEvent) -> str:
+    explicit = event.data.get("name")
+    if explicit:
+        return str(explicit)
+    labels = {
+        "building_level_reached": "Un bâtiment du Refuge a évolué",
+        "casino_jackpot_observed": "Un jackpot a marqué le Casino",
+        "hall_gallery_marker": "Une nouvelle trace est entrée au Hall",
+        "construction_vote_opened": "Un vote de chantier s’est ouvert",
+        "construction_vote_tied": "Un chantier a dû être départagé",
+        "construction_started": "Une construction a commencé",
+        "construction_completed": "Un monument a été inauguré",
+    }
+    if event.event_type.endswith("secret_discovered"):
+        return "Un mystère du Refuge a été découvert"
+    return labels.get(event.event_type, "Un événement a marqué le Refuge")
+
+
+def _chapter_events(
+    state: RefugeWorldState,
+    season_id: str,
+) -> tuple[RefugeHistoricalEvent, ...]:
+    start, end = season_bounds(season_id)
+    start_utc = start.astimezone(timezone.utc)
+    end_utc = end.astimezone(timezone.utc)
+    selected: list[tuple[datetime, RefugeHistoricalEvent]] = []
+    for event in state.events:
+        occurred = _parse_timestamp(event.occurred_at)
+        if occurred is None or not start_utc <= occurred < end_utc:
+            continue
+        selected.append((occurred, event))
+    selected.sort(key=lambda item: (item[0], item[1].event_id), reverse=True)
+    return tuple(event for _occurred, event in selected)
+
+
+def _construction_label(state: RefugeWorldState) -> str | None:
+    construction = state.active_construction
+    if construction is None:
+        return None
+    project_name = construction.data.get("project_name") or construction.data.get("name")
+    if project_name:
+        return str(project_name)
+    if construction.project_id:
+        return str(construction.project_id)
+    return "Chantier en cours"
+
+
+class RefugeTimelineService:
+    """Archive immutable monthly Refuge chapters and render them on demand."""
+
+    def __init__(
+        self,
+        *,
+        world_store: RefugeWorldStore = refuge_world_store,
+        renderer: RefugeConstructionRenderer = refuge_construction_renderer,
+    ) -> None:
+        self.world_store = world_store
+        self.renderer = renderer
+
+    async def sync(self, *, at: datetime | None = None) -> RefugeTimelineSyncResult:
+        now = _aware_utc(at)
+        async with refuge_world_mutation_lock():
+            return await self.sync_under_world_lock(at=now)
+
+    async def sync_under_world_lock(
+        self,
+        *,
+        at: datetime | None = None,
+    ) -> RefugeTimelineSyncResult:
+        """Synchronize while the caller already owns the Refuge mutation lock."""
+
+        now = _aware_utc(at)
+        state = await self.world_store.initialize(created_at=now)
+        current_season_id = season_id_for(now)
+        meta = _timeline_meta(state)
+        active_season_id = meta.get("active_season_id")
+
+        if not active_season_id:
+            meta["enabled_at"] = now.isoformat()
+            meta["active_season_id"] = current_season_id
+            updated = _state_with_meta(state, meta)
+            saved = await self.world_store.save_state(updated)
+            return RefugeTimelineSyncResult(saved, None, True)
+
+        active_season_id = str(active_season_id)
+        if active_season_id == current_season_id:
+            return RefugeTimelineSyncResult(state, None, False)
+
+        # Clock rollback must never rewrite an already opened historical chapter.
+        if active_season_id > current_season_id:
+            return RefugeTimelineSyncResult(state, None, False)
+
+        existing = next(
+            (
+                snapshot
+                for snapshot in state.snapshots
+                if snapshot.season_id == active_season_id
+            ),
+            None,
+        )
+        archived_id: str | None = None
+        snapshots = state.snapshots
+        if existing is None:
+            snapshot = RefugeWorldSnapshot(
+                season_id=active_season_id,
+                captured_at=now.isoformat(),
+                buildings=state.buildings,
+                event_ids=_event_ids_at_season_end(state.events, active_season_id),
+                active_construction=state.active_construction,
+                state=dict(state.state),
+            )
+            snapshots = tuple(
+                sorted(
+                    (*state.snapshots, snapshot),
+                    key=lambda item: item.season_id,
+                )
+            )
+            archived_id = active_season_id
+
+        meta["active_season_id"] = current_season_id
+        meta["last_archived_season_id"] = active_season_id
+        updated = replace(
+            _state_with_meta(state, meta),
+            snapshots=snapshots,
+        )
+        saved = await self.world_store.save_state(updated)
+        return RefugeTimelineSyncResult(saved, archived_id, True)
+
+    def _restore_snapshot_state(
+        self,
+        world: RefugeWorldState,
+        snapshot: RefugeWorldSnapshot,
+    ) -> RefugeWorldState:
+        event_ids = set(snapshot.event_ids)
+        historical_events = tuple(
+            event for event in world.events if event.event_id in event_ids
+        )
+        return RefugeWorldState(
+            schema_version=world.schema_version,
+            created_at=world.created_at,
+            buildings=snapshot.buildings,
+            events=historical_events,
+            snapshots=(),
+            panel=RefugePanelState(),
+            active_construction=snapshot.active_construction,
+            state=dict(snapshot.state),
+        )
+
+    def _chapter_from_snapshot(
+        self,
+        world: RefugeWorldState,
+        snapshot: RefugeWorldSnapshot,
+    ) -> RefugeTimelineChapter:
+        restored = self._restore_snapshot_state(world, snapshot)
+        chapter_events = _chapter_events(restored, snapshot.season_id)
+        monuments = tuple(
+            building
+            for building in restored.buildings
+            if building.building_id.startswith("monument:")
+        )
+        return RefugeTimelineChapter(
+            season_id=snapshot.season_id,
+            label=season_label(snapshot.season_id),
+            captured_at=snapshot.captured_at,
+            state=restored,
+            context=_snapshot_context(snapshot),
+            chapter_event_count=len(chapter_events),
+            chapter_event_labels=tuple(
+                _event_label(event) for event in chapter_events[:5]
+            ),
+            building_count=len(restored.buildings),
+            monument_count=len(monuments),
+            fire_level=_building_level(restored, "fire"),
+            hall_level=_building_level(restored, "hall"),
+            casino_level=_building_level(restored, "casino"),
+            construction_label=_construction_label(restored),
+        )
+
+    async def get_timeline(
+        self,
+        *,
+        selected_season_id: str | None = None,
+        at: datetime | None = None,
+    ) -> RefugeTimelineSnapshot:
+        sync_result = await self.sync(at=at)
+        world = sync_result.state
+        chapters = tuple(
+            self._chapter_from_snapshot(world, snapshot)
+            for snapshot in sorted(
+                world.snapshots,
+                key=lambda item: item.season_id,
+                reverse=True,
+            )
+        )
+        selected = selected_season_id
+        if selected is None and chapters:
+            selected = chapters[0].season_id
+        if selected is not None and not any(
+            chapter.season_id == selected for chapter in chapters
+        ):
+            selected = chapters[0].season_id if chapters else None
+        current_season_id = season_id_for(_aware_utc(at))
+        return RefugeTimelineSnapshot(
+            current_season_id=current_season_id,
+            current_season_label=season_label(current_season_id),
+            chapters=chapters,
+            selected_season_id=selected,
+        )
+
+    async def render_chapter_png(self, chapter: RefugeTimelineChapter) -> bytes:
+        return await self.renderer.render_png_async(
+            chapter.state,
+            context=chapter.context,
+        )
+
+
+refuge_timeline_service = RefugeTimelineService()
+
+
+__all__ = [
+    "TIMELINE_STATE_KEY",
+    "RefugeTimelineChapter",
+    "RefugeTimelineService",
+    "RefugeTimelineSnapshot",
+    "RefugeTimelineSyncResult",
+    "refuge_timeline_service",
+]

--- a/tests/test_refuge_panel_service.py
+++ b/tests/test_refuge_panel_service.py
@@ -29,6 +29,15 @@ class _Service:
         return self.status
 
 
+class _Timeline:
+    def __init__(self):
+        self.calls = []
+
+    async def sync_under_world_lock(self, *, at=None):
+        self.calls.append(at)
+        return None
+
+
 class _Renderer:
     def __init__(self):
         self.calls = []
@@ -50,7 +59,7 @@ def _status(state, **kwargs):
 
 
 @pytest.mark.asyncio
-async def test_panel_service_evaluates_systems_sequentially_and_builds_snapshot():
+async def test_panel_service_archives_then_evaluates_systems_sequentially():
     at = datetime(2026, 8, 9, 14, 0, tzinfo=timezone.utc)
     base = RefugeWorldState(created_at="2026-08-09T00:00:00+00:00")
     fire_state = replace(base, state={"stage": "fire"})
@@ -83,11 +92,13 @@ async def test_panel_service_evaluates_systems_sequentially_and_builds_snapshot(
             is_open=True,
         )
     )
+    timeline = _Timeline()
     renderer = _Renderer()
     service = RefugePanelService(
         fire_service=fire,
         hall_service=hall,
         casino_service=casino,
+        timeline_service=timeline,
         renderer=renderer,
     )
 
@@ -103,8 +114,8 @@ async def test_panel_service_evaluates_systems_sequentially_and_builds_snapshot(
     assert snapshot.casino_is_open is True
     assert snapshot.construction_label == "Aucun chantier actif"
     assert snapshot.changed is True
-    assert len(fire.calls) == len(hall.calls) == len(casino.calls) == 1
-    assert fire.calls[0] == hall.calls[0] == casino.calls[0]
+    assert len(timeline.calls) == 1
+    assert timeline.calls[0] == fire.calls[0] == hall.calls[0] == casino.calls[0]
 
     assert await service.render_png(snapshot) == b"PNG"
     assert renderer.calls[0][0] == final_state

--- a/tests/test_refuge_panel_view.py
+++ b/tests/test_refuge_panel_view.py
@@ -7,7 +7,6 @@ from rendering.refuge_world import RefugeRenderContext
 from services.refuge_panel import RefugePanelSnapshot
 from ui.refuge_panel_view import (
     REFUGE_MAP_FILENAME,
-    RefugePendingActionView,
     RefugePublicControlsView,
     RefugePublicPanelView,
 )
@@ -85,13 +84,11 @@ def test_callback_registration_view_is_persistent_and_has_same_custom_ids():
     ]
 
 
-def test_no_panel_action_is_described_as_future_after_refuge_011():
-    for action in ("explore", "footprint", "timeline", "construction"):
-        view = RefugePendingActionView(action)
-        text = "\n".join(
-            item.content
-            for item in view.walk_children()
-            if isinstance(item, discord.ui.TextDisplay)
-        )
-        assert "désormais disponible" in text
-        assert "sera" not in text
+def test_refuge_011_keeps_all_four_public_actions_registered():
+    controls = RefugePublicControlsView()
+    assert {button.custom_id for button in _buttons(controls)} == {
+        "refuge:panel:explore",
+        "refuge:panel:footprint",
+        "refuge:panel:timeline",
+        "refuge:panel:construction",
+    }

--- a/tests/test_refuge_panel_view.py
+++ b/tests/test_refuge_panel_view.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import discord
-import pytest
 
 from models.refuge_world import RefugeWorldState
 from rendering.refuge_world import RefugeRenderContext
@@ -86,17 +85,13 @@ def test_callback_registration_view_is_persistent_and_has_same_custom_ids():
     ]
 
 
-def test_only_timeline_remains_pending_after_refuge_010():
-    view = RefugePendingActionView("timeline")
-    assert isinstance(view, discord.ui.LayoutView)
-    assert view.timeout == 120
-    text = "\n".join(
-        item.content
-        for item in view.walk_children()
-        if isinstance(item, discord.ui.TextDisplay)
-    )
-    assert "Chronologie" in text
-
-    for action in ("explore", "footprint", "construction"):
-        with pytest.raises(ValueError):
-            RefugePendingActionView(action)
+def test_no_panel_action_is_described_as_future_after_refuge_011():
+    for action in ("explore", "footprint", "timeline", "construction"):
+        view = RefugePendingActionView(action)
+        text = "\n".join(
+            item.content
+            for item in view.walk_children()
+            if isinstance(item, discord.ui.TextDisplay)
+        )
+        assert "désormais disponible" in text
+        assert "sera" not in text

--- a/tests/test_refuge_timeline.py
+++ b/tests/test_refuge_timeline.py
@@ -8,7 +8,6 @@ import pytest
 from models.refuge_world import (
     RefugeBuildingState,
     RefugeHistoricalEvent,
-    RefugeWorldState,
 )
 from services.refuge_timeline import (
     TIMELINE_STATE_KEY,
@@ -80,7 +79,8 @@ async def test_paris_month_rollover_freezes_previous_world_state(tmp_path):
     assert len(result.state.snapshots) == 1
     snapshot = result.state.snapshots[0]
     assert snapshot.season_id == "2026-08"
-    assert [building.level for building in snapshot.buildings] == [1, 3, 2]
+    levels = {building.building_id: building.level for building in snapshot.buildings}
+    assert levels == {"fire": 3, "hall": 2, "casino": 1}
     assert snapshot.event_ids == ("aug-event",)
     assert snapshot.state["permanent_marker"] == "august"
     assert result.state.state[TIMELINE_STATE_KEY]["active_season_id"] == "2026-09"

--- a/tests/test_refuge_timeline.py
+++ b/tests/test_refuge_timeline.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+
+from models.refuge_world import (
+    RefugeBuildingState,
+    RefugeHistoricalEvent,
+    RefugeWorldState,
+)
+from services.refuge_timeline import (
+    TIMELINE_STATE_KEY,
+    RefugeTimelineService,
+)
+from storage.refuge_world_store import RefugeWorldStore
+
+
+class _Renderer:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def render_png_async(self, state, *, context=None):
+        self.calls.append((state, context))
+        return b"HISTORY"
+
+
+@pytest.mark.asyncio
+async def test_first_sync_activates_current_season_without_backfill(tmp_path):
+    store = RefugeWorldStore(tmp_path / "world.json")
+    service = RefugeTimelineService(world_store=store, renderer=_Renderer())
+    at = datetime(2026, 8, 9, 16, 0, tzinfo=timezone.utc)
+
+    result = await service.sync(at=at)
+
+    assert result.changed is True
+    assert result.archived_season_id is None
+    assert result.state.snapshots == ()
+    meta = result.state.state[TIMELINE_STATE_KEY]
+    assert meta["active_season_id"] == "2026-08"
+    assert meta["last_archived_season_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_paris_month_rollover_freezes_previous_world_state(tmp_path):
+    store = RefugeWorldStore(tmp_path / "world.json")
+    renderer = _Renderer()
+    service = RefugeTimelineService(world_store=store, renderer=renderer)
+
+    await service.sync(at=datetime(2026, 8, 9, 16, 0, tzinfo=timezone.utc))
+    current = await store.get_state()
+    current = replace(
+        current,
+        buildings=(
+            RefugeBuildingState("fire", level=3, unlocked_at="2026-08-15T12:00:00+00:00"),
+            RefugeBuildingState("hall", level=2, unlocked_at="2026-08-20T12:00:00+00:00"),
+            RefugeBuildingState("casino", level=1, unlocked_at="2026-08-21T12:00:00+00:00"),
+        ),
+        events=(
+            RefugeHistoricalEvent(
+                event_id="aug-event",
+                event_type="hall_gallery_marker",
+                occurred_at="2026-08-31T20:00:00+00:00",
+            ),
+            RefugeHistoricalEvent(
+                event_id="sep-event",
+                event_type="construction_started",
+                occurred_at="2026-09-01T00:30:00+00:00",
+            ),
+        ),
+        state={**current.state, "permanent_marker": "august"},
+    )
+    await store.save_state(current)
+
+    # 22:00 UTC on 31 August is 00:00 on 1 September in Europe/Paris.
+    result = await service.sync(at=datetime(2026, 8, 31, 22, 0, tzinfo=timezone.utc))
+
+    assert result.archived_season_id == "2026-08"
+    assert len(result.state.snapshots) == 1
+    snapshot = result.state.snapshots[0]
+    assert snapshot.season_id == "2026-08"
+    assert [building.level for building in snapshot.buildings] == [1, 3, 2]
+    assert snapshot.event_ids == ("aug-event",)
+    assert snapshot.state["permanent_marker"] == "august"
+    assert result.state.state[TIMELINE_STATE_KEY]["active_season_id"] == "2026-09"
+
+    timeline = await service.get_timeline(
+        at=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc)
+    )
+    chapter = timeline.selected
+    assert chapter is not None
+    assert chapter.season_id == "2026-08"
+    assert chapter.fire_level == 3
+    assert chapter.hall_level == 2
+    assert chapter.casino_level == 1
+    assert chapter.chapter_event_count == 1
+    assert chapter.context.season == "summer"
+    assert chapter.context.daypart == "night"
+
+    assert await service.render_chapter_png(chapter) == b"HISTORY"
+    assert renderer.calls[-1][0] == chapter.state
+    assert renderer.calls[-1][1] == chapter.context
+
+
+@pytest.mark.asyncio
+async def test_archived_snapshot_is_never_recalculated_or_overwritten(tmp_path):
+    store = RefugeWorldStore(tmp_path / "world.json")
+    service = RefugeTimelineService(world_store=store, renderer=_Renderer())
+
+    await service.sync(at=datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc))
+    state = await store.get_state()
+    await store.save_state(
+        replace(state, buildings=(RefugeBuildingState("fire", level=2),))
+    )
+    await service.sync(at=datetime(2026, 8, 31, 22, 0, tzinfo=timezone.utc))
+
+    archived = (await store.get_state()).snapshots[0]
+    september = await store.get_state()
+    await store.save_state(
+        replace(september, buildings=(RefugeBuildingState("fire", level=5),))
+    )
+    await service.sync(at=datetime(2026, 9, 15, 12, 0, tzinfo=timezone.utc))
+
+    after = await store.get_state()
+    assert after.snapshots[0] == archived
+    timeline = await service.get_timeline(
+        selected_season_id="2026-08",
+        at=datetime(2026, 9, 15, 12, 0, tzinfo=timezone.utc),
+    )
+    assert timeline.selected is not None
+    assert timeline.selected.fire_level == 2
+
+
+@pytest.mark.asyncio
+async def test_long_downtime_does_not_fabricate_missing_months(tmp_path):
+    store = RefugeWorldStore(tmp_path / "world.json")
+    service = RefugeTimelineService(world_store=store, renderer=_Renderer())
+
+    await service.sync(at=datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc))
+    result = await service.sync(at=datetime(2026, 10, 5, 12, 0, tzinfo=timezone.utc))
+
+    assert result.archived_season_id == "2026-08"
+    assert [snapshot.season_id for snapshot in result.state.snapshots] == ["2026-08"]
+    assert result.state.state[TIMELINE_STATE_KEY]["active_season_id"] == "2026-10"
+
+
+@pytest.mark.asyncio
+async def test_selected_unknown_season_falls_back_to_latest_archive(tmp_path):
+    store = RefugeWorldStore(tmp_path / "world.json")
+    service = RefugeTimelineService(world_store=store, renderer=_Renderer())
+
+    await service.sync(at=datetime(2026, 8, 10, 12, 0, tzinfo=timezone.utc))
+    await service.sync(at=datetime(2026, 8, 31, 22, 0, tzinfo=timezone.utc))
+
+    timeline = await service.get_timeline(
+        selected_season_id="1999-01",
+        at=datetime(2026, 9, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    assert timeline.selected_season_id == "2026-08"

--- a/tests/test_refuge_timeline_view.py
+++ b/tests/test_refuge_timeline_view.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import discord
+import pytest
+
+from models.refuge_world import RefugeWorldState
+from rendering.refuge_world import RefugeRenderContext
+from services.refuge_timeline import RefugeTimelineChapter, RefugeTimelineSnapshot
+from ui.refuge_timeline_view import (
+    REFUGE_HISTORY_FILENAME,
+    RefugeTimelinePageButton,
+    RefugeTimelineSelect,
+    RefugeTimelineView,
+)
+
+
+def _chapter(season_id: str, label: str) -> RefugeTimelineChapter:
+    return RefugeTimelineChapter(
+        season_id=season_id,
+        label=label,
+        captured_at="2026-09-01T00:00:00+00:00",
+        state=RefugeWorldState(),
+        context=RefugeRenderContext(season="summer", daypart="night"),
+        chapter_event_count=2,
+        chapter_event_labels=("Un monument a été inauguré", "Une nouvelle trace est entrée au Hall"),
+        building_count=3,
+        monument_count=1,
+        fire_level=3,
+        hall_level=2,
+        casino_level=1,
+        construction_label="Observatoire des Étoiles",
+    )
+
+
+def _text(view: RefugeTimelineView) -> str:
+    return "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+
+
+class _Service:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def render_chapter_png(self, chapter):
+        self.calls.append(chapter.season_id)
+        return b"PNG"
+
+
+def test_timeline_without_archive_explains_first_month() -> None:
+    snapshot = RefugeTimelineSnapshot(
+        current_season_id="2026-08",
+        current_season_label="Août 2026",
+        chapters=(),
+        selected_season_id=None,
+    )
+    view = RefugeTimelineView(snapshot, owner_user_id=42)
+
+    assert isinstance(view, discord.ui.LayoutView)
+    assert view.timeout == 300
+    text = _text(view)
+    assert "CHRONOLOGIE DU REFUGE" in text
+    assert "Août 2026" in text
+    assert "Aucun chapitre mensuel n’est clôturé" in text
+    assert not any(isinstance(item, discord.ui.MediaGallery) for item in view.walk_children())
+
+
+def test_timeline_chapter_renders_archived_summary_and_attachment() -> None:
+    chapter = _chapter("2026-08", "Août 2026")
+    snapshot = RefugeTimelineSnapshot(
+        current_season_id="2026-09",
+        current_season_label="Septembre 2026",
+        chapters=(chapter,),
+        selected_season_id="2026-08",
+    )
+    view = RefugeTimelineView(snapshot, owner_user_id=42)
+
+    text = _text(view)
+    assert "Août 2026" in text
+    assert "Feu : **niveau III**" in text
+    assert "Hall : **niveau II**" in text
+    assert "Casino : **niveau I**" in text
+    assert "Monuments permanents : **1**" in text
+    assert "Événements du chapitre : **2**" in text
+    assert "Observatoire des Étoiles" in text
+    assert "sans recalcul de progression" in text
+
+    galleries = [
+        item for item in view.walk_children() if isinstance(item, discord.ui.MediaGallery)
+    ]
+    assert len(galleries) == 1
+    assert galleries[0].items[0].media.url == f"attachment://{REFUGE_HISTORY_FILENAME}"
+    selects = [item for item in view.walk_children() if isinstance(item, RefugeTimelineSelect)]
+    assert len(selects) == 1
+    assert selects[0].options[0].default is True
+
+
+@pytest.mark.asyncio
+async def test_selected_file_uses_archived_chapter_renderer() -> None:
+    chapter = _chapter("2026-08", "Août 2026")
+    snapshot = RefugeTimelineSnapshot(
+        current_season_id="2026-09",
+        current_season_label="Septembre 2026",
+        chapters=(chapter,),
+        selected_season_id="2026-08",
+    )
+    service = _Service()
+    view = RefugeTimelineView(snapshot, owner_user_id=42, service=service)
+
+    file = await view.selected_file()
+
+    assert file is not None
+    assert file.filename == REFUGE_HISTORY_FILENAME
+    assert service.calls == ["2026-08"]
+
+
+def test_timeline_paginates_more_than_25_months() -> None:
+    chapters = tuple(
+        _chapter(f"2026-{month:02d}", f"Chapitre {index}")
+        for index, month in enumerate(range(1, 13), start=1)
+    ) + tuple(
+        _chapter(f"2025-{month:02d}", f"Ancien {index}")
+        for index, month in enumerate(range(1, 13), start=1)
+    ) + (
+        _chapter("2024-12", "Décembre 2024"),
+        _chapter("2024-11", "Novembre 2024"),
+    )
+    snapshot = RefugeTimelineSnapshot(
+        current_season_id="2026-09",
+        current_season_label="Septembre 2026",
+        chapters=chapters,
+        selected_season_id=chapters[0].season_id,
+    )
+    view = RefugeTimelineView(snapshot, owner_user_id=42)
+
+    assert view.page_count == 2
+    assert len(view.page_chapters) == 25
+    buttons = [
+        item for item in view.walk_children() if isinstance(item, RefugeTimelinePageButton)
+    ]
+    assert len(buttons) == 2
+    assert any(button.label == "Plus ancien" and not button.disabled for button in buttons)
+
+    view.change_page(1)
+    assert view.page_index == 1
+    assert len(view.page_chapters) == 1
+    assert view.selected_season_id == chapters[25].season_id

--- a/ui/refuge_construction_view.py
+++ b/ui/refuge_construction_view.py
@@ -12,6 +12,7 @@ from services.refuge_construction import (
     RefugeConstructionSnapshot,
     refuge_construction_service,
 )
+from services.refuge_timeline import refuge_timeline_service
 
 
 REFUGE_CONSTRUCTION_ACCENT = discord.Colour(0xB77B42)
@@ -73,6 +74,7 @@ class RefugeConstructionVoteSelect(discord.ui.Select):
         if not isinstance(view, RefugeConstructionView):
             return
         await interaction.response.defer()
+        await refuge_timeline_service.sync()
         try:
             snapshot = await refuge_construction_service.cast_vote(
                 interaction.user.id,

--- a/ui/refuge_panel_view.py
+++ b/ui/refuge_panel_view.py
@@ -24,22 +24,6 @@ REFUGE_MAP_FILENAME: Final[str] = "refuge-map.png"
 RefugePanelAction = Literal["explore", "footprint", "timeline", "construction"]
 
 
-class RefugePendingActionView(discord.ui.LayoutView):
-    """Compatibility shell retained after all REFUGE V1 panel actions became active."""
-
-    def __init__(self, action: RefugePanelAction) -> None:
-        super().__init__(timeout=120)
-        container = discord.ui.Container(accent_colour=REFUGE_PANEL_ACCENT)
-        container.add_item(discord.ui.TextDisplay("## 🏕️ Le Refuge"))
-        container.add_item(discord.ui.Separator())
-        container.add_item(
-            discord.ui.TextDisplay(
-                f"L’action **{action}** est désormais disponible depuis le panneau principal."
-            )
-        )
-        self.add_item(container)
-
-
 class RefugePanelButton(discord.ui.Button):
     """Persistent public control dispatching to private Refuge surfaces."""
 
@@ -222,7 +206,6 @@ __all__ = [
     "REFUGE_MAP_FILENAME",
     "REFUGE_PANEL_ACCENT",
     "RefugePanelButton",
-    "RefugePendingActionView",
     "RefugePublicControlsView",
     "RefugePublicPanelView",
     "refuge_controls_row",

--- a/ui/refuge_panel_view.py
+++ b/ui/refuge_panel_view.py
@@ -8,12 +8,14 @@ import discord
 from services.refuge_construction import refuge_construction_service
 from services.refuge_exploration_runtime import refuge_exploration_runtime_service
 from services.refuge_panel import RefugePanelSnapshot
+from services.refuge_timeline import refuge_timeline_service
 from ui.refuge_construction_view import RefugeConstructionView
 from ui.refuge_exploration_view import (
     RefugeExplorerView,
     RefugeFootprintView,
     RefugePrivateErrorView,
 )
+from ui.refuge_timeline_view import RefugeTimelineView
 
 
 logger = logging.getLogger(__name__)
@@ -21,33 +23,20 @@ REFUGE_PANEL_ACCENT = discord.Colour(0xD08A47)
 REFUGE_MAP_FILENAME: Final[str] = "refuge-map.png"
 RefugePanelAction = Literal["explore", "footprint", "timeline", "construction"]
 
-_ACTION_COPY: Final[dict[str, tuple[str, str, str]]] = {
-    "timeline": (
-        "🕰️ Chronologie",
-        "Les archives mensuelles du Refuge seront consultables depuis ce bouton.",
-        "Les saisons passées deviendront des chapitres permanents de son histoire.",
-    ),
-}
-
-
-def _roman(level: int) -> str:
-    values = {1: "I", 2: "II", 3: "III", 4: "IV", 5: "V"}
-    return values.get(max(1, min(5, int(level))), str(int(level)))
-
 
 class RefugePendingActionView(discord.ui.LayoutView):
-    """Small ephemeral V2 response for actions scheduled after REFUGE-010."""
+    """Compatibility shell retained after all REFUGE V1 panel actions became active."""
 
     def __init__(self, action: RefugePanelAction) -> None:
         super().__init__(timeout=120)
-        copy = _ACTION_COPY.get(action)
-        if copy is None:
-            raise ValueError(f"Refuge action is already active: {action}")
-        title, primary, secondary = copy
         container = discord.ui.Container(accent_colour=REFUGE_PANEL_ACCENT)
-        container.add_item(discord.ui.TextDisplay(f"## {title}"))
+        container.add_item(discord.ui.TextDisplay("## 🏕️ Le Refuge"))
         container.add_item(discord.ui.Separator())
-        container.add_item(discord.ui.TextDisplay(f"{primary}\n\n-# {secondary}"))
+        container.add_item(
+            discord.ui.TextDisplay(
+                f"L’action **{action}** est désormais disponible depuis le panneau principal."
+            )
+        )
         self.add_item(container)
 
 
@@ -71,14 +60,8 @@ class RefugePanelButton(discord.ui.Button):
         self.action = action
 
     async def callback(self, interaction: discord.Interaction) -> None:
-        if self.action == "timeline":
-            await interaction.response.send_message(
-                view=RefugePendingActionView(self.action),
-                ephemeral=True,
-            )
-            return
-
         await interaction.response.defer(ephemeral=True, thinking=True)
+        timeline_file: discord.File | None = None
         try:
             if self.action == "explore":
                 snapshot = await refuge_exploration_runtime_service.get_explorer()
@@ -108,6 +91,14 @@ class RefugePanelButton(discord.ui.Button):
                     display_name=display_name,
                     avatar_url=avatar_url,
                 )
+            elif self.action == "timeline":
+                snapshot = await refuge_timeline_service.get_timeline()
+                timeline_view = RefugeTimelineView(
+                    snapshot,
+                    owner_user_id=interaction.user.id,
+                )
+                timeline_file = await timeline_view.selected_file()
+                view = timeline_view
             else:
                 snapshot = await refuge_construction_service.get_snapshot(
                     interaction.user.id
@@ -125,8 +116,15 @@ class RefugePanelButton(discord.ui.Button):
             view = RefugePrivateErrorView(
                 "Impossible de charger cette partie du Refuge pour le moment."
             )
+            timeline_file = None
 
-        await interaction.edit_original_response(view=view)
+        if self.action == "timeline":
+            await interaction.edit_original_response(
+                view=view,
+                attachments=[timeline_file] if timeline_file is not None else [],
+            )
+        else:
+            await interaction.edit_original_response(view=view)
 
 
 def refuge_controls_row() -> discord.ui.ActionRow:
@@ -212,6 +210,11 @@ class RefugePublicPanelView(discord.ui.LayoutView):
         )
         container.add_item(refuge_controls_row())
         self.add_item(container)
+
+
+def _roman(level: int) -> str:
+    values = {1: "I", 2: "II", 3: "III", 4: "IV", 5: "V"}
+    return values.get(max(1, min(5, int(level))), str(int(level)))
 
 
 __all__ = [

--- a/ui/refuge_panel_view.py
+++ b/ui/refuge_panel_view.py
@@ -100,6 +100,7 @@ class RefugePanelButton(discord.ui.Button):
                 timeline_file = await timeline_view.selected_file()
                 view = timeline_view
             else:
+                await refuge_timeline_service.sync()
                 snapshot = await refuge_construction_service.get_snapshot(
                     interaction.user.id
                 )

--- a/ui/refuge_timeline_view.py
+++ b/ui/refuge_timeline_view.py
@@ -1,0 +1,290 @@
+from __future__ import annotations
+
+import io
+from datetime import datetime, timezone
+from typing import Final
+
+import discord
+
+from services.refuge_timeline import (
+    RefugeTimelineChapter,
+    RefugeTimelineService,
+    RefugeTimelineSnapshot,
+    refuge_timeline_service,
+)
+from utils.timezones import PARIS_TZ
+
+
+REFUGE_TIMELINE_ACCENT = discord.Colour(0xD08A47)
+REFUGE_HISTORY_FILENAME: Final[str] = "refuge-history.png"
+_TIMELINE_PAGE_SIZE: Final[int] = 25
+
+
+def _format_timestamp(value: str) -> str:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return "date inconnue"
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    local = parsed.astimezone(PARIS_TZ)
+    return local.strftime("%d/%m/%Y à %H:%M")
+
+
+def _roman(level: int) -> str:
+    values = {1: "I", 2: "II", 3: "III", 4: "IV", 5: "V"}
+    normalized = max(0, int(level))
+    return values.get(normalized, str(normalized))
+
+
+class RefugeTimelineSelect(discord.ui.Select):
+    def __init__(self, view: "RefugeTimelineView") -> None:
+        page = view.page_chapters
+        options = [
+            discord.SelectOption(
+                label=chapter.label,
+                value=chapter.season_id,
+                description=(
+                    f"{chapter.chapter_event_count} événement(s) · "
+                    f"{chapter.monument_count} monument(s)"
+                )[:100],
+                default=chapter.season_id == view.selected_season_id,
+            )
+            for chapter in page
+        ]
+        super().__init__(
+            custom_id="refuge:timeline:season",
+            placeholder="Choisir un chapitre",
+            min_values=1,
+            max_values=1,
+            options=options,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, RefugeTimelineView):
+            return
+        await interaction.response.defer()
+        view.select_season(self.values[0])
+        await view.edit_interaction(interaction)
+
+
+class RefugeTimelinePageButton(discord.ui.Button):
+    def __init__(self, *, direction: int, disabled: bool) -> None:
+        self.direction = -1 if direction < 0 else 1
+        super().__init__(
+            label="Plus récent" if self.direction < 0 else "Plus ancien",
+            emoji="◀️" if self.direction < 0 else "▶️",
+            style=discord.ButtonStyle.secondary,
+            custom_id=(
+                "refuge:timeline:newer" if self.direction < 0 else "refuge:timeline:older"
+            ),
+            disabled=disabled,
+        )
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, RefugeTimelineView):
+            return
+        await interaction.response.defer()
+        view.change_page(self.direction)
+        await view.edit_interaction(interaction)
+
+
+class RefugeTimelineView(discord.ui.LayoutView):
+    """Private Components V2 browser over immutable monthly Refuge snapshots."""
+
+    def __init__(
+        self,
+        snapshot: RefugeTimelineSnapshot,
+        *,
+        owner_user_id: int,
+        service: RefugeTimelineService = refuge_timeline_service,
+        page_index: int | None = None,
+    ) -> None:
+        super().__init__(timeout=300)
+        self.snapshot = snapshot
+        self.owner_user_id = int(owner_user_id)
+        self.service = service
+        self.selected_season_id = snapshot.selected_season_id
+        selected_index = self._selected_index()
+        self.page_index = (
+            max(0, int(page_index))
+            if page_index is not None
+            else (selected_index // _TIMELINE_PAGE_SIZE if selected_index >= 0 else 0)
+        )
+        self._clamp_page()
+        self.rebuild()
+
+    async def interaction_check(self, interaction: discord.Interaction, /) -> bool:
+        if interaction.user.id == self.owner_user_id:
+            return True
+        await interaction.response.send_message(
+            "Cette Chronologie privée appartient à la personne qui l’a ouverte.",
+            ephemeral=True,
+        )
+        return False
+
+    @property
+    def page_count(self) -> int:
+        if not self.snapshot.chapters:
+            return 1
+        return (len(self.snapshot.chapters) - 1) // _TIMELINE_PAGE_SIZE + 1
+
+    @property
+    def page_chapters(self) -> tuple[RefugeTimelineChapter, ...]:
+        start = self.page_index * _TIMELINE_PAGE_SIZE
+        end = start + _TIMELINE_PAGE_SIZE
+        return self.snapshot.chapters[start:end]
+
+    @property
+    def selected(self) -> RefugeTimelineChapter | None:
+        if self.selected_season_id is None:
+            return None
+        return next(
+            (
+                chapter
+                for chapter in self.snapshot.chapters
+                if chapter.season_id == self.selected_season_id
+            ),
+            None,
+        )
+
+    def _selected_index(self) -> int:
+        if self.selected_season_id is None:
+            return -1
+        for index, chapter in enumerate(self.snapshot.chapters):
+            if chapter.season_id == self.selected_season_id:
+                return index
+        return -1
+
+    def _clamp_page(self) -> None:
+        self.page_index = max(0, min(self.page_index, self.page_count - 1))
+
+    def select_season(self, season_id: str) -> None:
+        for index, chapter in enumerate(self.snapshot.chapters):
+            if chapter.season_id != season_id:
+                continue
+            self.selected_season_id = season_id
+            self.page_index = index // _TIMELINE_PAGE_SIZE
+            self.rebuild()
+            return
+
+    def change_page(self, direction: int) -> None:
+        self.page_index += -1 if direction < 0 else 1
+        self._clamp_page()
+        page = self.page_chapters
+        if page:
+            self.selected_season_id = page[0].season_id
+        self.rebuild()
+
+    def rebuild(self) -> None:
+        self.clear_items()
+        container = discord.ui.Container(accent_colour=REFUGE_TIMELINE_ACCENT)
+        container.add_item(
+            discord.ui.TextDisplay(
+                "## 🕰️ CHRONOLOGIE DU REFUGE\n"
+                "Les saisons clôturées deviennent des chapitres permanents."
+            )
+        )
+        container.add_item(discord.ui.Separator())
+
+        chapter = self.selected
+        if chapter is None:
+            container.add_item(
+                discord.ui.TextDisplay(
+                    f"### 📖 {self.snapshot.current_season_label}\n"
+                    "La première saison du Refuge est encore en cours.\n"
+                    "Aucun chapitre mensuel n’est clôturé pour le moment."
+                )
+            )
+            container.add_item(discord.ui.Separator())
+            container.add_item(
+                discord.ui.TextDisplay(
+                    "-# Le premier snapshot sera figé au prochain changement de mois Europe/Paris."
+                )
+            )
+            self.add_item(container)
+            return
+
+        gallery = discord.ui.MediaGallery()
+        gallery.add_item(
+            media=f"attachment://{REFUGE_HISTORY_FILENAME}",
+            description=f"Carte historique du Refuge — {chapter.label}",
+        )
+        container.add_item(gallery)
+        container.add_item(discord.ui.Separator())
+
+        lines = [
+            f"### 📖 {chapter.label}",
+            f"🔥 Feu : **niveau {_roman(chapter.fire_level)}**",
+            f"🏆 Hall : **niveau {_roman(chapter.hall_level)}**",
+            f"🎰 Casino : **niveau {_roman(chapter.casino_level)}**",
+            f"🏛️ Monuments permanents : **{chapter.monument_count}**",
+            f"🌌 Événements du chapitre : **{chapter.chapter_event_count}**",
+        ]
+        if chapter.construction_label:
+            lines.append(f"🏗️ Chantier à la clôture : **{chapter.construction_label}**")
+        container.add_item(discord.ui.TextDisplay("\n".join(lines)))
+
+        if chapter.chapter_event_labels:
+            container.add_item(discord.ui.Separator())
+            event_lines = ["### Traces du mois"]
+            event_lines.extend(f"• {label}" for label in chapter.chapter_event_labels)
+            container.add_item(discord.ui.TextDisplay("\n".join(event_lines)))
+
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                f"-# Snapshot figé le {_format_timestamp(chapter.captured_at)} · "
+                "la carte est régénérée depuis cet état archivé, sans recalcul de progression."
+            )
+        )
+
+        controls = discord.ui.ActionRow()
+        if self.page_chapters:
+            controls.add_item(RefugeTimelineSelect(self))
+        container.add_item(controls)
+
+        if self.page_count > 1:
+            container.add_item(
+                discord.ui.ActionRow(
+                    RefugeTimelinePageButton(
+                        direction=-1,
+                        disabled=self.page_index <= 0,
+                    ),
+                    RefugeTimelinePageButton(
+                        direction=1,
+                        disabled=self.page_index >= self.page_count - 1,
+                    ),
+                )
+            )
+            container.add_item(
+                discord.ui.TextDisplay(
+                    f"-# Archives {self.page_index + 1}/{self.page_count} · "
+                    "25 chapitres maximum par page."
+                )
+            )
+        self.add_item(container)
+
+    async def selected_file(self) -> discord.File | None:
+        chapter = self.selected
+        if chapter is None:
+            return None
+        png = await self.service.render_chapter_png(chapter)
+        return discord.File(io.BytesIO(png), filename=REFUGE_HISTORY_FILENAME)
+
+    async def edit_interaction(self, interaction: discord.Interaction) -> None:
+        file = await self.selected_file()
+        kwargs: dict[str, object] = {"view": self}
+        kwargs["attachments"] = [file] if file is not None else []
+        await interaction.edit_original_response(**kwargs)
+
+
+__all__ = [
+    "REFUGE_HISTORY_FILENAME",
+    "REFUGE_TIMELINE_ACCENT",
+    "RefugeTimelinePageButton",
+    "RefugeTimelineSelect",
+    "RefugeTimelineView",
+]


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-011 — Chronologie / snapshots mensuels** : figer chaque mois du Refuge comme chapitre permanent, consultable depuis le bouton `🕰️ Chronologie`, sans recalcul rétroactif de progression et sans toucher aux secrets REFUGE-012.

## Source de vérité
REFUGE-001 avait déjà prévu `RefugeWorldSnapshot` et le champ `snapshots` dans `refuge_world.json`.

REFUGE-011 réutilise ce modèle existant : **aucun nouveau fichier JSON et aucune migration de schéma**.

Chaque snapshot conserve :
- bâtiments et niveaux au moment de la clôture ;
- IDs des événements connus avant la fin du mois ;
- chantier éventuel ;
- `state` monde persistant.

Les événements complets restent dans l’historique permanent `RefugeWorldState.events` et sont résolus par leurs IDs lors de la consultation.

## Rollover mensuel Europe/Paris
La saison active est le mois civil `Europe/Paris` (`YYYY-MM`).

Au premier démarrage de REFUGE-011 :
- le mois courant devient la saison Chronologie active ;
- **aucun mois antérieur n’est backfill artificiellement**.

Au premier passage dans un nouveau mois :
- l’état connu du mois précédent est figé une seule fois ;
- le snapshot est immuable ;
- la nouvelle saison devient active.

Si le bot reste hors ligne pendant plusieurs mois, REFUGE-011 archive uniquement le dernier mois réellement suivi et saute les mois non observés au lieu d’inventer des états intermédiaires.

## Ordre des mutations
Le point critique est de figer le mois précédent **avant** toute mutation du nouveau mois.

REFUGE-011 utilise le verrou partagé `refuge_world_mutation_lock` introduit par REFUGE-010.

Le panneau appelle désormais le rollover avant la chaîne :
`Chronologie → Feu → Hall → Casino`.

Le Chantier appelle également la Chronologie avant sa boucle automatique et avant les actions privées pouvant déclencher une transition.

Cela évite qu’une clôture de vote, une inauguration ou une progression du 1er du mois modifie le monde avant l’archive du mois précédent.

## Carte historique déterministe
La Chronologie ne réévalue jamais Feu, Hall, Casino ou Chantier pour une saison passée.

Pour un snapshot :
1. reconstruction d’un `RefugeWorldState` historique ;
2. sélection des événements appartenant à ce snapshot ;
3. contexte visuel dérivé de la dernière microseconde du mois civil concerné ;
4. rendu via le renderer final `RefugeConstructionRenderer`.

Le contexte visuel de clôture est donc déterministe : même snapshot + même mois → même contexte saison/jourpart.

## Vue privée Components V2
Le `custom_id` public reste inchangé :
`refuge:panel:timeline`.

Le bouton ouvre une vue éphémère privée.

Avant le premier rollover mensuel :
- la vue explique que la première saison est encore en cours ;
- aucune fausse archive n’est créée.

Quand des chapitres existent, chaque chapitre affiche :
- carte historique ;
- niveaux Feu / Hall / Casino ;
- nombre de monuments permanents ;
- nombre d’événements du mois ;
- jusqu’à 5 traces du chapitre ;
- chantier encore actif à la clôture, le cas échéant ;
- date réelle d’écriture du snapshot.

La carte est régénérée depuis le snapshot et la vue indique explicitement qu’aucun recalcul de progression n’est effectué.

## Archives longues
Discord limite les `Select` à 25 options.

La Chronologie pagine donc les archives par blocs de **25 mois**, avec :
- `Plus récent` ;
- `Plus ancien`.

Le design reste utilisable après plusieurs années de fonctionnement sans reset.

## Nettoyage du panneau
`RefugePendingActionView` est supprimé : après REFUGE-011, les quatre boutons publics sont réellement actifs :
- Explorer ;
- Mon empreinte ;
- Chronologie ;
- Chantier.

Leurs `custom_id` persistants restent strictement inchangés.

## Fichiers principaux
- `services/refuge_timeline.py` — rollover, reconstruction et read model historique ;
- `cogs/refuge_timeline.py` — filet de sécurité de rollover chaque minute ;
- `ui/refuge_timeline_view.py` — navigateur Components V2 des archives ;
- `services/refuge_panel.py` — archive avant Feu/Hall/Casino ;
- `cogs/refuge_construction.py` / `ui/refuge_construction_view.py` — archive avant transitions Chantier ;
- `ui/refuge_panel_view.py` — activation du bouton Chronologie ;
- tests ciblés timeline/panel.

## Tests ajoutés / adaptés
Couverture prévue :
- première activation sans backfill ;
- rollover au changement de mois Paris ;
- snapshot unique et immuable ;
- événements postérieurs au mois exclus ;
- aucune fabrication de mois pendant une longue indisponibilité ;
- fallback vers le dernier chapitre valide ;
- rendu avec contexte historique déterministe ;
- vue sans archive ;
- résumé d’un chapitre ;
- pièce jointe historique ;
- pagination >25 mois ;
- panneau archive avant les services de progression ;
- maintien des quatre `custom_id` publics.

## Validation disponible
Branche basée sur `main` au commit `ca5892ea03209b1b86a2b93aee04eb3ac959cf15`, avec `behind_by=0` au dernier contrôle.

Le runtime ChatGPT ne peut toujours pas cloner GitHub (`Could not resolve host: github.com`), donc la suite pytest réelle n’est **pas déclarée comme passée**.

Les contrats discord.py utilisés pour Components V2, `ActionRow.add_item` et le remplacement de pièces jointes via `edit_original_response` ont été vérifiés dans la documentation officielle discord.py 2.6+.

## Hors périmètre
- aucun reset du Refuge ;
- aucune recomposition des stats historiques ;
- aucun classement personnel ;
- aucune modification XP / Casino / objectifs communautaires ;
- aucun déclencheur secret REFUGE-012 ;
- aucun hardening final REFUGE-013.

La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.