### PR TITLE
fix: harden Refuge V1 persistence and panel ownership

### DIFF
--- a/cogs/refuge_panel.py
+++ b/cogs/refuge_panel.py
@@ -11,6 +11,7 @@ from discord.ext import commands, tasks
 
 from models.refuge_world import RefugePanelState
 from services.refuge_panel import RefugePanelService, refuge_panel_service
+from services.refuge_world_coordination import refuge_world_mutation_lock
 from storage.refuge_world_store import RefugeWorldStore, refuge_world_store
 from ui.refuge_panel_view import (
     REFUGE_MAP_FILENAME,
@@ -133,8 +134,13 @@ class RefugePanelCog(commands.Cog):
         self,
         *,
         target_channel_id: int,
-    ) -> None:
-        """Best-effort removal of the previously owned panel after channel moves."""
+    ) -> bool:
+        """Retire the previous panel before allowing a panel in a new channel.
+
+        ``True`` means the old panel is definitively gone (or never existed).
+        A transient Discord failure returns ``False`` so the caller preserves
+        the stored reference and retries later instead of creating a duplicate.
+        """
 
         state = await self.world_store.get_state()
         panel = state.panel
@@ -142,7 +148,7 @@ class RefugePanelCog(commands.Cog):
             panel,
             target_channel_id=target_channel_id,
         ):
-            return
+            return True
 
         assert panel.channel_id is not None
         assert panel.message_id is not None
@@ -150,55 +156,76 @@ class RefugePanelCog(commands.Cog):
         if old_channel is None:
             try:
                 old_channel = await self.bot.fetch_channel(panel.channel_id)
+            except discord.NotFound:
+                # The whole old channel is gone, so its panel is definitively gone.
+                return True
             except discord.HTTPException:
                 logger.warning(
-                    "[refuge] Ancien salon du panneau inaccessible: %s",
+                    "[refuge] Ancien salon du panneau temporairement inaccessible: %s",
                     panel.channel_id,
                 )
-                return
+                return False
         if not isinstance(old_channel, (discord.TextChannel, discord.Thread)):
-            return
+            logger.warning(
+                "[refuge] Ancienne référence panneau non résolue vers un salon texte: %s",
+                panel.channel_id,
+            )
+            return False
         try:
             old_message = await old_channel.fetch_message(panel.message_id)
             await old_message.delete()
         except discord.NotFound:
-            return
+            return True
         except discord.HTTPException:
             logger.warning(
-                "[refuge] Impossible de retirer l'ancien panneau %s/%s",
+                "[refuge] Impossible de retirer temporairement l'ancien panneau %s/%s",
                 panel.channel_id,
                 panel.message_id,
             )
+            return False
+        return True
 
     async def _fetch_stored_message(
         self,
         channel: discord.TextChannel | discord.Thread,
-    ) -> discord.Message | None:
+    ) -> tuple[discord.Message | None, bool]:
+        """Return ``(message, definitive)`` for the current stored panel.
+
+        ``definitive=False`` means Discord could not confirm whether the
+        message exists. The caller must not create a replacement in that case.
+        """
+
         state = await self.world_store.get_state()
         panel = state.panel
         if panel.channel_id != channel.id or panel.message_id is None:
-            return None
+            return None, True
         try:
-            return await channel.fetch_message(panel.message_id)
+            return await channel.fetch_message(panel.message_id), True
         except discord.NotFound:
-            return None
+            return None, True
         except discord.HTTPException:
             logger.warning(
-                "[refuge] Impossible de récupérer le panneau %s/%s",
+                "[refuge] État du panneau %s/%s temporairement inconnu; "
+                "aucun duplicata ne sera créé",
                 channel.id,
                 panel.message_id,
             )
-            return None
+            return None, False
 
     async def _persist_panel_reference(self, message: discord.Message) -> None:
-        state = await self.world_store.get_state()
         desired = RefugePanelState(
             channel_id=message.channel.id,
             message_id=message.id,
         )
