### PR TITLE
feat: add Music 2.0 controller

### DIFF
--- a/cogs/music2.py
+++ b/cogs/music2.py
@@ -1,0 +1,628 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import deque
+from dataclasses import dataclass
+from typing import Deque
+from urllib.parse import urlparse
+
+import discord
+import yt_dlp
+from discord.ext import commands
+
+from config import (
+    DATA_DIR,
+    RADIO_RAP_FR_STREAM_URL,
+    RADIO_RAP_STREAM_URL,
+    RADIO_STREAM_URL,
+    RADIO_TEXT_CHANNEL_ID,
+    RADIO_VC_ID,
+    ROCK_RADIO_STREAM_URL,
+)
+from storage.radio_store import RadioStore
+from utils.voice import ensure_voice, play_stream
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class MusicTrack:
+    title: str
+    webpage_url: str
+    requester_id: int
+    duration: int | None = None
+    uploader: str | None = None
+
+
+class AddMusicModal(discord.ui.Modal, title="Ajouter une musique"):
+    query = discord.ui.TextInput(
+        label="Titre ou lien",
+        placeholder="Ex. Daft Punk One More Time ou un lien YouTube",
+        min_length=2,
+        max_length=300,
+        required=True,
+    )
+
+    def __init__(self, cog: "Music2Cog") -> None:
+        super().__init__(timeout=300, custom_id="music2:add_modal")
+        self.cog = cog
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        await self.cog.add_track_from_interaction(interaction, str(self.query.value))
+
+
+class Music2View(discord.ui.View):
+    """Contrôleur combiné radio + musique à la demande."""
+
+    def __init__(self, cog: "Music2Cog") -> None:
+        super().__init__(timeout=None)
+        self.cog = cog
+
+    async def interaction_check(self, interaction: discord.Interaction) -> bool:
+        if interaction.channel_id == RADIO_TEXT_CHANNEL_ID:
+            return True
+        await interaction.response.send_message(
+            f"❌ Utilise ce panneau dans <#{RADIO_TEXT_CHANNEL_ID}>.",
+            ephemeral=True,
+        )
+        return False
+
+    async def _dispatch_radio(self, interaction: discord.Interaction, method: str) -> None:
+        radio = interaction.client.get_cog("RadioCog")
+        if radio is None:
+            await interaction.response.send_message(
+                "❌ Radio indisponible.", ephemeral=True
+            )
+            return
+        callback = getattr(radio, method, None)
+        if callback is None:
+            await interaction.response.send_message(
+                "❌ Station indisponible.", ephemeral=True
+            )
+            return
+        await callback(interaction)
+        await self.cog.refresh_panel()
+
+    @discord.ui.button(
+        label="Rap FR",
+        style=discord.ButtonStyle.primary,
+        custom_id="radio_rap_fr",
+        row=0,
+    )
+    async def radio_rap_fr(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._dispatch_radio(interaction, "radio_rap_fr")
+
+    @discord.ui.button(
+        label="Rap US",
+        style=discord.ButtonStyle.primary,
+        custom_id="radio_rap",
+        row=0,
+    )
+    async def radio_rap(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._dispatch_radio(interaction, "radio_rap")
+
+    @discord.ui.button(
+        label="Rock",
+        style=discord.ButtonStyle.primary,
+        custom_id="radio_rock",
+        row=0,
+    )
+    async def radio_rock(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._dispatch_radio(interaction, "radio_rock")
+
+    @discord.ui.button(
+        label="Radio Hip-Hop",
+        style=discord.ButtonStyle.primary,
+        custom_id="radio_hiphop",
+        row=0,
+    )
+    async def radio_hiphop(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self._dispatch_radio(interaction, "radio_hiphop")
+
+    @discord.ui.button(
+        label="Ajouter",
+        emoji="➕",
+        style=discord.ButtonStyle.success,
+        custom_id="music2_add",
+        row=1,
+    )
+    async def add_music(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        if not await self.cog.require_radio_listener(interaction):
+            return
+        await interaction.response.send_modal(AddMusicModal(self.cog))
+
+    @discord.ui.button(
+        label="Pause / Reprendre",
+        emoji="⏯️",
+        style=discord.ButtonStyle.secondary,
+        custom_id="music2_pause_resume",
+        row=1,
+    )
+    async def pause_resume(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self.cog.pause_resume(interaction)
+
+    @discord.ui.button(
+        label="Suivant",
+        emoji="⏭️",
+        style=discord.ButtonStyle.secondary,
+        custom_id="music2_next",
+        row=1,
+    )
+    async def next_track(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self.cog.skip(interaction)
+
+    @discord.ui.button(
+        label="File",
+        emoji="📃",
+        style=discord.ButtonStyle.secondary,
+        custom_id="music2_queue",
+        row=1,
+    )
+    async def queue(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self.cog.show_queue(interaction)
+
+    @discord.ui.button(
+        label="En cours",
+        emoji="🎵",
+        style=discord.ButtonStyle.secondary,
+        custom_id="music2_now_playing",
+        row=1,
+    )
+    async def now_playing(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await self.cog.show_now_playing(interaction)
+
+
+class Music2Cog(commands.Cog):
+    """Couche Music 2.0 au-dessus de la radio existante, sans Lavalink."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self.queue: Deque[MusicTrack] = deque()
+        self.current: MusicTrack | None = None
+        self._radio_restore_stream: str | None = None
+        self._generation = 0
+        self._extract_lock = asyncio.Lock()
+        self._play_lock = asyncio.Lock()
+        self.store = RadioStore(data_dir=DATA_DIR)
+        self.view = Music2View(self)
+        self._panel_message: discord.Message | None = None
+
+    def _radio_cog(self):
+        return self.bot.get_cog("RadioCog")
+
+    def _station_label(self, stream_url: str | None) -> str:
+        return {
+            RADIO_RAP_FR_STREAM_URL: "Rap FR",
+            RADIO_RAP_STREAM_URL: "Rap US",
+            ROCK_RADIO_STREAM_URL: "Rock",
+            RADIO_STREAM_URL: "Hip-Hop",
+        }.get(stream_url, "Radio")
+
+    def _format_duration(self, duration: int | None) -> str:
+        if not duration:
+            return "durée inconnue"
+        minutes, seconds = divmod(int(duration), 60)
+        hours, minutes = divmod(minutes, 60)
+        if hours:
+            return f"{hours:d}:{minutes:02d}:{seconds:02d}"
+        return f"{minutes:d}:{seconds:02d}"
+
+    def build_panel_embed(self) -> discord.Embed:
+        embed = discord.Embed(
+            title="🎵 Refuge Music 2.0",
+            description=(
+                "Les radios existantes restent disponibles. "
+                "Une musique ajoutée suspend temporairement la radio, "
+                "qui reprend automatiquement à la fin de la file."
+            ),
+        )
+        if self.current is not None:
+            embed.add_field(
+                name="Lecture en cours",
+                value=(
+                    f"**{self.current.title}**\n"
+                    f"{self._format_duration(self.current.duration)} · "
+                    f"demandé par <@{self.current.requester_id}>"
+                ),
+                inline=False,
+            )
+            embed.add_field(
+                name="File d'attente",
+                value=f"{len(self.queue)} titre(s)",
+                inline=True,
+            )
+        else:
+            radio = self._radio_cog()
+            stream_url = (
+                getattr(radio, "stream_url", RADIO_STREAM_URL)
+                if radio
+                else RADIO_STREAM_URL
+            )
+            embed.add_field(
+                name="Lecture en cours",
+                value=f"📻 Radio **{self._station_label(stream_url)}**",
+                inline=False,
+            )
+            embed.add_field(name="File d'attente", value="Vide", inline=True)
+        embed.set_footer(text="Ajoute un titre ou un lien depuis le bouton ➕ Ajouter.")
+        return embed
+
+    async def require_radio_listener(self, interaction: discord.Interaction) -> bool:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await interaction.response.send_message(
+                "❌ Action disponible uniquement sur le serveur.", ephemeral=True
+            )
+            return False
+        voice = member.voice
+        if voice is None or voice.channel is None or voice.channel.id != RADIO_VC_ID:
+            await interaction.response.send_message(
+                f"❌ Rejoins d'abord <#{RADIO_VC_ID}> pour contrôler la musique.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def _ensure_panel(self) -> None:
+        text_channel = self.bot.get_channel(RADIO_TEXT_CHANNEL_ID)
+        if not isinstance(text_channel, discord.abc.Messageable):
+            return
+
+        stored = self.store.get_radio_message()
+        if not stored:
+            radio = self._radio_cog()
+            ensure = getattr(radio, "_ensure_radio_message", None) if radio else None
+            if callable(ensure):
+                await ensure(text_channel)
+                stored = self.store.get_radio_message()
+
+        if not stored or int(stored.get("channel_id", 0)) != RADIO_TEXT_CHANNEL_ID:
+            return
+
+        fetch = getattr(text_channel, "fetch_message", None)
+        if not callable(fetch):
+            return
+        try:
+            message = await fetch(int(stored.get("message_id", 0)))
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException, ValueError):
+            logger.warning("[music2] panneau radio existant introuvable")
+            return
+
+        self._panel_message = message
+        try:
+            await message.edit(
+                content=None,
+                embed=self.build_panel_embed(),
+                view=self.view,
+            )
+        except (discord.Forbidden, discord.HTTPException):
+            logger.exception("[music2] impossible de mettre à niveau le panneau radio")
+
+    async def refresh_panel(self) -> None:
+        message = self._panel_message
+        if message is None:
+            await self._ensure_panel()
+            message = self._panel_message
+        if message is None:
+            return
+        try:
+            await message.edit(
+                content=None,
+                embed=self.build_panel_embed(),
+                view=self.view,
+            )
+        except (discord.NotFound, discord.Forbidden, discord.HTTPException):
+            self._panel_message = None
+            logger.exception("[music2] rafraîchissement panneau impossible")
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        await self._ensure_panel()
+
+    def _extract_info_sync(self, target: str) -> dict:
+        is_url = urlparse(target).scheme in {"http", "https"}
+        lookup = target if is_url else f"ytsearch1:{target}"
+        options = {
+            "format": "bestaudio/best",
+            "quiet": True,
+            "no_warnings": True,
+            "noplaylist": True,
+            "skip_download": True,
+        }
+        with yt_dlp.YoutubeDL(options) as ydl:
+            info = ydl.extract_info(lookup, download=False)
+            if info is None:
+                raise RuntimeError("Aucun résultat")
+            entries = info.get("entries") if hasattr(info, "get") else None
+            if entries is not None:
+                info = next((entry for entry in entries if entry), None)
+            if info is None or not hasattr(info, "get"):
+                raise RuntimeError("Aucun résultat exploitable")
+            return dict(info)
+
+    async def _extract_info(self, target: str) -> dict:
+        async with self._extract_lock:
+            return await asyncio.to_thread(self._extract_info_sync, target)
+
+    def _track_from_info(self, info: dict, requester_id: int) -> MusicTrack:
+        title = str(info.get("title") or "Titre inconnu")
+        webpage_url = str(
+            info.get("webpage_url")
+            or info.get("original_url")
+            or info.get("url")
+            or ""
+        )
+        if not webpage_url:
+            raise RuntimeError("Lien du média introuvable")
+        duration_raw = info.get("duration")
+        try:
+            duration = int(duration_raw) if duration_raw is not None else None
+        except (TypeError, ValueError):
+            duration = None
+        uploader = info.get("uploader")
+        return MusicTrack(
+            title=title,
+            webpage_url=webpage_url,
+            requester_id=requester_id,
+            duration=duration,
+            uploader=str(uploader) if uploader else None,
+        )
+
+    async def add_track_from_interaction(
+        self, interaction: discord.Interaction, query: str
+    ) -> None:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await interaction.response.send_message(
+                "❌ Action disponible uniquement sur le serveur.", ephemeral=True
+            )
+            return
+        voice = member.voice
+        if voice is None or voice.channel is None or voice.channel.id != RADIO_VC_ID:
+            await interaction.response.send_message(
+                f"❌ Rejoins d'abord <#{RADIO_VC_ID}>.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True, thinking=True)
+        try:
+            info = await self._extract_info(query.strip())
+            track = self._track_from_info(info, member.id)
+        except Exception as exc:
+            logger.warning("[music2] recherche impossible: %s", exc)
+            await interaction.followup.send(
+                "❌ Impossible de trouver ou lire ce titre.", ephemeral=True
+            )
+            return
+
+        self.queue.append(track)
+        position = len(self.queue)
+        if self.current is None:
+            await self._play_next()
+            position = 0
+
+        if position == 0 and self.current is not None:
+            message = f"▶️ **{track.title}** démarre."
+        elif position == 0:
+            message = f"⚠️ **{track.title}** n'a pas pu démarrer."
+        else:
+            message = f"➕ **{track.title}** ajouté à la file (position {position})."
+        await interaction.followup.send(message, ephemeral=True)
+        await self.refresh_panel()
+
+    async def _resolve_stream(self, track: MusicTrack) -> tuple[str, str | None]:
+        info = await self._extract_info(track.webpage_url)
+        stream_url = str(info.get("url") or "")
+        if not stream_url:
+            formats = info.get("formats") or []
+            for fmt in reversed(formats):
+                if fmt and fmt.get("url"):
+                    stream_url = str(fmt["url"])
+                    break
+        if not stream_url:
+            raise RuntimeError("Flux audio introuvable")
+
+        raw_headers = info.get("http_headers")
+        headers = None
+        if isinstance(raw_headers, dict) and raw_headers:
+            headers = "\r\n".join(
+                f"{key}: {value}" for key, value in raw_headers.items()
+            ) + "\r\n"
+        return stream_url, headers
+
+    async def _suspend_radio(self):
+        radio = self._radio_cog()
+        if radio is None:
+            raise RuntimeError("RadioCog indisponible")
+
+        if self._radio_restore_stream is None:
+            current_stream = getattr(radio, "stream_url", None)
+            self._radio_restore_stream = current_stream or RADIO_STREAM_URL
+
+        radio.stream_url = None
+        voice = getattr(radio, "voice", None)
+        if voice and (voice.is_playing() or voice.is_paused()):
+            voice.stop()
+
+        radio.voice = await ensure_voice(self.bot, RADIO_VC_ID, voice)
+        if radio.voice is None:
+            raise RuntimeError("Connexion vocale impossible")
+        return radio
+
+    async def _play_next(self) -> None:
+        async with self._play_lock:
+            if self.current is not None:
+                return
+            if not self.queue:
+                await self._restore_radio()
+                await self.refresh_panel()
+                return
+
+            track = self.queue.popleft()
+            self.current = track
+            self._generation += 1
+            generation = self._generation
+
+            try:
+                radio = await self._suspend_radio()
+                stream_url, headers = await self._resolve_stream(track)
+                voice = radio.voice
+                if voice and (voice.is_playing() or voice.is_paused()):
+                    voice.stop()
+
+                def after(error: Exception | None) -> None:
+                    asyncio.run_coroutine_threadsafe(
+                        self._handle_track_end(generation, error), self.bot.loop
+                    )
+
+                play_stream(voice, stream_url, after=after, headers=headers)
+                if not voice.is_playing() and not voice.is_paused():
+                    raise RuntimeError("Le lecteur audio n'a pas démarré")
+            except Exception:
+                logger.exception("[music2] lecture de %s impossible", track.webpage_url)
+                self.current = None
+                if self.queue:
+                    asyncio.create_task(self._play_next())
+                else:
+                    await self._restore_radio()
+
+        await self.refresh_panel()
+
+    async def _handle_track_end(
+        self, generation: int, error: Exception | None
+    ) -> None:
+        if generation != self._generation:
+            return
+        if error:
+            logger.warning("[music2] fin de piste avec erreur: %s", error)
+
+        radio = self._radio_cog()
+        # Pendant Music 2.0, RadioCog.stream_url reste à None. Si une station
+        # a été sélectionnée manuellement, RadioCog l'a déjà remise à une URL:
+        # la radio prend alors la main et la file à la demande est annulée.
+        if radio is not None and getattr(radio, "stream_url", None):
+            self.current = None
+            self.queue.clear()
+            self._radio_restore_stream = None
+            await self.refresh_panel()
+            return
+
+        self.current = None
+        await self._play_next()
+
+    async def _restore_radio(self) -> None:
+        radio = self._radio_cog()
+        if radio is None:
+            self._radio_restore_stream = None
+            return
+
+        stream_url = self._radio_restore_stream or RADIO_STREAM_URL
+        self._radio_restore_stream = None
+        radio.stream_url = stream_url
+        try:
+            await radio._connect_and_play()
+            channel = self.bot.get_channel(RADIO_VC_ID)
+            if isinstance(channel, discord.VoiceChannel):
+                await radio._rename_for_stream(channel, stream_url)
+        except Exception:
+            logger.exception("[music2] restauration de la radio impossible")
+
+    async def pause_resume(self, interaction: discord.Interaction) -> None:
+        if not await self.require_radio_listener(interaction):
+            return
+        if self.current is None:
+            await interaction.response.send_message(
+                "ℹ️ Aucune musique à la demande n'est en cours.", ephemeral=True
+            )
+            return
+        radio = self._radio_cog()
+        voice = getattr(radio, "voice", None) if radio else None
+        if voice is None:
+            await interaction.response.send_message(
+                "❌ Lecteur vocal indisponible.", ephemeral=True
+            )
+            return
+        if voice.is_paused():
+            voice.resume()
+            message = "▶️ Lecture reprise."
+        elif voice.is_playing():
+            voice.pause()
+            message = "⏸️ Lecture en pause."
+        else:
+            message = "ℹ️ Le titre n'est plus en lecture."
+        await interaction.response.send_message(message, ephemeral=True)
+        await self.refresh_panel()
+
+    async def skip(self, interaction: discord.Interaction) -> None:
+        if not await self.require_radio_listener(interaction):
+            return
+        if self.current is None:
+            await interaction.response.send_message(
+                "ℹ️ Aucune musique à passer.", ephemeral=True
+            )
+            return
+
+        self._generation += 1
+        self.current = None
+        radio = self._radio_cog()
+        voice = getattr(radio, "voice", None) if radio else None
+        if voice and (voice.is_playing() or voice.is_paused()):
+            voice.stop()
+        await interaction.response.send_message("⏭️ Titre passé.", ephemeral=True)
+        await self._play_next()
+
+    async def show_queue(self, interaction: discord.Interaction) -> None:
+        lines: list[str] = []
+        if self.current is not None:
+            lines.append(f"▶️ **{self.current.title}**")
+        for index, track in enumerate(list(self.queue)[:10], start=1):
+            lines.append(f"`{index}.` {track.title}")
+        if len(self.queue) > 10:
+            lines.append(f"… et {len(self.queue) - 10} autre(s).")
+        if not lines:
+            lines.append("La file est vide : la radio est en lecture.")
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+    async def show_now_playing(self, interaction: discord.Interaction) -> None:
+        if self.current is not None:
+            description = (
+                f"🎵 **{self.current.title}**\n"
+                f"{self._format_duration(self.current.duration)} · "
+                f"demandé par <@{self.current.requester_id}>"
+            )
+            if self.current.uploader:
+                description += f"\nArtiste/chaîne : {self.current.uploader}"
+        else:
+            radio = self._radio_cog()
+            stream_url = (
+                getattr(radio, "stream_url", RADIO_STREAM_URL)
+                if radio
+                else RADIO_STREAM_URL
+            )
+            description = f"📻 Radio **{self._station_label(stream_url)}**"
+        await interaction.response.send_message(description, ephemeral=True)
+
+
+async def setup(bot: commands.Bot) -> None:
+    cog = Music2Cog(bot)
+    await bot.add_cog(cog)
+    bot.add_view(cog.view)

--- a/cogs/music2.py
+++ b/cogs/music2.py
@@ -252,25 +252,24 @@ class Music2Cog(commands.Cog):
             )
         else:
             radio = self._radio_cog()
-            stream_url = (
-                getattr(radio, "stream_url", RADIO_STREAM_URL)
-                if radio
-                else RADIO_STREAM_URL
-            )
+            stream_url = getattr(radio, "stream_url", RADIO_STREAM_URL) if radio else RADIO_STREAM_URL
             embed.add_field(
                 name="Lecture en cours",
                 value=f"📻 Radio **{self._station_label(stream_url)}**",
                 inline=False,
             )
             embed.add_field(name="File d'attente", value="Vide", inline=True)
-        embed.set_footer(text="Ajoute un titre ou un lien depuis le bouton ➕ Ajouter.")
+        embed.set_footer(
+            text="Ajoute un titre ou un lien depuis le bouton ➕ Ajouter."
+        )
         return embed
 
     async def require_radio_listener(self, interaction: discord.Interaction) -> bool:
         member = interaction.user
         if not isinstance(member, discord.Member):
             await interaction.response.send_message(
-                "❌ Action disponible uniquement sur le serveur.", ephemeral=True
+                "❌ Action disponible uniquement sur le serveur.",
+                ephemeral=True,
             )
             return False
         voice = member.voice
@@ -338,6 +337,30 @@ class Music2Cog(commands.Cog):
     async def on_ready(self) -> None:
         await self._ensure_panel()
 
+    @commands.Cog.listener()
+    async def on_interaction(self, interaction: discord.Interaction) -> None:
+        """Keep the upgraded panel in sync when the legacy RadioView handles a click."""
+        data = interaction.data if isinstance(interaction.data, dict) else {}
+        custom_id = data.get("custom_id")
+        if (
+            interaction.channel_id != RADIO_TEXT_CHANNEL_ID
+            or custom_id
+            not in {"radio_rap_fr", "radio_rap", "radio_rock", "radio_hiphop"}
+        ):
+            return
+
+        # The legacy persistent RadioView is registered after extensions during
+        # setup_hook. Give its callback a short window to update RadioCog first.
+        await asyncio.sleep(0.25)
+        radio = self._radio_cog()
+        if self.current is not None and radio is not None:
+            if getattr(radio, "stream_url", None):
+                self._generation += 1
+                self.current = None
+                self.queue.clear()
+                self._radio_restore_stream = None
+        await self.refresh_panel()
+
     def _extract_info_sync(self, target: str) -> dict:
         is_url = urlparse(target).scheme in {"http", "https"}
         lookup = target if is_url else f"ytsearch1:{target}"
@@ -393,13 +416,15 @@ class Music2Cog(commands.Cog):
         member = interaction.user
         if not isinstance(member, discord.Member):
             await interaction.response.send_message(
-                "❌ Action disponible uniquement sur le serveur.", ephemeral=True
+                "❌ Action disponible uniquement sur le serveur.",
+                ephemeral=True,
             )
             return
         voice = member.voice
         if voice is None or voice.channel is None or voice.channel.id != RADIO_VC_ID:
             await interaction.response.send_message(
-                f"❌ Rejoins d'abord <#{RADIO_VC_ID}>.", ephemeral=True
+                f"❌ Rejoins d'abord <#{RADIO_VC_ID}>.",
+                ephemeral=True,
             )
             return
 
@@ -410,7 +435,8 @@ class Music2Cog(commands.Cog):
         except Exception as exc:
             logger.warning("[music2] recherche impossible: %s", exc)
             await interaction.followup.send(
-                "❌ Impossible de trouver ou lire ce titre.", ephemeral=True
+                "❌ Impossible de trouver ou lire ce titre.",
+                ephemeral=True,
             )
             return
 
@@ -449,7 +475,7 @@ class Music2Cog(commands.Cog):
             ) + "\r\n"
         return stream_url, headers
 
-    async def _suspend_radio(self):
+    async def _suspend_radio(self) -> object:
         radio = self._radio_cog()
         if radio is None:
             raise RuntimeError("RadioCog indisponible")
@@ -491,7 +517,8 @@ class Music2Cog(commands.Cog):
 
                 def after(error: Exception | None) -> None:
                     asyncio.run_coroutine_threadsafe(
-                        self._handle_track_end(generation, error), self.bot.loop
+                        self._handle_track_end(generation, error),
+                        self.bot.loop,
                     )
 
                 play_stream(voice, stream_url, after=after, headers=headers)
@@ -551,14 +578,16 @@ class Music2Cog(commands.Cog):
             return
         if self.current is None:
             await interaction.response.send_message(
-                "ℹ️ Aucune musique à la demande n'est en cours.", ephemeral=True
+                "ℹ️ Aucune musique à la demande n'est en cours.",
+                ephemeral=True,
             )
             return
         radio = self._radio_cog()
         voice = getattr(radio, "voice", None) if radio else None
         if voice is None:
             await interaction.response.send_message(
-                "❌ Lecteur vocal indisponible.", ephemeral=True
+                "❌ Lecteur vocal indisponible.",
+                ephemeral=True,
             )
             return
         if voice.is_paused():
@@ -577,7 +606,8 @@ class Music2Cog(commands.Cog):
             return
         if self.current is None:
             await interaction.response.send_message(
-                "ℹ️ Aucune musique à passer.", ephemeral=True
+                "ℹ️ Aucune musique à passer.",
+                ephemeral=True,
             )
             return
 
@@ -600,7 +630,10 @@ class Music2Cog(commands.Cog):
             lines.append(f"… et {len(self.queue) - 10} autre(s).")
         if not lines:
             lines.append("La file est vide : la radio est en lecture.")
-        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+        await interaction.response.send_message(
+            "\n".join(lines),
+            ephemeral=True,
+        )
 
     async def show_now_playing(self, interaction: discord.Interaction) -> None:
         if self.current is not None:
@@ -613,11 +646,7 @@ class Music2Cog(commands.Cog):
                 description += f"\nArtiste/chaîne : {self.current.uploader}"
         else:
             radio = self._radio_cog()
-            stream_url = (
-                getattr(radio, "stream_url", RADIO_STREAM_URL)
-                if radio
-                else RADIO_STREAM_URL
-            )
+            stream_url = getattr(radio, "stream_url", RADIO_STREAM_URL) if radio else RADIO_STREAM_URL
             description = f"📻 Radio **{self._station_label(stream_url)}**"
         await interaction.response.send_message(description, ephemeral=True)
 

--- a/tests/test_music2.py
+++ b/tests/test_music2.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cogs.music2 as music2
+
+
+class DummyBot:
+    def __init__(self, radio=None) -> None:
+        self.radio = radio
+        self.loop = None
+
+    def get_cog(self, name: str):
+        return self.radio if name == "RadioCog" else None
+
+    def get_channel(self, _channel_id: int):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_music2_view_keeps_existing_radio_buttons_and_adds_music_controls():
+    cog = music2.Music2Cog(DummyBot())
+
+    custom_ids = {
+        item.custom_id for item in cog.view.children if getattr(item, "custom_id", None)
+    }
+
+    assert {
+        "radio_rap_fr",
+        "radio_rap",
+        "radio_rock",
+        "radio_hiphop",
+    }.issubset(custom_ids)
+    assert {
+        "music2_add",
+        "music2_pause_resume",
+        "music2_next",
+        "music2_queue",
+        "music2_now_playing",
+    }.issubset(custom_ids)
+
+
+@pytest.mark.asyncio
+async def test_idle_panel_reports_current_radio_station():
+    radio = SimpleNamespace(stream_url=music2.ROCK_RADIO_STREAM_URL)
+    cog = music2.Music2Cog(DummyBot(radio))
+
+    embed = cog.build_panel_embed()
+
+    assert embed.title == "🎵 Refuge Music 2.0"
+    assert "Radio **Rock**" in embed.fields[0].value
+    assert embed.fields[1].value == "Vide"
+
+
+@pytest.mark.asyncio
+async def test_panel_reports_current_track_and_queue_size():
+    cog = music2.Music2Cog(DummyBot())
+    cog.current = music2.MusicTrack(
+        title="One More Time",
+        webpage_url="https://example.test/current",
+        requester_id=42,
+        duration=320,
+    )
+    cog.queue.append(
+        music2.MusicTrack(
+            title="Around the World",
+            webpage_url="https://example.test/next",
+            requester_id=43,
+        )
+    )
+
+    embed = cog.build_panel_embed()
+
+    assert "One More Time" in embed.fields[0].value
+    assert "5:20" in embed.fields[0].value
+    assert embed.fields[1].value == "1 titre(s)"
+
+
+def test_track_from_info_keeps_stable_webpage_url_and_metadata():
+    cog = music2.Music2Cog(DummyBot())
+
+    track = cog._track_from_info(
+        {
+            "title": "Test Song",
+            "webpage_url": "https://example.test/watch/123",
+            "url": "https://cdn.example.test/temporary-stream",
+            "duration": 185,
+            "uploader": "Artist",
+        },
+        requester_id=99,
+    )
+
+    assert track.title == "Test Song"
+    assert track.webpage_url == "https://example.test/watch/123"
+    assert track.duration == 185
+    assert track.uploader == "Artist"
+    assert track.requester_id == 99
+
+
+def test_search_query_is_resolved_with_ytsearch1(monkeypatch):
+    captured = {}
+
+    class FakeYoutubeDL:
+        def __init__(self, options):
+            captured["options"] = options
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def extract_info(self, target, download=False):
+            captured["target"] = target
+            captured["download"] = download
+            return {
+                "entries": [
+                    {
+                        "title": "Found",
+                        "webpage_url": "https://example.test/found",
+                        "url": "https://cdn.example.test/found",
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(music2.yt_dlp, "YoutubeDL", FakeYoutubeDL)
+    cog = music2.Music2Cog(DummyBot())
+
+    result = cog._extract_info_sync("daft punk one more time")
+
+    assert captured["target"] == "ytsearch1:daft punk one more time"
+    assert captured["download"] is False
+    assert captured["options"]["format"] == "bestaudio/best"
+    assert result["title"] == "Found"
+
+
+@pytest.mark.asyncio
+async def test_manual_radio_takeover_cancels_on_demand_queue():
+    radio = SimpleNamespace(stream_url=music2.RADIO_RAP_STREAM_URL)
+    cog = music2.Music2Cog(DummyBot(radio))
+    cog.current = music2.MusicTrack(
+        title="Current",
+        webpage_url="https://example.test/current",
+        requester_id=1,
+    )
+    cog.queue.append(
+        music2.MusicTrack(
+            title="Queued",
+            webpage_url="https://example.test/queued",
+            requester_id=2,
+        )
+    )
+    cog._radio_restore_stream = music2.RADIO_STREAM_URL
+    cog._generation = 7
+    cog.refresh_panel = AsyncMock()
+
+    await cog._handle_track_end(7, None)
+
+    assert cog.current is None
+    assert list(cog.queue) == []
+    assert cog._radio_restore_stream is None
+    cog.refresh_panel.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_natural_track_end_advances_queue_when_radio_is_suspended():
+    radio = SimpleNamespace(stream_url=None)
+    cog = music2.Music2Cog(DummyBot(radio))
+    cog.current = music2.MusicTrack(
+        title="Current",
+        webpage_url="https://example.test/current",
+        requester_id=1,
+    )
+    cog._generation = 3
+    cog._play_next = AsyncMock()
+
+    await cog._handle_track_end(3, None)
+
+    assert cog.current is None
+    cog._play_next.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stale_audio_callback_is_ignored():
+    radio = SimpleNamespace(stream_url=None)
+    cog = music2.Music2Cog(DummyBot(radio))
+    current = music2.MusicTrack(
+        title="Current",
+        webpage_url="https://example.test/current",
+        requester_id=1,
+    )
+    cog.current = current
+    cog._generation = 10
+    cog._play_next = AsyncMock()
+
+    await cog._handle_track_end(9, None)
+
+    assert cog.current is current
+    cog._play_next.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_restore_radio_uses_station_active_before_music():
+    radio = SimpleNamespace(
+        stream_url=None,
+        _connect_and_play=AsyncMock(),
+        _rename_for_stream=AsyncMock(),
+    )
+    cog = music2.Music2Cog(DummyBot(radio))
+    cog._radio_restore_stream = music2.ROCK_RADIO_STREAM_URL
+
+    await cog._restore_radio()
+
+    assert radio.stream_url == music2.ROCK_RADIO_STREAM_URL
+    assert cog._radio_restore_stream is None
+    radio._connect_and_play.assert_awaited_once()


### PR DESCRIPTION
## Objectif
Faire évoluer le panneau radio existant du salon texte `1409333722754580571` vers **Refuge Music 2.0**, sans remplacer le moteur radio actuel ni migrer vers Lavalink.

## Compatibilité conservée
- salon texte inchangé : `RADIO_TEXT_CHANNEL_ID = 1409333722754580571` ;
- salon vocal inchangé : `RADIO_VC_ID = 1405695147114758245` ;
- stations Rap FR / Rap US / Rock / Hip-Hop conservées ;
- `cogs/radio.py`, `view.py`, `config.py` et les URLs radio ne sont pas modifiés ;
- le message radio existant est réutilisé et transformé en panneau Music 2.0 ;
- le chargeur dynamique existant découvre automatiquement `cogs/music2.py`.

## Fonctionnalités V1
- affichage de la lecture en cours ;
- recherche par titre ou ajout par URL via `yt-dlp` ;
- file d'attente ;
- pause / reprise ;
- morceau suivant ;
- consultation de la file ;
- consultation du titre en cours ;
- seuls les membres présents dans le vocal radio peuvent modifier la lecture à la demande.

## Interaction avec la radio
Lorsqu'un titre à la demande démarre :
1. la station active est mémorisée ;
2. le flux radio est suspendu ;
3. la musique demandée est jouée dans le même vocal ;
4. les titres suivants sont lus dans l'ordre ;
5. lorsque la file devient vide, la station précédemment active reprend automatiquement.

Si un utilisateur sélectionne manuellement une station pendant une musique à la demande, la radio reprend immédiatement la main et la file à la demande est annulée afin d'éviter deux systèmes concurrents.

## Robustesse
- extraction `yt-dlp` exécutée hors de la boucle asyncio avec `asyncio.to_thread` ;
- URL média réextraite au moment de la lecture pour éviter de conserver un flux temporaire expiré ;
- génération de lecture pour ignorer les callbacks audio obsolètes lors d'un skip ou d'un changement manuel de station ;
- compatibilité avec l'ancien `RadioView` persistant, qui est réenregistré après les extensions ;
- le panneau reste synchronisé même si Discord route un clic radio vers l'ancien handler.

## Tests ajoutés
Couverture de :
- conservation des quatre boutons radio ;
- présence des cinq nouveaux contrôles Music 2.0 ;
- affichage radio / morceau en cours ;
- métadonnées de piste ;
- recherche `ytsearch1` ;
- annulation de la queue lors d'une reprise radio manuelle ;
- passage naturel au titre suivant ;
- rejet des callbacks audio obsolètes ;
- restauration de la station précédente.

## Validation
La syntaxe de `cogs/music2.py` a été vérifiée avant publication. Un clone local du dépôt a ensuite été tenté pour lancer `pytest`, mais le runtime ChatGPT ne résout actuellement pas `github.com` (`Could not resolve host: github.com`). La suite pytest réelle n'est donc pas déclarée comme passée.

La PR reste en **draft** jusqu'à validation / décision de fusion.