### PR TITLE
feat: add temp voice channel controls

### DIFF
--- a/cogs/temp_vc_controls.py
+++ b/cogs/temp_vc_controls.py
@@ -7,8 +7,7 @@ import discord
 from discord import app_commands
 from discord.ext import commands
 
-from config import LOBBY_VC_ID
-from cogs.temp_vc import TEMP_VC_IDS
+from config import LOBBY_VC_ID, TEMP_VC_CATEGORY
 from storage.temp_vc_control_store import (
     load_temp_vc_owners,
     save_temp_vc_owners_async,
@@ -332,6 +331,14 @@ class TempVCControlsCog(commands.Cog):
             return False
         return any(member.id == owner_id for member in channel.members)
 
+    def _is_standard_temp_channel(self, channel: discord.VoiceChannel) -> bool:
+        """Return whether the channel belongs to the existing standard temp category."""
+        category_id = getattr(channel, "category_id", None)
+        if category_id is None:
+            category = getattr(channel, "category", None)
+            category_id = getattr(category, "id", None)
+        return category_id == TEMP_VC_CATEGORY
+
     async def require_control_channel(
         self,
         interaction: discord.Interaction,
@@ -350,7 +357,7 @@ class TempVCControlsCog(commands.Cog):
         channel = voice.channel if voice else None
         if (
             not isinstance(channel, discord.VoiceChannel)
-            or channel.id not in TEMP_VC_IDS
+            or not self._is_standard_temp_channel(channel)
             or channel.id not in self._owners
         ):
             await interaction.response.send_message(
@@ -393,7 +400,7 @@ class TempVCControlsCog(commands.Cog):
             channel = self.bot.get_channel(channel_id)
             if (
                 not isinstance(channel, discord.VoiceChannel)
-                or channel_id not in TEMP_VC_IDS
+                or not self._is_standard_temp_channel(channel)
             ):
                 self._owners.pop(channel_id, None)
                 self._panel_posted.discard(channel_id)
@@ -411,7 +418,7 @@ class TempVCControlsCog(commands.Cog):
         channel = after.channel
         if not isinstance(channel, discord.VoiceChannel):
             return
-        if channel.id not in TEMP_VC_IDS:
+        if not self._is_standard_temp_channel(channel):
             return
 
         before_channel = before.channel

--- a/cogs/temp_vc_controls.py
+++ b/cogs/temp_vc_controls.py
@@ -339,6 +339,37 @@ class TempVCControlsCog(commands.Cog):
             category_id = getattr(category, "id", None)
         return category_id == TEMP_VC_CATEGORY
 
+    async def _ensure_owner_access(
+        self,
+        channel: discord.VoiceChannel,
+        owner: discord.Member,
+    ) -> None:
+        """Keep the owner able to see and rejoin a locked/hidden channel."""
+        overwrite = channel.overwrites_for(owner)
+        overwrite.view_channel = True
+        overwrite.connect = True
+        overwrite.speak = True
+        await channel.set_permissions(
+            owner,
+            overwrite=overwrite,
+            reason="Protection accès propriétaire Temp VC",
+        )
+
+    async def _ensure_current_owner_access(
+        self,
+        channel: discord.VoiceChannel,
+        guild: discord.Guild,
+    ) -> None:
+        owner_id = self._owners.get(channel.id)
+        if owner_id is None:
+            return
+        getter = getattr(guild, "get_member", None)
+        if not callable(getter):
+            return
+        owner = getter(owner_id)
+        if isinstance(owner, discord.Member):
+            await self._ensure_owner_access(channel, owner)
+
     async def require_control_channel(
         self,
         interaction: discord.Interaction,
@@ -446,6 +477,7 @@ class TempVCControlsCog(commands.Cog):
         if channel is None or interaction.guild is None:
             return
 
+        await self._ensure_current_owner_access(channel, interaction.guild)
         overwrite = channel.overwrites_for(interaction.guild.default_role)
         overwrite.connect = False if locked else None
         await channel.set_permissions(
@@ -467,6 +499,7 @@ class TempVCControlsCog(commands.Cog):
         if channel is None or interaction.guild is None:
             return
 
+        await self._ensure_current_owner_access(channel, interaction.guild)
         overwrite = channel.overwrites_for(interaction.guild.default_role)
         overwrite.view_channel = False if hidden else None
         await channel.set_permissions(
@@ -506,6 +539,7 @@ class TempVCControlsCog(commands.Cog):
             return
 
         await self._set_owner(channel.id, member.id)
+        await self._ensure_owner_access(channel, member)
         await interaction.response.send_message(
             "👑 Tu es maintenant propriétaire du salon.",
             ephemeral=True,
@@ -708,6 +742,7 @@ class TempVCControlsCog(commands.Cog):
             return
 
         await self._set_owner(channel.id, target.id)
+        await self._ensure_owner_access(channel, target)
         await interaction.response.send_message(
             f"🔁 {target.mention} est maintenant propriétaire du salon.",
             ephemeral=True,

--- a/cogs/temp_vc_controls.py
+++ b/cogs/temp_vc_controls.py
@@ -1,0 +1,739 @@
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable, Dict
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from config import LOBBY_VC_ID
+from cogs.temp_vc import TEMP_VC_IDS
+from storage.temp_vc_control_store import (
+    load_temp_vc_owners,
+    save_temp_vc_owners_async,
+)
+
+logger = logging.getLogger(__name__)
+
+MemberAction = Callable[[discord.Interaction, discord.Member], Awaitable[None]]
+
+
+def build_control_embed() -> discord.Embed:
+    """Return the generic control panel without touching dynamic channel naming."""
+    embed = discord.Embed(
+        title="🎛️ Contrôles du salon vocal",
+        description=(
+            "Ces contrôles s'appliquent au salon vocal temporaire dans lequel tu te trouves.\n"
+            "Le nom du salon reste géré automatiquement par le Refuge "
+            "(plateforme, Crossplay, activité et AFK)."
+        ),
+    )
+    embed.add_field(
+        name="Accès",
+        value="🔒 Verrouiller · 👁️ Masquer · ✅ Autoriser · 🚫 Bloquer",
+        inline=False,
+    )
+    embed.add_field(
+        name="Gestion",
+        value="👑 Claim · 🔁 Transférer · 👥 Limite · 👢 Expulser",
+        inline=False,
+    )
+    return embed
+
+
+class LimitModal(discord.ui.Modal, title="Limite du salon vocal"):
+    limit = discord.ui.TextInput(
+        label="Nombre maximum de membres",
+        placeholder="0 = aucune limite, sinon 1 à 99",
+        min_length=1,
+        max_length=2,
+        required=True,
+    )
+
+    def __init__(self, cog: "TempVCControlsCog") -> None:
+        super().__init__()
+        self.cog = cog
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await self.cog.set_user_limit(interaction, str(self.limit.value))
+
+
+class MemberPicker(discord.ui.UserSelect):
+    def __init__(
+        self,
+        *,
+        action: MemberAction,
+        placeholder: str,
+    ) -> None:
+        super().__init__(
+            placeholder=placeholder,
+            min_values=1,
+            max_values=1,
+        )
+        self.action = action
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        value = self.values[0]
+        guild = interaction.guild
+        member = value if isinstance(value, discord.Member) else None
+        if member is None and guild is not None:
+            member = guild.get_member(value.id)
+        if member is None:
+            await interaction.response.send_message(
+                "❌ Membre introuvable.",
+                ephemeral=True,
+            )
+            return
+        await self.action(interaction, member)
+
+
+class MemberPickerView(discord.ui.View):
+    def __init__(
+        self,
+        *,
+        action: MemberAction,
+        placeholder: str,
+    ) -> None:
+        super().__init__(timeout=60)
+        self.add_item(MemberPicker(action=action, placeholder=placeholder))
+
+
+class TempVoiceControlView(discord.ui.View):
+    """Persistent generic controls for the user's current managed temporary VC."""
+
+    def __init__(self, cog: "TempVCControlsCog") -> None:
+        super().__init__(timeout=None)
+        self.cog = cog
+
+    @discord.ui.button(
+        label="Verrouiller",
+        emoji="🔒",
+        style=discord.ButtonStyle.secondary,
+        custom_id="temp_vc_control_lock",
+        row=0,
+    )
+    async def lock(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self.cog.set_locked(interaction, True)
+
+    @discord.ui.button(
+        label="Déverrouiller",
+        emoji="🔓",
+        style=discord.ButtonStyle.secondary,
+        custom_id="temp_vc_control_unlock",
+        row=0,
+    )
+    async def unlock(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self.cog.set_locked(interaction, False)
+
+    @discord.ui.button(
+        label="Masquer",
+        emoji="🙈",
+        style=discord.ButtonStyle.secondary,
+        custom_id="temp_vc_control_hide",
+        row=0,
+    )
+    async def hide(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self.cog.set_hidden(interaction, True)
+
+    @discord.ui.button(
+        label="Afficher",
+        emoji="👁️",
+        style=discord.ButtonStyle.secondary,
+        custom_id="temp_vc_control_show",
+        row=0,
+    )
+    async def show(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self.cog.set_hidden(interaction, False)
+
+    @discord.ui.button(
+        label="Claim",
+        emoji="👑",
+        style=discord.ButtonStyle.primary,
+        custom_id="temp_vc_control_claim",
+        row=1,
+    )
+    async def claim(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self.cog.claim(interaction)
+
+    @discord.ui.button(
+        label="Limite",
+        emoji="👥",
+        style=discord.ButtonStyle.primary,
+        custom_id="temp_vc_control_limit",
+        row=1,
+    )
+    async def limit(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        channel = await self.cog.require_control_channel(
+            interaction, require_owner=True
+        )
+        if channel is None:
+            return
+        await interaction.response.send_modal(LimitModal(self.cog))
+
+    async def _open_picker(
+        self,
+        interaction: discord.Interaction,
+        *,
+        action: MemberAction,
+        placeholder: str,
+        require_owner: bool = True,
+    ) -> None:
+        channel = await self.cog.require_control_channel(
+            interaction, require_owner=require_owner
+        )
+        if channel is None:
+            return
+        await interaction.response.send_message(
+            "Sélectionne un membre :",
+            view=MemberPickerView(action=action, placeholder=placeholder),
+            ephemeral=True,
+        )
+
+    @discord.ui.button(
+        label="Autoriser",
+        emoji="✅",
+        style=discord.ButtonStyle.success,
+        custom_id="temp_vc_control_trust",
+        row=2,
+    )
+    async def trust(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._open_picker(
+            interaction,
+            action=self.cog.trust_member,
+            placeholder="Membre à autoriser",
+        )
+
+    @discord.ui.button(
+        label="Retirer accès",
+        emoji="⛔",
+        style=discord.ButtonStyle.secondary,
+        custom_id="temp_vc_control_untrust",
+        row=2,
+    )
+    async def untrust(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._open_picker(
+            interaction,
+            action=self.cog.untrust_member,
+            placeholder="Membre dont retirer l'accès",
+        )
+
+    @discord.ui.button(
+        label="Bloquer",
+        emoji="🚫",
+        style=discord.ButtonStyle.danger,
+        custom_id="temp_vc_control_block",
+        row=3,
+    )
+    async def block(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._open_picker(
+            interaction,
+            action=self.cog.block_member,
+            placeholder="Membre à bloquer",
+        )
+
+    @discord.ui.button(
+        label="Débloquer",
+        emoji="✔️",
+        style=discord.ButtonStyle.secondary,
+        custom_id="temp_vc_control_unblock",
+        row=3,
+    )
+    async def unblock(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._open_picker(
+            interaction,
+            action=self.cog.unblock_member,
+            placeholder="Membre à débloquer",
+        )
+
+    @discord.ui.button(
+        label="Expulser",
+        emoji="👢",
+        style=discord.ButtonStyle.danger,
+        custom_id="temp_vc_control_kick",
+        row=3,
+    )
+    async def kick(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._open_picker(
+            interaction,
+            action=self.cog.kick_member,
+            placeholder="Membre à expulser du vocal",
+        )
+
+    @discord.ui.button(
+        label="Transférer",
+        emoji="🔁",
+        style=discord.ButtonStyle.primary,
+        custom_id="temp_vc_control_transfer",
+        row=4,
+    )
+    async def transfer(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._open_picker(
+            interaction,
+            action=self.cog.transfer_owner,
+            placeholder="Nouveau propriétaire",
+        )
+
+
+class TempVCControlsCog(commands.Cog):
+    """VoiceForge-inspired ownership and access controls layered over TempVCCog."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._owners: Dict[int, int] = load_temp_vc_owners()
+        self._panel_posted: set[int] = set()
+
+    async def _persist(self) -> None:
+        await save_temp_vc_owners_async(self._owners.copy())
+
+    async def _set_owner(self, channel_id: int, owner_id: int) -> None:
+        self._owners[channel_id] = owner_id
+        await self._persist()
+
+    async def _forget_channel(self, channel_id: int) -> None:
+        if self._owners.pop(channel_id, None) is not None:
+            await self._persist()
+        self._panel_posted.discard(channel_id)
+
+    def owner_id(self, channel_id: int) -> int | None:
+        return self._owners.get(channel_id)
+
+    def _member_is_staff(self, member: discord.Member) -> bool:
+        return bool(getattr(member.guild_permissions, "manage_channels", False))
+
+    def _owner_is_present(
+        self, channel: discord.VoiceChannel, owner_id: int | None
+    ) -> bool:
+        if owner_id is None:
+            return False
+        return any(member.id == owner_id for member in channel.members)
+
+    async def require_control_channel(
+        self,
+        interaction: discord.Interaction,
+        *,
+        require_owner: bool,
+    ) -> discord.VoiceChannel | None:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await interaction.response.send_message(
+                "❌ Action disponible uniquement sur le serveur.",
+                ephemeral=True,
+            )
+            return None
+
+        voice = member.voice
+        channel = voice.channel if voice else None
+        if (
+            not isinstance(channel, discord.VoiceChannel)
+            or channel.id not in TEMP_VC_IDS
+            or channel.id not in self._owners
+        ):
+            await interaction.response.send_message(
+                "❌ Tu dois être dans un salon vocal temporaire contrôlé par le Refuge.",
+                ephemeral=True,
+            )
+            return None
+
+        if require_owner:
+            owner_id = self._owners.get(channel.id)
+            if owner_id != member.id and not self._member_is_staff(member):
+                await interaction.response.send_message(
+                    "❌ Seul le propriétaire du salon (ou un modérateur) peut faire ça.",
+                    ephemeral=True,
+                )
+                return None
+
+        return channel
+
+    async def _maybe_post_panel(self, channel: discord.VoiceChannel) -> None:
+        if channel.id in self._panel_posted:
+            return
+        sender = getattr(channel, "send", None)
+        if not callable(sender):
+            return
+        try:
+            await sender(embed=build_control_embed(), view=TempVoiceControlView(self))
+        except (discord.Forbidden, discord.HTTPException):
+            logger.info(
+                "[temp_vc_controls] panneau non envoyé dans le vocal %s",
+                channel.id,
+            )
+            return
+        self._panel_posted.add(channel.id)
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        changed = False
+        for channel_id in list(self._owners):
+            channel = self.bot.get_channel(channel_id)
+            if (
+                not isinstance(channel, discord.VoiceChannel)
+                or channel_id not in TEMP_VC_IDS
+            ):
+                self._owners.pop(channel_id, None)
+                self._panel_posted.discard(channel_id)
+                changed = True
+        if changed:
+            await self._persist()
+
+    @commands.Cog.listener()
+    async def on_voice_state_update(
+        self,
+        member: discord.Member,
+        before: discord.VoiceState,
+        after: discord.VoiceState,
+    ) -> None:
+        channel = after.channel
+        if not isinstance(channel, discord.VoiceChannel):
+            return
+        if channel.id not in TEMP_VC_IDS:
+            return
+
+        before_channel = before.channel
+        came_from_standard_lobby = (
+            before_channel is not None and before_channel.id == LOBBY_VC_ID
+        )
+        if channel.id not in self._owners and came_from_standard_lobby:
+            await self._set_owner(channel.id, member.id)
+
+        if self._owners.get(channel.id) == member.id:
+            await self._maybe_post_panel(channel)
+
+    @commands.Cog.listener()
+    async def on_guild_channel_delete(
+        self, channel: discord.abc.GuildChannel
+    ) -> None:
+        await self._forget_channel(channel.id)
+
+    async def set_locked(
+        self, interaction: discord.Interaction, locked: bool
+    ) -> None:
+        channel = await self.require_control_channel(
+            interaction, require_owner=True
+        )
+        if channel is None or interaction.guild is None:
+            return
+
+        overwrite = channel.overwrites_for(interaction.guild.default_role)
+        overwrite.connect = False if locked else None
+        await channel.set_permissions(
+            interaction.guild.default_role,
+            overwrite=overwrite,
+            reason=f"Temp VC {'lock' if locked else 'unlock'} par {interaction.user}",
+        )
+        await interaction.response.send_message(
+            "🔒 Salon verrouillé." if locked else "🔓 Salon déverrouillé.",
+            ephemeral=True,
+        )
+
+    async def set_hidden(
+        self, interaction: discord.Interaction, hidden: bool
+    ) -> None:
+        channel = await self.require_control_channel(
+            interaction, require_owner=True
+        )
+        if channel is None or interaction.guild is None:
+            return
+
+        overwrite = channel.overwrites_for(interaction.guild.default_role)
+        overwrite.view_channel = False if hidden else None
+        await channel.set_permissions(
+            interaction.guild.default_role,
+            overwrite=overwrite,
+            reason=f"Temp VC {'hide' if hidden else 'show'} par {interaction.user}",
+        )
+        await interaction.response.send_message(
+            "🙈 Salon masqué." if hidden else "👁️ Salon visible.",
+            ephemeral=True,
+        )
+
+    async def claim(self, interaction: discord.Interaction) -> None:
+        channel = await self.require_control_channel(
+            interaction, require_owner=False
+        )
+        if channel is None:
+            return
+
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            return
+
+        owner_id = self._owners.get(channel.id)
+        if owner_id == member.id:
+            await interaction.response.send_message(
+                "👑 Tu es déjà propriétaire de ce salon.",
+                ephemeral=True,
+            )
+            return
+
+        if self._owner_is_present(channel, owner_id) and not self._member_is_staff(member):
+            await interaction.response.send_message(
+                "❌ Le propriétaire actuel est encore dans le salon.",
+                ephemeral=True,
+            )
+            return
+
+        await self._set_owner(channel.id, member.id)
+        await interaction.response.send_message(
+            "👑 Tu es maintenant propriétaire du salon.",
+            ephemeral=True,
+        )
+
+    async def set_user_limit(
+        self, interaction: discord.Interaction, raw_limit: str
+    ) -> None:
+        channel = await self.require_control_channel(
+            interaction, require_owner=True
+        )
+        if channel is None:
+            return
+
+        try:
+            value = int(raw_limit.strip())
+        except (TypeError, ValueError):
+            await interaction.response.send_message(
+                "❌ Entre un nombre de 0 à 99.",
+                ephemeral=True,
+            )
+            return
+
+        if not 0 <= value <= 99:
+            await interaction.response.send_message(
+                "❌ La limite doit être comprise entre 0 et 99.",
+                ephemeral=True,
+            )
+            return
+
+        await channel.edit(
+            user_limit=value,
+            reason=f"Limite Temp VC modifiée par {interaction.user}",
+        )
+        text = "aucune limite" if value == 0 else f"{value} membre(s)"
+        await interaction.response.send_message(
+            f"👥 Limite mise à jour : **{text}**.",
+            ephemeral=True,
+        )
+
+    async def _set_member_access(
+        self,
+        interaction: discord.Interaction,
+        target: discord.Member,
+        *,
+        view_channel: bool | None,
+        connect: bool | None,
+        speak: bool | None,
+        message: str,
+        reason: str,
+    ) -> None:
+        channel = await self.require_control_channel(
+            interaction, require_owner=True
+        )
+        if channel is None:
+            return
+
+        if target.bot:
+            await interaction.response.send_message(
+                "❌ Cette action n'est pas prévue pour les bots.",
+                ephemeral=True,
+            )
+            return
+
+        overwrite = channel.overwrites_for(target)
+        overwrite.view_channel = view_channel
+        overwrite.connect = connect
+        overwrite.speak = speak
+        await channel.set_permissions(
+            target,
+            overwrite=overwrite,
+            reason=reason,
+        )
+        await interaction.response.send_message(message, ephemeral=True)
+
+    async def trust_member(
+        self, interaction: discord.Interaction, target: discord.Member
+    ) -> None:
+        await self._set_member_access(
+            interaction,
+            target,
+            view_channel=True,
+            connect=True,
+            speak=True,
+            message=f"✅ {target.mention} est autorisé dans le salon.",
+            reason=f"Temp VC trust par {interaction.user}",
+        )
+
+    async def untrust_member(
+        self, interaction: discord.Interaction, target: discord.Member
+    ) -> None:
+        await self._set_member_access(
+            interaction,
+            target,
+            view_channel=None,
+            connect=None,
+            speak=None,
+            message=f"⛔ Accès spécifique retiré pour {target.mention}.",
+            reason=f"Temp VC untrust par {interaction.user}",
+        )
+
+    async def block_member(
+        self, interaction: discord.Interaction, target: discord.Member
+    ) -> None:
+        channel = await self.require_control_channel(
+            interaction, require_owner=True
+        )
+        if channel is None:
+            return
+
+        owner_id = self._owners.get(channel.id)
+        if target.id == owner_id:
+            await interaction.response.send_message(
+                "❌ Le propriétaire ne peut pas se bloquer lui-même.",
+                ephemeral=True,
+            )
+            return
+
+        overwrite = channel.overwrites_for(target)
+        overwrite.view_channel = False
+        overwrite.connect = False
+        overwrite.speak = False
+        await channel.set_permissions(
+            target,
+            overwrite=overwrite,
+            reason=f"Temp VC block par {interaction.user}",
+        )
+        if target.voice and target.voice.channel == channel:
+            try:
+                await target.move_to(None, reason="Bloqué du salon temporaire")
+            except discord.HTTPException:
+                logger.exception(
+                    "[temp_vc_controls] impossible de déconnecter %s",
+                    target.id,
+                )
+        await interaction.response.send_message(
+            f"🚫 {target.mention} est bloqué.",
+            ephemeral=True,
+        )
+
+    async def unblock_member(
+        self, interaction: discord.Interaction, target: discord.Member
+    ) -> None:
+        await self._set_member_access(
+            interaction,
+            target,
+            view_channel=None,
+            connect=None,
+            speak=None,
+            message=f"✔️ {target.mention} est débloqué.",
+            reason=f"Temp VC unblock par {interaction.user}",
+        )
+
+    async def kick_member(
+        self, interaction: discord.Interaction, target: discord.Member
+    ) -> None:
+        channel = await self.require_control_channel(
+            interaction, require_owner=True
+        )
+        if channel is None:
+            return
+
+        if not target.voice or target.voice.channel != channel:
+            await interaction.response.send_message(
+                "❌ Ce membre n'est pas dans ton salon vocal.",
+                ephemeral=True,
+            )
+            return
+
+        if target.id == self._owners.get(channel.id):
+            await interaction.response.send_message(
+                "❌ Le propriétaire ne peut pas s'expulser lui-même.",
+                ephemeral=True,
+            )
+            return
+
+        await target.move_to(
+            None,
+            reason=f"Expulsé du Temp VC par {interaction.user}",
+        )
+        await interaction.response.send_message(
+            f"👢 {target.mention} a été expulsé du vocal.",
+            ephemeral=True,
+        )
+
+    async def transfer_owner(
+        self, interaction: discord.Interaction, target: discord.Member
+    ) -> None:
+        channel = await self.require_control_channel(
+            interaction, require_owner=True
+        )
+        if channel is None:
+            return
+
+        if target not in channel.members:
+            await interaction.response.send_message(
+                "❌ Le nouveau propriétaire doit être présent dans le salon.",
+                ephemeral=True,
+            )
+            return
+
+        await self._set_owner(channel.id, target.id)
+        await interaction.response.send_message(
+            f"🔁 {target.mention} est maintenant propriétaire du salon.",
+            ephemeral=True,
+        )
+
+    @app_commands.command(
+        name="vocal_panel",
+        description="Publier le panneau de contrôle des salons vocaux temporaires.",
+    )
+    @app_commands.checks.has_permissions(manage_channels=True)
+    async def post_control_panel(
+        self, interaction: discord.Interaction
+    ) -> None:
+        channel = interaction.channel
+        sender = getattr(channel, "send", None)
+        if not callable(sender):
+            await interaction.response.send_message(
+                "❌ Impossible de publier le panneau dans ce salon.",
+                ephemeral=True,
+            )
+            return
+
+        await sender(
+            embed=build_control_embed(),
+            view=TempVoiceControlView(self),
+        )
+        await interaction.response.send_message(
+            "✅ Panneau vocal publié.",
+            ephemeral=True,
+        )
+
+
+async def setup(bot: commands.Bot) -> None:
+    cog = TempVCControlsCog(bot)
+    await bot.add_cog(cog)
+    bot.add_view(TempVoiceControlView(cog))

--- a/storage/temp_vc_control_store.py
+++ b/storage/temp_vc_control_store.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Dict, Mapping
+
+from config import DATA_DIR
+from utils.persistence import atomic_write_json_async, read_json_safe
+
+OWNERS_FILE = Path(DATA_DIR) / "temp_vc_owners.json"
+
+
+def load_temp_vc_owners() -> Dict[int, int]:
+    """Load ``channel_id -> owner_id`` for controllable temporary voice channels."""
+    data = read_json_safe(OWNERS_FILE)
+    if not isinstance(data, dict):
+        return {}
+
+    owners: Dict[int, int] = {}
+    for channel_id, owner_id in data.items():
+        try:
+            owners[int(channel_id)] = int(owner_id)
+        except (TypeError, ValueError):
+            logging.warning(
+                "[temp_vc_control_store] Entrée propriétaire invalide ignorée: %r -> %r",
+                channel_id,
+                owner_id,
+            )
+    return owners
+
+
+async def save_temp_vc_owners_async(mapping: Mapping[int, int]) -> None:
+    """Persist temporary voice owners atomically."""
+    payload = {
+        str(int(channel_id)): int(owner_id)
+        for channel_id, owner_id in mapping.items()
+    }
+    await atomic_write_json_async(OWNERS_FILE, payload)

--- a/tests/test_temp_vc_controls.py
+++ b/tests/test_temp_vc_controls.py
@@ -19,10 +19,18 @@ class DummyOverwrite:
 
 
 class DummyVoiceChannel:
-    def __init__(self, channel_id: int, *, name: str = "PC • Fortnite", members=None):
+    def __init__(
+        self,
+        channel_id: int,
+        *,
+        name: str = "PC • Fortnite",
+        members=None,
+        category_id: int = 500,
+    ):
         self.id = channel_id
         self.name = name
         self.members = list(members or [])
+        self.category_id = category_id
         self.user_limit = 0
         self.set_permissions = AsyncMock()
         self.edit = AsyncMock()
@@ -65,8 +73,8 @@ def discord_types(monkeypatch):
 async def test_standard_lobby_move_records_owner_without_touching_name(
     monkeypatch, discord_types
 ):
-    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
     monkeypatch.setattr(controls, "LOBBY_VC_ID", 10)
+    monkeypatch.setattr(controls, "TEMP_VC_CATEGORY", 500)
     monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {})
     save = AsyncMock()
     monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
@@ -90,8 +98,8 @@ async def test_standard_lobby_move_records_owner_without_touching_name(
 async def test_non_lobby_join_does_not_claim_unowned_channel(
     monkeypatch, discord_types
 ):
-    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
     monkeypatch.setattr(controls, "LOBBY_VC_ID", 10)
+    monkeypatch.setattr(controls, "TEMP_VC_CATEGORY", 500)
     monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {})
     save = AsyncMock()
     monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
@@ -114,7 +122,7 @@ async def test_non_lobby_join_does_not_claim_unowned_channel(
 async def test_lock_changes_permissions_not_dynamic_name(
     monkeypatch, discord_types
 ):
-    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "TEMP_VC_CATEGORY", 500)
     monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
     monkeypatch.setattr(controls, "save_temp_vc_owners_async", AsyncMock())
 
@@ -142,7 +150,7 @@ async def test_lock_changes_permissions_not_dynamic_name(
 async def test_limit_updates_only_user_limit(
     monkeypatch, discord_types
 ):
-    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "TEMP_VC_CATEGORY", 500)
     monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
     monkeypatch.setattr(controls, "save_temp_vc_owners_async", AsyncMock())
 
@@ -167,7 +175,7 @@ async def test_limit_updates_only_user_limit(
 async def test_claim_rejected_while_owner_is_present(
     monkeypatch, discord_types
 ):
-    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "TEMP_VC_CATEGORY", 500)
     monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
     save = AsyncMock()
     monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
@@ -194,7 +202,7 @@ async def test_claim_rejected_while_owner_is_present(
 async def test_claim_succeeds_after_owner_leaves(
     monkeypatch, discord_types
 ):
-    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "TEMP_VC_CATEGORY", 500)
     monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
     save = AsyncMock()
     monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
@@ -219,7 +227,7 @@ async def test_claim_succeeds_after_owner_leaves(
 async def test_transfer_requires_target_in_same_channel(
     monkeypatch, discord_types
 ):
-    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "TEMP_VC_CATEGORY", 500)
     monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
     save = AsyncMock()
     monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
@@ -245,6 +253,7 @@ async def test_transfer_requires_target_in_same_channel(
 async def test_deleted_channel_cleans_owner_mapping(
     monkeypatch, discord_types
 ):
+    monkeypatch.setattr(controls, "TEMP_VC_CATEGORY", 500)
     monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
     save = AsyncMock()
     monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)

--- a/tests/test_temp_vc_controls.py
+++ b/tests/test_temp_vc_controls.py
@@ -1,0 +1,256 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cogs.temp_vc_controls as controls
+
+
+class DummyPermissions:
+    def __init__(self, *, manage_channels: bool = False) -> None:
+        self.manage_channels = manage_channels
+
+
+class DummyOverwrite:
+    def __init__(self) -> None:
+        self.connect = None
+        self.view_channel = None
+        self.speak = None
+
+
+class DummyVoiceChannel:
+    def __init__(self, channel_id: int, *, name: str = "PC • Fortnite", members=None):
+        self.id = channel_id
+        self.name = name
+        self.members = list(members or [])
+        self.user_limit = 0
+        self.set_permissions = AsyncMock()
+        self.edit = AsyncMock()
+        self.send = AsyncMock()
+
+    def overwrites_for(self, _target):
+        return DummyOverwrite()
+
+
+class DummyMember:
+    def __init__(
+        self,
+        member_id: int,
+        *,
+        channel=None,
+        manage_channels: bool = False,
+        bot: bool = False,
+    ) -> None:
+        self.id = member_id
+        self.bot = bot
+        self.mention = f"<@{member_id}>"
+        self.guild_permissions = DummyPermissions(manage_channels=manage_channels)
+        self.voice = SimpleNamespace(channel=channel) if channel is not None else None
+        self.move_to = AsyncMock()
+
+
+class DummyResponse:
+    def __init__(self) -> None:
+        self.send_message = AsyncMock()
+        self.send_modal = AsyncMock()
+
+
+@pytest.fixture
+def discord_types(monkeypatch):
+    monkeypatch.setattr(controls.discord, "VoiceChannel", DummyVoiceChannel)
+    monkeypatch.setattr(controls.discord, "Member", DummyMember)
+
+
+@pytest.mark.asyncio
+async def test_standard_lobby_move_records_owner_without_touching_name(
+    monkeypatch, discord_types
+):
+    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "LOBBY_VC_ID", 10)
+    monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {})
+    save = AsyncMock()
+    monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
+
+    channel = DummyVoiceChannel(99, name="PC • Fortnite")
+    bot = SimpleNamespace(get_channel=lambda cid: channel if cid == 99 else None)
+    cog = controls.TempVCControlsCog(bot)
+    member = DummyMember(7, channel=channel)
+
+    before = SimpleNamespace(channel=SimpleNamespace(id=10))
+    after = SimpleNamespace(channel=channel)
+    await cog.on_voice_state_update(member, before, after)
+
+    assert cog.owner_id(99) == 7
+    assert channel.name == "PC • Fortnite"
+    channel.edit.assert_not_awaited()
+    save.assert_awaited_once_with({99: 7})
+
+
+@pytest.mark.asyncio
+async def test_non_lobby_join_does_not_claim_unowned_channel(
+    monkeypatch, discord_types
+):
+    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "LOBBY_VC_ID", 10)
+    monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {})
+    save = AsyncMock()
+    monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
+
+    channel = DummyVoiceChannel(99)
+    cog = controls.TempVCControlsCog(SimpleNamespace(get_channel=lambda _cid: channel))
+    member = DummyMember(8, channel=channel)
+
+    await cog.on_voice_state_update(
+        member,
+        SimpleNamespace(channel=SimpleNamespace(id=123)),
+        SimpleNamespace(channel=channel),
+    )
+
+    assert cog.owner_id(99) is None
+    save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_lock_changes_permissions_not_dynamic_name(
+    monkeypatch, discord_types
+):
+    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
+    monkeypatch.setattr(controls, "save_temp_vc_owners_async", AsyncMock())
+
+    channel = DummyVoiceChannel(99, name="Crossplay • Call of Duty")
+    owner = DummyMember(7, channel=channel)
+    default_role = object()
+    guild = SimpleNamespace(default_role=default_role)
+    interaction = SimpleNamespace(
+        user=owner,
+        guild=guild,
+        response=DummyResponse(),
+    )
+    cog = controls.TempVCControlsCog(SimpleNamespace())
+
+    await cog.set_locked(interaction, True)
+
+    assert channel.name == "Crossplay • Call of Duty"
+    channel.edit.assert_not_awaited()
+    channel.set_permissions.assert_awaited_once()
+    overwrite = channel.set_permissions.await_args.kwargs["overwrite"]
+    assert overwrite.connect is False
+
+
+@pytest.mark.asyncio
+async def test_limit_updates_only_user_limit(
+    monkeypatch, discord_types
+):
+    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
+    monkeypatch.setattr(controls, "save_temp_vc_owners_async", AsyncMock())
+
+    channel = DummyVoiceChannel(99, name="PC • Rocket League")
+    owner = DummyMember(7, channel=channel)
+    interaction = SimpleNamespace(
+        user=owner,
+        guild=SimpleNamespace(default_role=object()),
+        response=DummyResponse(),
+    )
+    cog = controls.TempVCControlsCog(SimpleNamespace())
+
+    await cog.set_user_limit(interaction, "5")
+
+    assert channel.name == "PC • Rocket League"
+    channel.edit.assert_awaited_once()
+    assert channel.edit.await_args.kwargs["user_limit"] == 5
+    assert "name" not in channel.edit.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_claim_rejected_while_owner_is_present(
+    monkeypatch, discord_types
+):
+    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
+    save = AsyncMock()
+    monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
+
+    owner = DummyMember(7)
+    claimant = DummyMember(8)
+    channel = DummyVoiceChannel(99, members=[owner, claimant])
+    claimant.voice = SimpleNamespace(channel=channel)
+    interaction = SimpleNamespace(
+        user=claimant,
+        guild=SimpleNamespace(default_role=object()),
+        response=DummyResponse(),
+    )
+    cog = controls.TempVCControlsCog(SimpleNamespace())
+
+    await cog.claim(interaction)
+
+    assert cog.owner_id(99) == 7
+    save.assert_not_awaited()
+    interaction.response.send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_claim_succeeds_after_owner_leaves(
+    monkeypatch, discord_types
+):
+    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
+    save = AsyncMock()
+    monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
+
+    claimant = DummyMember(8)
+    channel = DummyVoiceChannel(99, members=[claimant])
+    claimant.voice = SimpleNamespace(channel=channel)
+    interaction = SimpleNamespace(
+        user=claimant,
+        guild=SimpleNamespace(default_role=object()),
+        response=DummyResponse(),
+    )
+    cog = controls.TempVCControlsCog(SimpleNamespace())
+
+    await cog.claim(interaction)
+
+    assert cog.owner_id(99) == 8
+    save.assert_awaited_once_with({99: 8})
+
+
+@pytest.mark.asyncio
+async def test_transfer_requires_target_in_same_channel(
+    monkeypatch, discord_types
+):
+    monkeypatch.setattr(controls, "TEMP_VC_IDS", {99})
+    monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
+    save = AsyncMock()
+    monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
+
+    channel = DummyVoiceChannel(99)
+    owner = DummyMember(7, channel=channel)
+    target = DummyMember(8)
+    channel.members = [owner]
+    interaction = SimpleNamespace(
+        user=owner,
+        guild=SimpleNamespace(default_role=object()),
+        response=DummyResponse(),
+    )
+    cog = controls.TempVCControlsCog(SimpleNamespace())
+
+    await cog.transfer_owner(interaction, target)
+
+    assert cog.owner_id(99) == 7
+    save.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_deleted_channel_cleans_owner_mapping(
+    monkeypatch, discord_types
+):
+    monkeypatch.setattr(controls, "load_temp_vc_owners", lambda: {99: 7})
+    save = AsyncMock()
+    monkeypatch.setattr(controls, "save_temp_vc_owners_async", save)
+
+    cog = controls.TempVCControlsCog(SimpleNamespace())
+    await cog.on_guild_channel_delete(SimpleNamespace(id=99))
+
+    assert cog.owner_id(99) is None
+    save.assert_awaited_once_with({})


### PR DESCRIPTION
## Objectif
Ajouter une couche de contrôle inspirée de VoiceForge aux salons vocaux temporaires sans modifier leur création ni leur naming dynamique existant.

## Changements
- persistance `channel_id -> owner_id` dans `temp_vc_owners.json` ;
- propriétaire automatique pour les salons créés via le lobby vocal standard ;
- panneau persistant : lock/unlock, hide/show, claim, limite, trust/untrust, block/unblock, kick, transfert ;
- publication automatique du panneau dans le chat du vocal quand possible ;
- commande admin `/vocal_panel` pour republier le panneau ;
- claim autorisé lorsque le propriétaire n'est plus présent ;
- modérateurs avec `manage_channels` autorisés à administrer le salon ;
- aucun bouton de renommage et aucune écriture dans `channel.name`.

## Garantie de compatibilité
`cogs/temp_vc.py` n'est pas modifié. La logique actuelle PC / Console / Mobile / Crossplay / activité / AFK reste donc la source unique du naming.

## Tests ajoutés
Les tests couvrent notamment : attribution du propriétaire depuis le lobby, absence de prise de contrôle sur une entrée normale, lock sans renommage, modification de limite sans renommage, claim, transfert et nettoyage de la persistance.