-        if state.panel == desired:
-            return
-        await self.world_store.save_state(replace(state, panel=desired))
+        # Panel ownership is part of RefugeWorldState. The full read-modify-
+        # write must share the same mutation lock as Timeline, Construction and
+        # Secrets, otherwise a concurrent world mutation can be overwritten by
+        # a stale panel-only save.
+        async with refuge_world_mutation_lock():
+            state = await self.world_store.get_state()
+            if state.panel == desired:
+                return
+            await self.world_store.save_state(replace(state, panel=desired))
 
     async def _render_file(self, snapshot) -> discord.File:
         png = await self.panel_service.render_png(snapshot)
@@ -215,10 +242,16 @@ class RefugePanelCog(commands.Cog):
             if channel is None:
                 return
 
-            await self._retire_previous_panel_if_moved(
+            retired = await self._retire_previous_panel_if_moved(
                 target_channel_id=channel.id,
             )
-            message = await self._fetch_stored_message(channel)
+            if not retired:
+                return
+
+            message, lookup_definitive = await self._fetch_stored_message(channel)
+            if not lookup_definitive:
+                return
+
             snapshot = await self.panel_service.evaluate()
             action = panel_refresh_action(
                 message_exists=message is not None,

--- a/services/refuge_world.py
+++ b/services/refuge_world.py
@@ -4,10 +4,25 @@ import hashlib
 import json
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
-from typing import Mapping, Sequence
+from typing import Final, Mapping, Sequence
 
 from models.refuge_world import RefugeBuildingState, RefugeHistoricalEvent, RefugeWorldState
 from storage.refuge_world_store import RefugeWorldStore, refuge_world_store
+
+
+# These keys persist orchestration/history metadata only. They do not affect
+# any current V1 renderer. Unknown state keys remain render-relevant by
+# default so future visual features cannot accidentally become invisible to
+# panel refreshes.
+_NON_VISUAL_WORLD_STATE_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "refuge_timeline",
+        "refuge_secrets",
+        "construction_enabled_at",
+        "construction_pending_goals",
+        "construction_consumed_goal_ids",
+    }
+)
 
 
 def _utc_iso(at: datetime | None = None) -> str:
@@ -66,6 +81,14 @@ def level_for_metric(
     return level
 
 
+def _render_relevant_world_state(state: RefugeWorldState) -> dict[str, object]:
+    return {
+        str(key): value
+        for key, value in state.state.items()
+        if str(key) not in _NON_VISUAL_WORLD_STATE_KEYS
+    }
+
+
 def world_render_signature(state: RefugeWorldState) -> str:
     """Hash only fields that can affect the rendered current world."""
 
@@ -86,7 +109,7 @@ def world_render_signature(state: RefugeWorldState) -> str:
             if state.active_construction is not None
             else None
         ),
