### PR TITLE
feat: automate Refuge hidden events

### DIFF
--- a/cogs/refuge_secrets.py
+++ b/cogs/refuge_secrets.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from discord.ext import commands, tasks
+
+from services.refuge_secrets import refuge_secrets_service
+
+
+logger = logging.getLogger(__name__)
+
+
+class RefugeSecretsCog(commands.Cog):
+    """Discover hidden Refuge events from real community evidence."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    async def cog_load(self) -> None:
+        # The first sync only establishes REFUGE-012 prospective activation.
+        try:
+            await refuge_secrets_service.sync()
+        except Exception:
+            logger.exception("[refuge] initialisation des événements secrets échouée")
+        if not self.discover_hidden_events.is_running():
+            self.discover_hidden_events.start()
+
+    def cog_unload(self) -> None:
+        self.discover_hidden_events.cancel()
+
+    @tasks.loop(minutes=1)
+    async def discover_hidden_events(self) -> None:
+        try:
+            result = await refuge_secrets_service.sync()
+            for discovery in result.discoveries:
+                logger.info(
+                    "[refuge] découverte persistée: building=%s marker=%s",
+                    discovery.building_id,
+                    discovery.marker_id,
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("[refuge] détection des événements secrets échouée")
+
+    @discover_hidden_events.before_loop
+    async def before_discover_hidden_events(self) -> None:
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(RefugeSecretsCog(bot))
+
+
+__all__ = ["RefugeSecretsCog"]

--- a/services/refuge_panel.py
+++ b/services/refuge_panel.py
@@ -16,6 +16,7 @@ from rendering.refuge_world import RefugeRenderContext
 from services.refuge_casino import RefugeCasinoService, refuge_casino_service
 from services.refuge_fire import RefugeFireService, refuge_fire_service
 from services.refuge_hall import RefugeHallService, refuge_hall_service
+from services.refuge_secrets import RefugeSecretsService, refuge_secrets_service
 from services.refuge_timeline import RefugeTimelineService, refuge_timeline_service
 from services.refuge_world_coordination import refuge_world_mutation_lock
 from utils.seasons import season_id_for, season_label
@@ -165,28 +166,35 @@ class RefugePanelService:
         hall_service: RefugeHallService = refuge_hall_service,
         casino_service: RefugeCasinoService = refuge_casino_service,
         timeline_service: RefugeTimelineService = refuge_timeline_service,
+        secrets_service: RefugeSecretsService = refuge_secrets_service,
         renderer: RefugeConstructionRenderer = refuge_construction_renderer,
     ) -> None:
         self.fire_service = fire_service
         self.hall_service = hall_service
         self.casino_service = casino_service
         self.timeline_service = timeline_service
+        self.secrets_service = secrets_service
         self.renderer = renderer
 
     async def evaluate(self, *, at: datetime | None = None) -> RefugePanelSnapshot:
         now = _aware_utc(at)
         async with refuge_world_mutation_lock():
-            # REFUGE-011 must archive the previous Paris calendar month before
-            # any current-month progression can mutate the shared world state.
+            # REFUGE-011 archives the previous Paris calendar month before any
+            # current-month mutation can touch the shared world state.
             await self.timeline_service.sync_under_world_lock(at=now)
 
-            # Sequential evaluation is intentional: all three services share
+            # Sequential evaluation is intentional: all systems share
             # RefugeWorldStore and each stage must observe the previous write.
             fire = await self.fire_service.evaluate(at=now)
             hall = await self.hall_service.evaluate(at=now)
             casino = await self.casino_service.evaluate(at=now)
 
-            state = casino.state
+            # Hidden discoveries are evaluated only after their source systems
+            # have projected the latest real evidence into the world. The
+            # service already runs under the shared mutation lock here.
+            secrets = await self.secrets_service.sync_under_world_lock(at=now)
+            state = secrets.state
+
             context = RefugeRenderContext.from_datetime(now)
             current_season = season_id_for(now)
             last_event = latest_event(state)
@@ -233,7 +241,12 @@ class RefugePanelService:
                 latest_event_label=last_event_label,
                 visual_signature=visual_signature,
                 summary_signature=_summary_signature(summary_payload),
-                changed=bool(fire.changed or hall.changed or casino.changed),
+                changed=bool(
+                    fire.changed
+                    or hall.changed
+                    or casino.changed
+                    or secrets.changed
+                ),
             )
 
     async def render_png(self, snapshot: RefugePanelSnapshot) -> bytes:

--- a/services/refuge_secrets.py
+++ b/services/refuge_secrets.py
@@ -1,0 +1,588 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, Final, Mapping, Sequence
+
+from models.refuge_world import (
+    RefugeBuildingState,
+    RefugeHistoricalEvent,
+    RefugeWorldState,
+)
+from rendering.refuge_world import RefugeRenderContext
+from services.refuge_casino import (
+    CASINO_BUILDING_ID,
+    CASINO_EVENTS,
+    CASINO_SECRET_EVENTS,
+    casino_is_open,
+)
+from services.refuge_fire import FIRE_BUILDING_ID, FIRE_SECRET_EVENTS
+from services.refuge_hall import HALL_BUILDING_ID, HALL_SECRET_EVENTS
+from services.refuge_timeline import RefugeTimelineService, refuge_timeline_service
+from services.refuge_world_coordination import refuge_world_mutation_lock
+from storage.achievement_store import AchievementStore, achievement_store
+from storage.refuge_activity_store import RefugeActivityStore, refuge_activity_store
+from storage.refuge_casino_activity_store import (
+    RefugeCasinoActivityStore,
+    refuge_casino_activity_store,
+)
+from storage.refuge_world_store import RefugeWorldStore, refuge_world_store
+from utils.achievements import ACHIEVEMENT_BY_ID
+from utils.timezones import PARIS_TZ
+
+
+REFUGE_SECRETS_STATE_KEY: Final[str] = "refuge_secrets"
+REFUGE_SECRETS_VERSION: Final[int] = 1
+RECENT_CASINO_WINDOW_SECONDS: Final[int] = 24 * 60 * 60
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeSecretDiscovery:
+    building_id: str
+    marker_id: str
+    name: str
+    event_type: str
+    occurred_at: str
+
+
+@dataclass(frozen=True, slots=True)
+class RefugeSecretsSyncResult:
+    state: RefugeWorldState
+    discoveries: tuple[RefugeSecretDiscovery, ...]
+    changed: bool
+
+
+def _aware_utc(at: datetime | None = None) -> datetime:
+    moment = at or datetime.now(timezone.utc)
+    if moment.tzinfo is None:
+        moment = moment.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc)
+
+
+def _parse_timestamp(value: object) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return _aware_utc(value).isoformat()
+
+
+def _secrets_meta(state: RefugeWorldState) -> dict[str, Any]:
+    raw = state.state.get(REFUGE_SECRETS_STATE_KEY, {})
+    source = raw if isinstance(raw, Mapping) else {}
+    return {
+        "version": REFUGE_SECRETS_VERSION,
+        "enabled_at": str(source.get("enabled_at") or "") or None,
+    }
+
+
+def _with_meta(state: RefugeWorldState, meta: Mapping[str, Any]) -> RefugeWorldState:
+    payload = dict(state.state)
+    payload[REFUGE_SECRETS_STATE_KEY] = dict(meta)
+    return replace(state, state=payload)
+
+
+def _building(state: RefugeWorldState, building_id: str) -> RefugeBuildingState | None:
+    return next(
+        (item for item in state.buildings if item.building_id == building_id),
+        None,
+    )
+
+
+def _replace_building(
+    state: RefugeWorldState,
+    building: RefugeBuildingState,
+) -> RefugeWorldState:
+    buildings = {item.building_id: item for item in state.buildings}
+    buildings[building.building_id] = building
+    return replace(
+        state,
+        buildings=tuple(sorted(buildings.values(), key=lambda item: item.building_id)),
+    )
+
+
+def _string_values(value: object) -> set[str]:
+    if not isinstance(value, (list, tuple, set, frozenset)):
+        return set()
+    return {str(item) for item in value if str(item).strip()}
+
+
+def _voice_evidence(
+    snapshot: Mapping[str, Any],
+    *,
+    enabled_at: datetime,
+    now: datetime,
+) -> tuple[tuple[datetime, str], ...]:
+    raw = snapshot.get("recent_voice_buckets", {})
+    if not isinstance(raw, Mapping):
+        return ()
+    evidence: list[tuple[datetime, str]] = []
+    for raw_key, raw_seconds in raw.items():
+        moment = _parse_timestamp(raw_key)
+        if moment is None or moment < enabled_at or moment > now:
+            continue
+        try:
+            seconds = int(raw_seconds)
+        except (TypeError, ValueError):
+            continue
+        if seconds <= 0:
+            continue
+        local = moment.astimezone(PARIS_TZ)
+        context = RefugeRenderContext.from_datetime(local)
+        evidence.append((moment, context.daypart))
+    evidence.sort(key=lambda item: item[0])
+    return tuple(evidence)
+
+
+def _achievement_evidence(
+    snapshot: Mapping[str, Any],
+    *,
+    enabled_at: datetime,
+    now: datetime,
+) -> tuple[tuple[datetime, int, str], ...]:
+    users = snapshot.get("users", {})
+    if not isinstance(users, Mapping):
+        return ()
+    events: list[tuple[datetime, int, str]] = []
+    for raw_user_id, raw_achievements in users.items():
+        if not isinstance(raw_achievements, Mapping):
+            continue
+        try:
+            user_id = int(raw_user_id)
+        except (TypeError, ValueError):
+            continue
+        for raw_achievement_id, raw_unlocked_at in raw_achievements.items():
+            moment = _parse_timestamp(raw_unlocked_at)
+            if moment is None or moment < enabled_at or moment > now:
+                continue
+            achievement_id = str(raw_achievement_id)
+            if achievement_id not in ACHIEVEMENT_BY_ID:
+                continue
+            events.append((moment, user_id, achievement_id))
+    events.sort(key=lambda item: (item[0], item[2], item[1]))
+    return tuple(events)
+
+
+def _casino_evidence(
+    snapshot: Mapping[str, Any],
+    *,
+    enabled_at: datetime,
+    now: datetime,
+) -> tuple[dict[str, int], tuple[dict[str, Any], ...], tuple[datetime, ...]]:
+    cutoff = max(enabled_at, now - timedelta(seconds=RECENT_CASINO_WINDOW_SECONDS))
+    totals = {
+        "roulette_wagered_xp": 0,
+        "roulette_payout_xp": 0,
+        "machine_payout_xp": 0,
+        "transactions": 0,
+    }
+    transaction_times: list[datetime] = []
+    raw_buckets = snapshot.get("recent_buckets", {})
+    if isinstance(raw_buckets, Mapping):
+        for raw_key, raw_payload in raw_buckets.items():
+            if not isinstance(raw_payload, Mapping):
+                continue
+            moment = _parse_timestamp(raw_key)
+            if moment is None or moment < cutoff or moment > now:
+                continue
+            for field in totals:
+                try:
+                    totals[field] += max(0, int(raw_payload.get(field, 0)))
+                except (TypeError, ValueError):
+                    continue
+            try:
+                transactions = max(0, int(raw_payload.get("transactions", 0)))
+            except (TypeError, ValueError):
+                transactions = 0
+            if transactions > 0:
+                transaction_times.append(moment)
+
+    jackpots: list[dict[str, Any]] = []
+    raw_jackpots = snapshot.get("jackpots", [])
+    if isinstance(raw_jackpots, list):
+        for item in raw_jackpots:
+            if not isinstance(item, Mapping):
+                continue
+            moment = _parse_timestamp(item.get("occurred_at"))
+            if moment is None or moment < enabled_at or moment > now:
+                continue
+            candidate = dict(item)
+            candidate["_moment"] = moment
+            jackpots.append(candidate)
+    jackpots.sort(
+        key=lambda item: (
+            item.get("_moment", datetime.min.replace(tzinfo=timezone.utc)),
+            str(item.get("event_id", "")),
+        )
+    )
+    transaction_times.sort()
+    return totals, tuple(jackpots), tuple(transaction_times)
+
+
+def _discovery_exists(state: RefugeWorldState, event_id: str) -> bool:
+    return any(event.event_id == event_id for event in state.events)
+
+
+def _discover(
+    state: RefugeWorldState,
+    *,
+    building_id: str,
+    marker_id: str,
+    name: str,
+    state_key: str,
+    event_id: str,
+    event_type: str,
+    occurred_at: datetime,
+    marker_data_key: str,
+) -> tuple[RefugeWorldState, RefugeSecretDiscovery | None]:
+    if _discovery_exists(state, event_id):
+        return state, None
+    building = _building(state, building_id)
+    if building is None:
+        return state, None
+
+    values = _string_values(building.state.get(state_key, ()))
+    values.add(marker_id)
+    building_state = dict(building.state)
+    building_state[state_key] = sorted(values)
+    updated = _replace_building(state, replace(building, state=building_state))
+    event = RefugeHistoricalEvent(
+        event_id=event_id,
+        event_type=event_type,
+        occurred_at=_iso(occurred_at),
+        data={
+            "building_id": building_id,
+            marker_data_key: marker_id,
+            "name": name,
+        },
+    )
+    updated = replace(updated, events=updated.events + (event,))
+    discovery = RefugeSecretDiscovery(
+        building_id=building_id,
+        marker_id=marker_id,
+        name=name,
+        event_type=event_type,
+        occurred_at=event.occurred_at,
+    )
+    return updated, discovery
+
+
+def _latest_time(values: Sequence[datetime], fallback: datetime) -> datetime:
+    return max(values) if values else fallback
+
+
+class RefugeSecretsService:
+    """Discover hidden Refuge events from real, prospective community evidence."""
+
+    def __init__(
+        self,
+        *,
+        world_store: RefugeWorldStore = refuge_world_store,
+        activity_store: RefugeActivityStore = refuge_activity_store,
+        achievement_store_: AchievementStore = achievement_store,
+        casino_activity_store: RefugeCasinoActivityStore = refuge_casino_activity_store,
+        timeline_service: RefugeTimelineService = refuge_timeline_service,
+    ) -> None:
+        self.world_store = world_store
+        self.activity_store = activity_store
+        self.achievement_store = achievement_store_
+        self.casino_activity_store = casino_activity_store
+        self.timeline_service = timeline_service
+
+    async def sync(self, *, at: datetime | None = None) -> RefugeSecretsSyncResult:
+        now = _aware_utc(at)
+        async with refuge_world_mutation_lock():
+            await self.timeline_service.sync_under_world_lock(at=now)
+            return await self.sync_under_world_lock(at=now)
+
+    async def sync_under_world_lock(
+        self,
+        *,
+        at: datetime | None = None,
+    ) -> RefugeSecretsSyncResult:
+        now = _aware_utc(at)
+        state = await self.world_store.initialize(created_at=now)
+        meta = _secrets_meta(state)
+        enabled_at = _parse_timestamp(meta.get("enabled_at"))
+        if enabled_at is None:
+            meta["enabled_at"] = now.isoformat()
+            saved = await self.world_store.save_state(_with_meta(state, meta))
+            return RefugeSecretsSyncResult(saved, (), True)
+
+        voice_snapshot = await self.activity_store.get_snapshot()
+        achievement_snapshot = await self.achievement_store.get_snapshot()
+        casino_snapshot = await self.casino_activity_store.get_snapshot(at=now)
+
+        voice = _voice_evidence(
+            voice_snapshot,
+            enabled_at=enabled_at,
+            now=now,
+        )
+        achievements = _achievement_evidence(
+            achievement_snapshot,
+            enabled_at=enabled_at,
+            now=now,
+        )
+        casino_totals, jackpots, transaction_times = _casino_evidence(
+            casino_snapshot,
+            enabled_at=enabled_at,
+            now=now,
+        )
+
+        discoveries: list[RefugeSecretDiscovery] = []
+
+        # Fire secrets are based only on qualifying community voice buckets.
+        if voice:
+            state, discovery = _discover(
+                state,
+                building_id=FIRE_BUILDING_ID,
+                marker_id="first_visitor",
+                name=FIRE_SECRET_EVENTS["first_visitor"],
+                state_key="secret_events",
+                event_id="fire:secret:first_visitor",
+                event_type="fire_secret_discovered",
+                occurred_at=voice[0][0],
+                marker_data_key="secret_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        night_times = [moment for moment, daypart in voice if daypart == "night"]
+        if night_times:
+            state, discovery = _discover(
+                state,
+                building_id=FIRE_BUILDING_ID,
+                marker_id="night_of_stars",
+                name=FIRE_SECRET_EVENTS["night_of_stars"],
+                state_key="secret_events",
+                event_id="fire:secret:night_of_stars",
+                event_type="fire_secret_discovered",
+                occurred_at=night_times[0],
+                marker_data_key="secret_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        voice_dayparts = {daypart for _moment, daypart in voice}
+        if {"morning", "day", "sunset", "night"}.issubset(voice_dayparts):
+            state, discovery = _discover(
+                state,
+                building_id=FIRE_BUILDING_ID,
+                marker_id="full_circle",
+                name=FIRE_SECRET_EVENTS["full_circle"],
+                state_key="secret_events",
+                event_id="fire:secret:full_circle",
+                event_type="fire_secret_discovered",
+                occurred_at=voice[-1][0],
+                marker_data_key="secret_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        # Hall secrets use real achievement unlocks and the existing catalogue.
+        if achievements:
+            state, discovery = _discover(
+                state,
+                building_id=HALL_BUILDING_ID,
+                marker_id="memory_flame",
+                name=HALL_SECRET_EVENTS["memory_flame"],
+                state_key="secret_events",
+                event_id="hall:secret:memory_flame",
+                event_type="hall_secret_discovered",
+                occurred_at=achievements[0][0],
+                marker_data_key="secret_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        known_categories = {
+            definition.category for definition in ACHIEVEMENT_BY_ID.values()
+        }
+        observed_categories = {
+            ACHIEVEMENT_BY_ID[achievement_id].category
+            for _moment, _user_id, achievement_id in achievements
+            if achievement_id in ACHIEVEMENT_BY_ID
+        }
+        if known_categories and known_categories.issubset(observed_categories):
+            state, discovery = _discover(
+                state,
+                building_id=HALL_BUILDING_ID,
+                marker_id="endless_book",
+                name=HALL_SECRET_EVENTS["endless_book"],
+                state_key="secret_events",
+                event_id="hall:secret:endless_book",
+                event_type="hall_secret_discovered",
+                occurred_at=achievements[-1][0],
+                marker_data_key="secret_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        achievement_counts: dict[str, int] = {}
+        achievers = {user_id for _moment, user_id, _achievement_id in achievements}
+        for _moment, _user_id, achievement_id in achievements:
+            achievement_counts[achievement_id] = achievement_counts.get(achievement_id, 0) + 1
+        if len(achievers) >= 2 and any(count == 1 for count in achievement_counts.values()):
+            state, discovery = _discover(
+                state,
+                building_id=HALL_BUILDING_ID,
+                marker_id="forgotten_crown",
+                name=HALL_SECRET_EVENTS["forgotten_crown"],
+                state_key="secret_events",
+                event_id="hall:secret:forgotten_crown",
+                event_type="hall_secret_discovered",
+                occurred_at=achievements[-1][0],
+                marker_data_key="secret_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        # Casino regular events and secrets use only observed prospective flows.
+        wagered = int(casino_totals["roulette_wagered_xp"])
+        paid = int(casino_totals["roulette_payout_xp"]) + int(
+            casino_totals["machine_payout_xp"]
+        )
+        transactions = int(casino_totals["transactions"])
+        casino_occurrence = _latest_time(transaction_times, now)
+
+        if transactions > 0 and wagered > 0 and paid > wagered:
+            state, discovery = _discover(
+                state,
+                building_id=CASINO_BUILDING_ID,
+                marker_id="grand_heist",
+                name=CASINO_EVENTS["grand_heist"],
+                state_key="casino_events",
+                event_id="casino:casino_events:grand_heist",
+                event_type="casino_event_discovered",
+                occurred_at=casino_occurrence,
+                marker_data_key="marker_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        if transactions > 0 and any(
+            RefugeRenderContext.from_datetime(moment.astimezone(PARIS_TZ)).daypart == "night"
+            for moment in transaction_times
+        ):
+            state, discovery = _discover(
+                state,
+                building_id=CASINO_BUILDING_ID,
+                marker_id="black_night",
+                name=CASINO_EVENTS["black_night"],
+                state_key="casino_events",
+                event_id="casino:casino_events:black_night",
+                event_type="casino_event_discovered",
+                occurred_at=casino_occurrence,
+                marker_data_key="marker_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        jackpot_500 = [item for item in jackpots if int(item.get("tier", 0) or 0) == 500]
+        if jackpot_500:
+            state, discovery = _discover(
+                state,
+                building_id=CASINO_BUILDING_ID,
+                marker_id="break_in",
+                name=CASINO_EVENTS["break_in"],
+                state_key="casino_events",
+                event_id="casino:casino_events:break_in",
+                event_type="casino_event_discovered",
+                occurred_at=jackpot_500[0]["_moment"],
+                marker_data_key="marker_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        if transactions > 0 and wagered > 0 and paid > 0 and wagered > paid:
+            state, discovery = _discover(
+                state,
+                building_id=CASINO_BUILDING_ID,
+                marker_id="house_always_wins",
+                name=CASINO_EVENTS["house_always_wins"],
+                state_key="casino_events",
+                event_id="casino:casino_events:house_always_wins",
+                event_type="casino_event_discovered",
+                occurred_at=casino_occurrence,
+                marker_data_key="marker_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        if transactions > 0 and wagered > 0 and paid > 0 and wagered == paid:
+            state, discovery = _discover(
+                state,
+                building_id=CASINO_BUILDING_ID,
+                marker_id="black_cat",
+                name=CASINO_SECRET_EVENTS["black_cat"],
+                state_key="secret_events",
+                event_id="casino:secret_events:black_cat",
+                event_type="casino_secret_discovered",
+                occurred_at=casino_occurrence,
+                marker_data_key="marker_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        jackpot_1000 = [item for item in jackpots if int(item.get("tier", 0) or 0) == 1000]
+        if jackpot_1000:
+            state, discovery = _discover(
+                state,
+                building_id=CASINO_BUILDING_ID,
+                marker_id="diamond",
+                name=CASINO_SECRET_EVENTS["diamond"],
+                state_key="secret_events",
+                event_id="casino:secret_events:diamond",
+                event_type="casino_secret_discovered",
+                occurred_at=jackpot_1000[0]["_moment"],
+                marker_data_key="marker_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        ghost_jackpots = [
+            item
+            for item in jackpots
+            if not casino_is_open(item["_moment"])
+        ]
+        if ghost_jackpots:
+            state, discovery = _discover(
+                state,
+                building_id=CASINO_BUILDING_ID,
+                marker_id="ghost_player",
+                name=CASINO_SECRET_EVENTS["ghost_player"],
+                state_key="secret_events",
+                event_id="casino:secret_events:ghost_player",
+                event_type="casino_secret_discovered",
+                occurred_at=ghost_jackpots[0]["_moment"],
+                marker_data_key="marker_id",
+            )
+            if discovery:
+                discoveries.append(discovery)
+
+        if not discoveries:
+            return RefugeSecretsSyncResult(state, (), False)
+
+        saved = await self.world_store.save_state(state)
+        return RefugeSecretsSyncResult(saved, tuple(discoveries), True)
+
+
+refuge_secrets_service = RefugeSecretsService()
+
+
+__all__ = [
+    "REFUGE_SECRETS_STATE_KEY",
+    "REFUGE_SECRETS_VERSION",
+    "RefugeSecretDiscovery",
+    "RefugeSecretsService",
+    "RefugeSecretsSyncResult",
+    "refuge_secrets_service",
+]

--- a/tests/test_refuge_panel_service.py
+++ b/tests/test_refuge_panel_service.py
@@ -38,6 +38,21 @@ class _Timeline:
         return None
 
 
+class _Secrets:
+    def __init__(self, state, *, changed=False):
+        self.state = state
+        self.changed = changed
+        self.calls = []
+
+    async def sync_under_world_lock(self, *, at=None):
+        self.calls.append(at)
+        return SimpleNamespace(
+            state=self.state,
+            changed=self.changed,
+            discoveries=(),
+        )
+
+
 class _Renderer:
     def __init__(self):
         self.calls = []
@@ -59,12 +74,23 @@ def _status(state, **kwargs):
 
 
 @pytest.mark.asyncio
-async def test_panel_service_archives_then_evaluates_systems_sequentially():
+async def test_panel_service_archives_then_evaluates_systems_and_secrets_sequentially():
     at = datetime(2026, 8, 9, 14, 0, tzinfo=timezone.utc)
     base = RefugeWorldState(created_at="2026-08-09T00:00:00+00:00")
     fire_state = replace(base, state={"stage": "fire"})
     hall_state = replace(base, state={"stage": "hall"})
-    final_state = replace(base, state={"stage": "casino"})
+    casino_state = replace(base, state={"stage": "casino"})
+    secret_event = RefugeHistoricalEvent(
+        event_id="fire:secret:first_visitor",
+        event_type="fire_secret_discovered",
+        occurred_at="2026-08-09T14:00:00+00:00",
+        data={"name": "Le Premier Visiteur"},
+    )
+    final_state = replace(
+        casino_state,
+        state={"stage": "secrets"},
+        events=(secret_event,),
+    )
 
     fire = _Service(
         _status(
@@ -72,7 +98,7 @@ async def test_panel_service_archives_then_evaluates_systems_sequentially():
             level=2,
             level_name="Le Campement",
             intensity="normal",
-            changed=True,
+            changed=False,
         )
     )
     hall = _Service(
@@ -84,7 +110,7 @@ async def test_panel_service_archives_then_evaluates_systems_sequentially():
     )
     casino = _Service(
         _status(
-            final_state,
+            casino_state,
             level=1,
             level_name="Baraque de Jeux",
             fortune="stable",
@@ -93,12 +119,14 @@ async def test_panel_service_archives_then_evaluates_systems_sequentially():
         )
     )
     timeline = _Timeline()
+    secrets = _Secrets(final_state, changed=True)
     renderer = _Renderer()
     service = RefugePanelService(
         fire_service=fire,
         hall_service=hall,
         casino_service=casino,
         timeline_service=timeline,
+        secrets_service=secrets,
         renderer=renderer,
     )
 
@@ -113,9 +141,16 @@ async def test_panel_service_archives_then_evaluates_systems_sequentially():
     assert snapshot.casino_fortune_name == "Stable"
     assert snapshot.casino_is_open is True
     assert snapshot.construction_label == "Aucun chantier actif"
+    assert snapshot.latest_event_label == "Le Premier Visiteur"
     assert snapshot.changed is True
-    assert len(timeline.calls) == 1
-    assert timeline.calls[0] == fire.calls[0] == hall.calls[0] == casino.calls[0]
+    assert len(timeline.calls) == len(secrets.calls) == 1
+    assert (
+        timeline.calls[0]
+        == fire.calls[0]
+        == hall.calls[0]
+        == casino.calls[0]
+        == secrets.calls[0]
+    )
 
     assert await service.render_png(snapshot) == b"PNG"
     assert renderer.calls[0][0] == final_state

--- a/tests/test_refuge_secrets.py
+++ b/tests/test_refuge_secrets.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -147,14 +146,17 @@ async def test_hall_secrets_use_post_activation_achievement_history(tmp_path):
     assert by_category
 
     users = {"42": {}, "99": {}}
+    base_time = datetime(2026, 8, 9, 10, 0, tzinfo=timezone.utc)
     for index, achievement_id in enumerate(by_category.values()):
         user = "42" if index % 2 == 0 else "99"
-        users[user][achievement_id] = f"2026-08-09T{10 + index:02d}:00:00+00:00"
+        users[user][achievement_id] = (base_time + timedelta(minutes=index)).isoformat()
     if not users["99"]:
-        # Keep the rarity rule meaningful even if the catalogue ever collapses
-        # to one category.
-        extra_id = next(iter(ACHIEVEMENT_BY_ID))
-        users["99"][extra_id] = "2026-08-09T20:00:00+00:00"
+        used = set(users["42"])
+        extra_id = next(
+            (item for item in ACHIEVEMENT_BY_ID if item not in used),
+            next(iter(ACHIEVEMENT_BY_ID)),
+        )
+        users["99"][extra_id] = (base_time + timedelta(hours=1)).isoformat()
     achievements.snapshot = {"users": users}
 
     result = await service.sync(
@@ -179,9 +181,8 @@ async def test_casino_regular_and_secret_markers_are_separate_and_idempotent(tmp
     service, world_store, _voice, _achievements, casino = await _service(tmp_path)
     await service.sync(at=datetime(2026, 8, 8, 0, 0, tzinfo=timezone.utc))
 
-    # 23:00 local: observed night activity, players ahead of the house, and
-    # both prospective jackpot tiers. Exact conditions remain internal to the
-    # engine; Discord only sees discoveries once persisted.
+    # 23:00 local provides real night activity. The jackpot timestamps are
+    # deliberately inside the configured closed window (07:00 local).
     casino.snapshot = {
         "recent_buckets": {
             "2026-08-09T21:00:00+00:00": {
@@ -196,13 +197,13 @@ async def test_casino_regular_and_secret_markers_are_separate_and_idempotent(tmp
                 "event_id": "j500",
                 "user_id": 42,
                 "tier": 500,
-                "occurred_at": "2026-08-09T21:00:00+00:00",
+                "occurred_at": "2026-08-09T05:00:00+00:00",
             },
             {
                 "event_id": "j1000",
                 "user_id": 99,
                 "tier": 1000,
-                "occurred_at": "2026-08-09T21:01:00+00:00",
+                "occurred_at": "2026-08-09T05:01:00+00:00",
             },
         ],
     }
@@ -219,6 +220,10 @@ async def test_casino_regular_and_secret_markers_are_separate_and_idempotent(tmp
         set(casino_building.state["secret_events"])
     )
     assert any(item.marker_id == "diamond" for item in first.discoveries)
+    for event in state.events:
+        if event.event_type.endswith("secret_discovered"):
+            assert "condition" not in event.data
+            assert "trigger" not in event.data
 
     again = await service.sync(
         at=datetime(2026, 8, 9, 21, 6, tzinfo=timezone.utc)

--- a/tests/test_refuge_secrets.py
+++ b/tests/test_refuge_secrets.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+
+from models.refuge_world import RefugeBuildingState, RefugeWorldState
+from services.refuge_secrets import REFUGE_SECRETS_STATE_KEY, RefugeSecretsService
+from storage.refuge_world_store import RefugeWorldStore
+from utils.achievements import ACHIEVEMENT_BY_ID
+
+
+class _SnapshotStore:
+    def __init__(self, snapshot):
+        self.snapshot = snapshot
+
+    async def get_snapshot(self, **_kwargs):
+        return self.snapshot
+
+
+class _Timeline:
+    async def sync_under_world_lock(self, *, at=None):
+        return None
+
+
+async def _service(tmp_path):
+    world_store = RefugeWorldStore(tmp_path / "world.json")
+    await world_store.save_state(
+        RefugeWorldState(
+            created_at="2026-08-01T00:00:00+00:00",
+            buildings=(
+                RefugeBuildingState("casino", level=1),
+                RefugeBuildingState("fire", level=1),
+                RefugeBuildingState("hall", level=1),
+            ),
+        )
+    )
+    voice = _SnapshotStore({"recent_voice_buckets": {}})
+    achievements = _SnapshotStore({"users": {}})
+    casino = _SnapshotStore({"recent_buckets": {}, "jackpots": []})
+    service = RefugeSecretsService(
+        world_store=world_store,
+        activity_store=voice,
+        achievement_store_=achievements,
+        casino_activity_store=casino,
+        timeline_service=_Timeline(),
+    )
+    return service, world_store, voice, achievements, casino
+
+
+def _event_ids(state):
+    return {event.event_id for event in state.events}
+
+
+def _building(state, building_id):
+    return next(item for item in state.buildings if item.building_id == building_id)
+
+
+@pytest.mark.asyncio
+async def test_first_sync_is_prospective_and_never_backfills_old_evidence(tmp_path):
+    service, world_store, voice, achievements, casino = await _service(tmp_path)
+    old = "2026-08-09T10:00:00+00:00"
+    voice.snapshot = {"recent_voice_buckets": {old: 60}}
+    achievements.snapshot = {"users": {"42": {next(iter(ACHIEVEMENT_BY_ID)): old}}}
+    casino.snapshot = {
+        "recent_buckets": {
+            old: {
+                "roulette_wagered_xp": 100,
+                "roulette_payout_xp": 100,
+                "machine_payout_xp": 0,
+                "transactions": 2,
+            }
+        },
+        "jackpots": [
+            {
+                "event_id": "old",
+                "user_id": 42,
+                "tier": 1000,
+                "occurred_at": old,
+            }
+        ],
+    }
+
+    activated_at = datetime(2026, 8, 9, 16, 50, tzinfo=timezone.utc)
+    first = await service.sync(at=activated_at)
+    second = await service.sync(
+        at=datetime(2026, 8, 9, 16, 51, tzinfo=timezone.utc)
+    )
+
+    assert first.discoveries == ()
+    assert second.discoveries == ()
+    state = await world_store.get_state()
+    assert state.events == ()
+    assert state.state[REFUGE_SECRETS_STATE_KEY]["enabled_at"] == activated_at.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_fire_discovers_only_from_real_post_activation_dayparts(tmp_path):
+    service, world_store, voice, _achievements, _casino = await _service(tmp_path)
+    await service.sync(at=datetime(2026, 8, 8, 0, 0, tzinfo=timezone.utc))
+
+    # Europe/Paris in August is UTC+2: 07:00, 12:00, 20:00 and 23:00 local.
+    voice.snapshot = {
+        "recent_voice_buckets": {
+            "2026-08-09T05:00:00+00:00": 60,
+            "2026-08-09T10:00:00+00:00": 60,
+            "2026-08-09T18:00:00+00:00": 60,
+            "2026-08-09T21:00:00+00:00": 60,
+        }
+    }
+    result = await service.sync(
+        at=datetime(2026, 8, 9, 21, 1, tzinfo=timezone.utc)
+    )
+
+    assert {item.marker_id for item in result.discoveries} >= {
+        "first_visitor",
+        "night_of_stars",
+        "full_circle",
+    }
+    state = await world_store.get_state()
+    assert {
+        "fire:secret:first_visitor",
+        "fire:secret:night_of_stars",
+        "fire:secret:full_circle",
+    }.issubset(_event_ids(state))
+    assert set(_building(state, "fire").state["secret_events"]) == {
+        "first_visitor",
+        "night_of_stars",
+        "full_circle",
+    }
+
+    again = await service.sync(
+        at=datetime(2026, 8, 9, 21, 2, tzinfo=timezone.utc)
+    )
+    assert again.discoveries == ()
+
+
+@pytest.mark.asyncio
+async def test_hall_secrets_use_post_activation_achievement_history(tmp_path):
+    service, world_store, _voice, achievements, _casino = await _service(tmp_path)
+    await service.sync(at=datetime(2026, 8, 8, 0, 0, tzinfo=timezone.utc))
+
+    by_category = {}
+    for achievement_id, definition in ACHIEVEMENT_BY_ID.items():
+        by_category.setdefault(definition.category, achievement_id)
+    assert by_category
+
+    users = {"42": {}, "99": {}}
+    for index, achievement_id in enumerate(by_category.values()):
+        user = "42" if index % 2 == 0 else "99"
+        users[user][achievement_id] = f"2026-08-09T{10 + index:02d}:00:00+00:00"
+    if not users["99"]:
+        # Keep the rarity rule meaningful even if the catalogue ever collapses
+        # to one category.
+        extra_id = next(iter(ACHIEVEMENT_BY_ID))
+        users["99"][extra_id] = "2026-08-09T20:00:00+00:00"
+    achievements.snapshot = {"users": users}
+
+    result = await service.sync(
+        at=datetime(2026, 8, 10, 0, 0, tzinfo=timezone.utc)
+    )
+
+    assert {item.marker_id for item in result.discoveries} >= {
+        "memory_flame",
+        "endless_book",
+        "forgotten_crown",
+    }
+    state = await world_store.get_state()
+    assert {
+        "hall:secret:memory_flame",
+        "hall:secret:endless_book",
+        "hall:secret:forgotten_crown",
+    }.issubset(_event_ids(state))
+
+
+@pytest.mark.asyncio
+async def test_casino_regular_and_secret_markers_are_separate_and_idempotent(tmp_path):
+    service, world_store, _voice, _achievements, casino = await _service(tmp_path)
+    await service.sync(at=datetime(2026, 8, 8, 0, 0, tzinfo=timezone.utc))
+
+    # 23:00 local: observed night activity, players ahead of the house, and
+    # both prospective jackpot tiers. Exact conditions remain internal to the
+    # engine; Discord only sees discoveries once persisted.
+    casino.snapshot = {
+        "recent_buckets": {
+            "2026-08-09T21:00:00+00:00": {
+                "roulette_wagered_xp": 100,
+                "roulette_payout_xp": 150,
+                "machine_payout_xp": 500,
+                "transactions": 4,
+            }
+        },
+        "jackpots": [
+            {
+                "event_id": "j500",
+                "user_id": 42,
+                "tier": 500,
+                "occurred_at": "2026-08-09T21:00:00+00:00",
+            },
+            {
+                "event_id": "j1000",
+                "user_id": 99,
+                "tier": 1000,
+                "occurred_at": "2026-08-09T21:01:00+00:00",
+            },
+        ],
+    }
+    first = await service.sync(
+        at=datetime(2026, 8, 9, 21, 5, tzinfo=timezone.utc)
+    )
+
+    state = await world_store.get_state()
+    casino_building = _building(state, "casino")
+    assert {"grand_heist", "black_night", "break_in"}.issubset(
+        set(casino_building.state["casino_events"])
+    )
+    assert {"diamond", "ghost_player"}.issubset(
+        set(casino_building.state["secret_events"])
+    )
+    assert any(item.marker_id == "diamond" for item in first.discoveries)
+
+    again = await service.sync(
+        at=datetime(2026, 8, 9, 21, 6, tzinfo=timezone.utc)
+    )
+    assert again.discoveries == ()
+
+
+@pytest.mark.asyncio
+async def test_casino_break_even_and_house_positive_patterns_unlock_once(tmp_path):
+    service, world_store, _voice, _achievements, casino = await _service(tmp_path)
+    await service.sync(at=datetime(2026, 8, 8, 0, 0, tzinfo=timezone.utc))
+
+    casino.snapshot = {
+        "recent_buckets": {
+            "2026-08-09T10:00:00+00:00": {
+                "roulette_wagered_xp": 200,
+                "roulette_payout_xp": 200,
+                "machine_payout_xp": 0,
+                "transactions": 4,
+            }
+        },
+        "jackpots": [],
+    }
+    await service.sync(at=datetime(2026, 8, 9, 10, 5, tzinfo=timezone.utc))
+    state = await world_store.get_state()
+    assert "black_cat" in _building(state, "casino").state["secret_events"]
+
+    casino.snapshot = {
+        "recent_buckets": {
+            "2026-08-10T10:00:00+00:00": {
+                "roulette_wagered_xp": 300,
+                "roulette_payout_xp": 100,
+                "machine_payout_xp": 0,
+                "transactions": 4,
+            }
+        },
+        "jackpots": [],
+    }
+    await service.sync(at=datetime(2026, 8, 10, 10, 5, tzinfo=timezone.utc))
+    state = await world_store.get_state()
+    assert "house_always_wins" in _building(state, "casino").state["casino_events"]


### PR DESCRIPTION
## Objectif
Implémenter uniquement **REFUGE-012 — Événements secrets** : détecter automatiquement les secrets déjà prévus par Feu / Hall / Casino, ainsi que les 4 événements réguliers Casino réservés en REFUGE-007, sans modifier les probabilités, récompenses, XP ou progression.

## Principe
REFUGE-012 introduit un moteur central `RefugeSecretsService` qui observe uniquement des données déjà persistées et réelles :
- activité vocale communautaire qualifiante et horodatée ;
- succès réellement débloqués et horodatés ;
- flux Casino prospectifs déjà observés par REFUGE-007 ;
- jackpots 500 / 1000 déjà persistés.

Aucun clic, aucune commande et aucune action répétitive n’est ajoutée pour provoquer une découverte.

## Activation prospective
Au premier démarrage, REFUGE-012 écrit seulement un marqueur `refuge_secrets.enabled_at` dans `refuge_world.json`.

Les données antérieures à cette activation ne débloquent **aucun** secret rétroactivement.

Cela évite qu’un déploiement fasse apparaître instantanément des mystères à partir d’anciens succès ou jackpots.

## Secrets existants activés
### Feu
Les trois IDs déjà définis restent inchangés :
- `night_of_stars` ;
- `first_visitor` ;
- `full_circle`.

### Hall
Les trois IDs déjà définis restent inchangés :
- `memory_flame` ;
- `endless_book` ;
- `forgotten_crown`.

### Casino
Les trois secrets déjà définis restent inchangés :
- `black_cat` ;
- `diamond` ;
- `ghost_player`.

Les quatre événements réguliers déjà prévus sont également automatisés :
- `grand_heist` ;
- `black_night` ;
- `break_in` ;
- `house_always_wins`.

Les conditions exactes restent internes au moteur : aucune vue Discord, événement historique ou payload public ne stocke le détail de la condition de déclenchement.

## Pas de seuils arbitraires
Les déclencheurs reposent sur des faits / combinaisons réellement observés et sur les périodes temporelles déjà existantes du Refuge.

REFUGE-012 n’ajoute aucun gros seuil de volume de voix, XP, messages ou mises à calibrer.

## Persistance / idempotence
Le moteur réutilise exactement les clés et IDs prévus par les services existants :
- Feu / Hall : `secret_events` ;
- Casino : `secret_events` et `casino_events` ;
- mêmes IDs historiques que `unlock_secret()` / `unlock_event()`.

Une découverte déjà persistée n’est donc jamais dupliquée.

L’événement historique contient uniquement l’identité de la découverte et son nom, jamais sa condition secrète.

Aucun nouveau fichier JSON et aucune migration de schéma.

## Visuels
Aucun renderer n’est modifié.

Les tests renderer existants couvrent déjà une trace visuelle distincte pour :
- les 3 secrets Feu ;
- les 3 secrets Hall ;
- les 4 événements Casino ;
- les 3 secrets Casino.

REFUGE-012 active simplement ces marqueurs au moment où leurs conditions réelles deviennent vraies.

## Explorer / Chronologie
Les secrets persistés utilisent toujours les événements `*_secret_discovered` existants :
- `Explorer → Mystères` continue donc à afficher uniquement les découvertes réellement révélées ;
- les secrets non découverts et leurs conditions restent invisibles ;
- REFUGE-011 archive naturellement ces événements dans le chapitre mensuel concerné.

## Orchestration
Le panneau exécute désormais :
`Chronologie → Feu → Hall → Casino → Événements cachés`
sous le verrou partagé du monde.

Une découverte peut donc changer immédiatement la signature graphique et la dernière trace du panneau.

Un nouveau cog `refuge_secrets.py` vérifie également les conditions chaque minute. Le chargeur automatique existant découvrira ce cog via `pkgutil`, sans changement de `bot.py`.

## Récompenses
Découvrir un événement secret ou régulier du Refuge :
- n’accorde aucun XP ;
- n’accorde aucun ticket ;
- ne modifie aucune probabilité Casino ;
- ne modifie aucun seuil de progression ;
- ne donne aucun avantage individuel.

La récompense est uniquement historique et visuelle.

## Fichiers
- `services/refuge_secrets.py` — nouveau moteur automatique ;
- `cogs/refuge_secrets.py` — détection périodique ;
- `services/refuge_panel.py` — intégration après Casino ;
- `tests/test_refuge_secrets.py` — activation prospective, Feu, Hall, Casino, idempotence et confidentialité ;
- `tests/test_refuge_panel_service.py` — orchestration avec secrets.

## Validation disponible
Branche basée sur `main` au commit `727b8b3106c005579db2a4098a38ba2b49a58565`.

Le diff ne touche que 5 fichiers et `main` n’a pas avancé au dernier contrôle.

La suite pytest réelle n’est pas déclarée comme passée : aucun checkout local fiable n’est disponible dans le runtime ChatGPT. Les workflows GitHub du head seront contrôlés avant fusion.

## Hors périmètre
- aucun hardening final REFUGE-013 ;
- aucune nouvelle zone ou bâtiment ;
- aucune modification économique ;
- aucune nouvelle commande ;
- aucune divulgation des conditions secrètes côté Discord.

La PR reste en **draft** jusqu’à validation explicite de l’utilisateur.