### PR TITLE
fix: restore YouTube extraction for Music 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,16 @@ RUN apt-get update && \
     ffmpeg \
     libjpeg-dev \
     zlib1g-dev \
+    curl \
+    ca-certificates \
+    unzip \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# yt-dlp requiert désormais un runtime JavaScript externe pour une prise en
+# charge complète de YouTube. Deno est le runtime recommandé et activé par
+# défaut par yt-dlp.
+RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh && \
+    deno --version
 
 # Répertoire de travail dans le conteneur
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 discord.py[voice]>=2.7,<3
 python-dotenv>=1.0,<2
 Pillow>=10.0,<13
-yt-dlp>=2024.7.1
+yt-dlp[default]>=2025.11.12
 imageio-ffmpeg>=0.4,<1
 aiohttp>=3.8,<4


### PR DESCRIPTION
## Problème observé
Le bouton **➕ Ajouter** de Music 2.0 retourne `❌ Impossible de trouver ou lire ce titre.` lors d'une recherche YouTube.

## Cause
Music 2.0 utilise `yt-dlp`, mais l'image de production installait seulement `yt-dlp>=2024.7.1` et ne fournissait aucun runtime JavaScript externe.

Depuis yt-dlp 2025.11.12, la prise en charge complète de YouTube nécessite :
- un runtime JavaScript externe ;
- les scripts EJS de résolution des challenges YouTube.

Le dépôt officiel recommande Deno et, pour une installation PyPI, `yt-dlp[default]` afin d'installer `yt-dlp-ejs`.

## Correction
- `requirements.txt` : remplacement de `yt-dlp>=2024.7.1` par `yt-dlp[default]>=2025.11.12` ;
- `Dockerfile` : installation de `curl`, `ca-certificates`, `unzip` ;
- installation de Deno dans `/usr/local` via le script officiel ;
- vérification de `deno --version` pendant le build.

## Périmètre
Aucun changement dans :
- `cogs/music2.py` ;
- `cogs/radio.py` ;
- le panneau Discord ;
- les stations radio ;
- la file d'attente ;
- les salons configurés.

La correction concerne uniquement l'environnement nécessaire à l'extraction YouTube.

## Validation
Les prérequis ont été vérifiés dans la documentation officielle actuelle de yt-dlp : Deno est recommandé et activé par défaut ; le package PyPI `yt-dlp[default]` installe le composant `yt-dlp-ejs`.

La PR reste en draft jusqu'à décision de fusion et redéploiement du conteneur.