-        "state": state.state,
+        "state": _render_relevant_world_state(state),
     }
     canonical = json.dumps(
         payload,

--- a/storage/refuge_world_store.py
+++ b/storage/refuge_world_store.py
@@ -20,12 +20,12 @@ REFUGE_WORLD_FILE = Path(DATA_DIR) / "refuge_world.json"
 
 
 class RefugeWorldSchemaError(ValueError):
-    """Raised when persisted Refuge data uses an unsupported schema."""
+    """Raised when persisted Refuge data is unsupported or unsafe to load."""
 
 
 def _migrate_payload(raw: Any) -> tuple[dict[str, Any], bool]:
     if not isinstance(raw, Mapping):
-        return RefugeWorldState().to_dict(), False
+        raise RefugeWorldSchemaError("refuge world root must be a JSON object")
 
     payload = {str(key): value for key, value in raw.items()}
     try:
@@ -95,8 +95,20 @@ class RefugeWorldStore:
         if self._loaded:
             return
 
+        # A missing primary + missing backup means a genuinely new Refuge.
+        # Any existing persistence artifact that cannot be decoded must never
+        # be mistaken for an empty world: the Refuge is permanent and a
+        # silent reset would be irreversible once a new save rotates backups.
+        backup_path = self.path.with_suffix(self.path.suffix + ".bak")
+        primary_exists = self.path.exists()
+        backup_exists = backup_path.exists()
         raw = await asyncio.to_thread(read_json_safe, self.path, None)
         if raw is None:
+            if primary_exists or backup_exists:
+                raise RefugeWorldSchemaError(
+                    "refuge world persistence is unreadable; refusing to reset "
+                    "the permanent world"
+                )
             self._state = RefugeWorldState()
             self._loaded = True
             return

--- a/storage/refuge_world_store.py
+++ b/storage/refuge_world_store.py
@@ -28,6 +28,8 @@ def _migrate_payload(raw: Any) -> tuple[dict[str, Any], bool]:
         raise RefugeWorldSchemaError("refuge world root must be a JSON object")
 
     payload = {str(key): value for key, value in raw.items()}
+    if not payload:
+        raise RefugeWorldSchemaError("refuge world persistence is an empty JSON object")
     try:
         version = int(payload.get("schema_version", 0))
     except (TypeError, ValueError):

--- a/tests/test_refuge_panel_cog.py
+++ b/tests/test_refuge_panel_cog.py
@@ -1,9 +1,18 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import discord
+import pytest
+
 from cogs.refuge_panel import (
     DEFAULT_REFUGE_PANEL_CHANNEL_ID,
+    RefugePanelCog,
     panel_reference_needs_retirement,
     panel_refresh_action,
 )
-from models.refuge_world import RefugePanelState
+from models.refuge_world import RefugeHistoricalEvent, RefugePanelState, RefugeWorldState
+from services.refuge_world_coordination import refuge_world_mutation_lock
 
 
 def test_default_public_panel_channel_is_refuge_channel():
@@ -68,3 +77,134 @@ def test_panel_reference_is_retired_only_when_configured_channel_moves():
         RefugePanelState(channel_id=123, message_id=None),
         target_channel_id=789,
     ) is False
+
+
+class _LockCheckingWorldStore:
+    def __init__(self, state: RefugeWorldState) -> None:
+        self.state = state
+        self.get_calls = 0
+        self.save_calls = 0
+
+    async def get_state(self) -> RefugeWorldState:
+        assert refuge_world_mutation_lock().locked()
+        self.get_calls += 1
+        return self.state
+
+    async def save_state(self, state: RefugeWorldState) -> RefugeWorldState:
+        assert refuge_world_mutation_lock().locked()
+        self.save_calls += 1
+        self.state = state
+        return state
+
+
+@pytest.mark.asyncio
+async def test_panel_reference_read_modify_write_uses_world_mutation_lock():
+    history = RefugeHistoricalEvent(
+        event_id="secret",
+        event_type="fire_secret_discovered",
+        occurred_at="2026-08-09T17:00:00+00:00",
+        data={"name": "Mystère"},
+    )
+    store = _LockCheckingWorldStore(RefugeWorldState(events=(history,)))
+    cog = RefugePanelCog(SimpleNamespace(), world_store=store)  # type: ignore[arg-type]
+    message = SimpleNamespace(
+        id=456,
+        channel=SimpleNamespace(id=123),
+    )
+
+    await cog._persist_panel_reference(message)  # type: ignore[arg-type]
+
+    assert store.get_calls == 1
+    assert store.save_calls == 1
+    assert store.state.panel == RefugePanelState(channel_id=123, message_id=456)
+    assert store.state.events == (history,)
+
+
+class _NeverEvaluatePanelService:
+    async def evaluate(self):
+        raise AssertionError("panel evaluation must not run on uncertain lookup")
+
+
+@pytest.mark.asyncio
+async def test_uncertain_message_lookup_never_creates_replacement_panel():
+    cog = RefugePanelCog(
+        SimpleNamespace(),  # type: ignore[arg-type]
+        panel_service=_NeverEvaluatePanelService(),  # type: ignore[arg-type]
+    )
+    channel = SimpleNamespace(id=123)
+
+    async def resolve_channel():
+        return channel
+
+    async def retire_previous_panel_if_moved(*, target_channel_id: int):
+        assert target_channel_id == 123
+        return True
+
+    async def fetch_stored_message(_channel):
+        return None, False
+
+    cog._resolve_channel = resolve_channel  # type: ignore[method-assign]
+    cog._retire_previous_panel_if_moved = retire_previous_panel_if_moved  # type: ignore[method-assign]
+    cog._fetch_stored_message = fetch_stored_message  # type: ignore[method-assign]
+
+    await cog.ensure_panel()
+
+
+def _http_exception(exc_type, *, status: int):
+    error = object.__new__(exc_type)
+    Exception.__init__(error, "temporary Discord failure")
+    error.status = status
+    error.reason = "temporary"
+    error.code = 0
+    error.text = "temporary"
+    return error
+
+
+class _PanelStateStore:
+    def __init__(self, panel: RefugePanelState) -> None:
+        self.state = RefugeWorldState(panel=panel)
+
+    async def get_state(self) -> RefugeWorldState:
+        return self.state
+
+
+@pytest.mark.asyncio
+async def test_transient_discord_fetch_is_not_treated_as_missing_message():
+    store = _PanelStateStore(RefugePanelState(channel_id=123, message_id=456))
+    cog = RefugePanelCog(
+        SimpleNamespace(),  # type: ignore[arg-type]
+        world_store=store,  # type: ignore[arg-type]
+    )
+
+    class Channel:
+        id = 123
+
+        async def fetch_message(self, message_id: int):
+            assert message_id == 456
+            raise _http_exception(discord.HTTPException, status=503)
+
+    message, definitive = await cog._fetch_stored_message(Channel())  # type: ignore[arg-type]
+
+    assert message is None
+    assert definitive is False
+
+
+@pytest.mark.asyncio
+async def test_confirmed_not_found_allows_safe_panel_recreation():
+    store = _PanelStateStore(RefugePanelState(channel_id=123, message_id=456))
+    cog = RefugePanelCog(
+        SimpleNamespace(),  # type: ignore[arg-type]
+        world_store=store,  # type: ignore[arg-type]
+    )
+
+    class Channel:
+        id = 123
+
+        async def fetch_message(self, message_id: int):
+            assert message_id == 456
+            raise _http_exception(discord.NotFound, status=404)
+
+    message, definitive = await cog._fetch_stored_message(Channel())  # type: ignore[arg-type]
+
+    assert message is None
+    assert definitive is True

--- a/tests/test_refuge_panel_cog.py
+++ b/tests/test_refuge_panel_cog.py
@@ -151,13 +151,8 @@ async def test_uncertain_message_lookup_never_creates_replacement_panel():
 
 
 def _http_exception(exc_type, *, status: int):
-    error = object.__new__(exc_type)
-    Exception.__init__(error, "temporary Discord failure")
-    error.status = status
-    error.reason = "temporary"
-    error.code = 0
-    error.text = "temporary"
-    return error
+    response = SimpleNamespace(status=status, reason="temporary")
+    return exc_type(response, "temporary Discord failure")
 
 
 class _PanelStateStore:

--- a/tests/test_refuge_world_service.py
+++ b/tests/test_refuge_world_service.py
@@ -185,7 +185,7 @@ async def test_service_keeps_unrelated_buildings_and_world_state(tmp_path):
     assert result.state.state == {"season_visual": "summer"}
 
 
-def test_render_signature_ignores_history_and_panel_but_tracks_visual_state():
+def test_render_signature_ignores_history_panel_and_orchestration_metadata():
     started = "2026-08-09T04:45:00+00:00"
     fire = RefugeBuildingState(
         building_id="fire",
@@ -213,11 +213,30 @@ def test_render_signature_ignores_history_and_panel_but_tracks_visual_state():
                 data={},
             ),
         ),
+        state={
+            "season_visual": "summer",
+            "refuge_timeline": {
+                "active_season_id": "2026-08",
+                "last_archived_season_id": None,
+            },
+            "refuge_secrets": {"enabled_at": started},
+            "construction_enabled_at": started,
+            "construction_pending_goals": [{"id": "goal-2"}],
+            "construction_consumed_goal_ids": ["goal-1"],
+        },
     )
     assert world_render_signature(metadata_only) == signature
 
     visual_change = replace(state, state={"season_visual": "autumn"})
     assert world_render_signature(visual_change) != signature
+
+    secret_visual_change = replace(
+        state,
+        buildings=(
+            replace(fire, state={"intensity": "normal", "secret_events": ["full_circle"]}),
+        ),
+    )
+    assert world_render_signature(secret_visual_change) != signature
 
 
 @pytest.mark.asyncio

--- a/tests/test_refuge_world_store.py
+++ b/tests/test_refuge_world_store.py
@@ -129,6 +129,17 @@ async def test_non_object_world_payload_is_rejected_without_overwrite(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_empty_object_world_payload_is_rejected_without_overwrite(tmp_path):
+    path = tmp_path / "refuge_world.json"
+    path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(RefugeWorldSchemaError, match="empty JSON object"):
+        await RefugeWorldStore(path).get_state()
+
+    assert path.read_text(encoding="utf-8") == "{}"
+
+
+@pytest.mark.asyncio
 async def test_unversioned_payload_migrates_to_schema_v1(tmp_path):
     path = tmp_path / "refuge_world.json"
     path.write_text(

--- a/tests/test_refuge_world_store.py
+++ b/tests/test_refuge_world_store.py
@@ -106,13 +106,26 @@ async def test_corrupt_primary_recovers_from_atomic_backup(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_corrupt_primary_without_backup_falls_back_to_empty_world(tmp_path):
+async def test_corrupt_primary_without_backup_is_rejected_without_overwrite(tmp_path):
     path = tmp_path / "refuge_world.json"
     path.write_text("{broken", encoding="utf-8")
 
-    recovered = await RefugeWorldStore(path).get_state()
+    with pytest.raises(RefugeWorldSchemaError, match="refusing to reset"):
+        await RefugeWorldStore(path).get_state()
 
-    assert recovered == RefugeWorldState()
+    assert path.read_text(encoding="utf-8") == "{broken"
+    assert not path.with_suffix(".json.bak").exists()
+
+
+@pytest.mark.asyncio
+async def test_non_object_world_payload_is_rejected_without_overwrite(tmp_path):
+    path = tmp_path / "refuge_world.json"
+    path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(RefugeWorldSchemaError, match="JSON object"):
+        await RefugeWorldStore(path).get_state()
+
+    assert path.read_text(encoding="utf-8") == "[]"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Objectif
Clôturer **REFUGE-013 — Hardening / clôture V1** par un audit de robustesse du Refuge Vivant et corriger uniquement les incohérences démontrables, sans ajouter de nouvelle fonctionnalité.

Branche basée sur `main` au commit `0fc24711266721bd79b1330428c2e6767a43d057`.

## 1. Le monde permanent ne peut plus repartir silencieusement de zéro
`refuge_world.json` représente un monde qui ne doit jamais se réinitialiser.

Avant ce hardening, si le fichier principal était illisible et qu’aucun backup exploitable n’existait, `read_json_safe(..., None)` pouvait conduire `RefugeWorldStore` à interpréter la situation comme un monde neuf.

REFUGE-013 distingue désormais strictement :
- aucun fichier principal et aucun `.bak` : création légitime d’un nouveau monde ;
- primaire corrompu + backup valide : récupération depuis le backup, comportement conservé ;
- artefact existant mais primaire/backup illisibles : `RefugeWorldSchemaError`, aucune sauvegarde de remplacement ;
- racine JSON non objet : rejet explicite ;
- objet JSON vide `{}` existant : rejet explicite plutôt qu’un reset implicite ;
- schéma futur : rejet sans overwrite, comportement conservé.

Le choix est volontairement fail-closed : une panne du Refuge est préférable à l’effacement silencieux de son histoire permanente.

## 2. Référence du panneau protégée contre les lost updates
La référence `channel_id/message_id` du panneau fait partie de `RefugeWorldState`.

Avant REFUGE-013, `_persist_panel_reference()` faisait un `get_state()` puis un `save_state(replace(...))` sans le verrou de mutation global. Une découverte secrète, un rollover ou une transition de Chantier entre ces deux opérations pouvait être écrasé par la sauvegarde d’un état devenu obsolète.

Le read-modify-write du panneau s’effectue désormais sous `refuge_world_mutation_lock()`, le même verrou partagé par les orchestrateurs du monde.

## 3. Unicité du panneau sous erreur Discord transitoire
Avant REFUGE-013, un `discord.HTTPException` lors de la récupération du panneau enregistré était traité comme une absence de message. Le bot pouvait donc créer un deuxième panneau alors que Discord n’avait simplement pas pu confirmer l’état du premier.

Désormais :
- `discord.NotFound` = absence certaine, recréation autorisée ;
- `discord.HTTPException` = état inconnu, aucune création de remplacement ;
- lors d’un changement de salon, un nouvel emplacement n’est utilisé que lorsque l’ancien panneau est définitivement supprimé/inexistant ;
- une panne transitoire conserve la référence existante et reporte l’opération au prochain rafraîchissement.

## 4. Signature graphique limitée aux données réellement visuelles
`world_render_signature()` incluait tout `RefugeWorldState.state`, alors que ce dictionnaire contient désormais des métadonnées d’orchestration qui ne changent aucun pixel :
- `refuge_timeline` ;
- `refuge_secrets` ;
- activation Construction ;
- file des objectifs Construction ;
- IDs d’objectifs consommés.

Ces clés connues comme non visuelles sont maintenant exclues du hash afin d’éviter des régénérations PNG inutiles.

Les clés inconnues restent volontairement incluses par défaut : une future donnée visuelle ne pourra donc pas être oubliée silencieusement par la signature. Les états des bâtiments, secrets visuels et chantier actif restent bien suivis.

## 5. Audit des autres invariants V1
L’audit a également revérifié :
- Chronologie avant mutations mensuelles ;
- boucles Timeline / Construction / Secrets sous coordination partagée ;
- activation prospective des secrets ;
- objectifs automatiques avec création atomique `require_no_active=True` ;
- callbacks privés qui répondent/diffèrent avant les opérations coûteuses ;
- persistance atomique avec backup ;
- rendu déterministe ;
- absence de récompense ou de farm dans le Refuge.

La protection Chronologie du Chantier reste assurée par tous les points d’entrée de production actuels (cog de fond et interfaces privées). REFUGE-013 n’introduit pas de refactor circulaire `Construction ↔ Timeline ↔ renderer` uniquement pour dupliquer cette garantie.

## Fichiers modifiés
1. `cogs/refuge_panel.py`
2. `services/refuge_world.py`
3. `storage/refuge_world_store.py`
4. `tests/test_refuge_panel_cog.py`
5. `tests/test_refuge_world_service.py`
6. `tests/test_refuge_world_store.py`

Aucun fichier gameplay, économie, probabilités Casino, progression, renderer, Chantier, Chronologie ou Secrets n’est modifié.

## Tests ajoutés / adaptés
Couverture ciblée pour :
- corruption sans backup refusée sans overwrite ;
- récupération depuis backup toujours fonctionnelle ;
- JSON non objet refusé ;
- `{}` persistant refusé ;
- schéma futur toujours protégé ;
- read-modify-write du panneau sous verrou global ;
- événement historique concurrent préservé lors de la sauvegarde du panneau ;
- erreur Discord transitoire non assimilée à `NotFound` ;
- `NotFound` autorise bien la recréation ;
- lookup incertain n’évalue/crée pas de nouveau panneau ;
- métadonnées Timeline / Secrets / Construction n’altèrent plus le hash graphique ;
- une vraie modification visuelle continue de changer la signature.

Le contrat `discord.HTTPException(response, message)` et l’héritage direct de `NotFound` ont été vérifiés contre la source officielle discord.py ; les tests utilisent ce constructeur réel avec une réponse simulée.

## Validation disponible
Le checkout local a de nouveau été tenté mais le runtime ChatGPT ne résout pas `github.com` (`Could not resolve host: github.com`). La suite pytest réelle n’est donc **pas déclarée comme passée**.

Les workflows GitHub associés au head seront vérifiés avant toute fusion.

## Hors périmètre
- aucune nouvelle fonctionnalité V2 ;
- aucun nouveau bâtiment ou district ;
- aucun nouveau secret ;
- aucune modification des seuils ;
- aucune modification XP / économie / probabilités ;
- aucune modification des objectifs automatiques ou des règles de Chantier.

Cette PR reste en **draft** jusqu’à validation explicite de l’utilisateur.