### PR TITLE
fix: stabilize YouTube on-demand playback

### DIFF
--- a/tests/test_voice_stream_profiles.py
+++ b/tests/test_voice_stream_profiles.py
@@ -1,0 +1,74 @@
+from unittest.mock import Mock
+
+import utils.voice as voice_utils
+from utils.audio import (
+    FFMPEG_BEFORE,
+    FFMPEG_OPTIONS,
+    FFMPEG_VOD_BEFORE,
+    FFMPEG_VOD_OPTIONS,
+)
+
+
+class DummyVoice:
+    def __init__(self) -> None:
+        self.played = None
+
+    def is_playing(self) -> bool:
+        return False
+
+    def play(self, source, after=None) -> None:
+        self.played = (source, after)
+
+
+def test_radio_stream_keeps_low_latency_profile(monkeypatch):
+    captured = {}
+
+    def fake_ffmpeg(source, *, before_options, options):
+        captured.update(
+            source=source,
+            before_options=before_options,
+            options=options,
+        )
+        return object()
+
+    monkeypatch.setattr(voice_utils.shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(voice_utils.discord, "FFmpegPCMAudio", fake_ffmpeg)
+
+    voice = DummyVoice()
+    voice_utils.play_stream(voice, "https://radio.example/live")
+
+    assert captured["before_options"] == FFMPEG_BEFORE
+    assert captured["options"] == FFMPEG_OPTIONS
+    assert "nobuffer" in captured["before_options"]
+    assert "reconnect_streamed" not in captured["before_options"]
+
+
+def test_on_demand_stream_uses_buffered_reconnect_profile(monkeypatch):
+    captured = {}
+
+    def fake_ffmpeg(source, *, before_options, options):
+        captured.update(
+            source=source,
+            before_options=before_options,
+            options=options,
+        )
+        return object()
+
+    monkeypatch.setattr(voice_utils.shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(voice_utils.discord, "FFmpegPCMAudio", fake_ffmpeg)
+
+    voice = DummyVoice()
+    voice_utils.play_stream(
+        voice,
+        "https://youtube.example/audio",
+        headers="User-Agent: yt-dlp\r\nReferer: https://youtube.com/\r\n",
+    )
+
+    assert captured["options"] == FFMPEG_VOD_OPTIONS
+    assert FFMPEG_VOD_BEFORE in captured["before_options"]
+    assert "reconnect_on_network_error 1" in captured["before_options"]
+    assert "reconnect_on_http_error 4xx,5xx" in captured["before_options"]
+    assert "reconnect_streamed 1" in captured["before_options"]
+    assert "thread_queue_size 4096" in captured["before_options"]
+    assert "nobuffer" not in captured["before_options"]
+    assert "User-Agent: yt-dlp" in captured["before_options"]

--- a/tests/test_voice_stream_profiles.py
+++ b/tests/test_voice_stream_profiles.py
@@ -1,5 +1,3 @@
-from unittest.mock import Mock
-
 import utils.voice as voice_utils
 from utils.audio import (
     FFMPEG_BEFORE,

--- a/utils/audio.py
+++ b/utils/audio.py
@@ -1,5 +1,18 @@
 """Audio-related constants and utilities."""
 
-# Common FFmpeg options for audio streaming
+# Profil historique pour les radios live : latence faible, tampon minimal.
 FFMPEG_BEFORE = "-fflags nobuffer -probesize 32k"
 FFMPEG_OPTIONS = "-filter:a loudnorm"
+
+# Profil dédié aux morceaux à la demande (YouTube/yt-dlp).
+# Contrairement aux radios live, on conserve le buffering normal de FFmpeg et
+# on autorise les reconnexions HTTP afin d'absorber les variations réseau sans
+# provoquer de coupures audibles dans Discord.
+FFMPEG_VOD_BEFORE = (
+    "-reconnect_on_network_error 1 "
+    "-reconnect_on_http_error 4xx,5xx "
+    "-reconnect_streamed 1 "
+    "-reconnect_delay_max 5 "
+    "-thread_queue_size 4096"
+)
+FFMPEG_VOD_OPTIONS = "-vn"

--- a/utils/voice.py
+++ b/utils/voice.py
@@ -5,7 +5,12 @@ from typing import Callable, Optional
 
 import discord
 
-from utils.audio import FFMPEG_BEFORE, FFMPEG_OPTIONS
+from utils.audio import (
+    FFMPEG_BEFORE,
+    FFMPEG_OPTIONS,
+    FFMPEG_VOD_BEFORE,
+    FFMPEG_VOD_OPTIONS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -78,16 +83,28 @@ def play_stream(
     after: Optional[Callable[[Optional[Exception]], None]] = None,
     headers: Optional[str] = None,
 ) -> None:
-    """Lance la lecture du flux ``stream_url`` si rien n'est joué."""
+    """Lance la lecture du flux ``stream_url`` si rien n'est joué.
+
+    Les radios live conservent le profil faible latence historique. Les flux
+    à la demande résolus par yt-dlp fournissent des en-têtes HTTP ; ils utilisent
+    alors un profil FFmpeg séparé avec buffering normal et reconnexion réseau.
+    """
     if voice and not voice.is_playing():
         if shutil.which("ffmpeg") is None:
             logger.warning("FFmpeg introuvable: impossible de lire le flux %s", stream_url)
             return
-        before_options = FFMPEG_BEFORE
+
         header_value = headers.strip() if headers else ""
+        is_on_demand = bool(header_value)
+        before_options = FFMPEG_VOD_BEFORE if is_on_demand else FFMPEG_BEFORE
+        ffmpeg_options = FFMPEG_VOD_OPTIONS if is_on_demand else FFMPEG_OPTIONS
+
         if header_value:
             before_options = f"{before_options} -headers {shlex.quote(header_value)}"
+
         source = discord.FFmpegPCMAudio(
-            stream_url, before_options=before_options, options=FFMPEG_OPTIONS
+            stream_url,
+            before_options=before_options,
+            options=ffmpeg_options,
         )
         voice.play(source, after=after)


### PR DESCRIPTION
## Problème observé
Les morceaux ajoutés via un lien YouTube dans **Musique personnalisée** peuvent saccader pendant la lecture.

## Cause identifiée
Le helper audio utilisait pour tous les flux le même profil FFmpeg que la radio live : `-fflags nobuffer -probesize 32k` avec `loudnorm`.

Ce profil réduit volontairement le buffering. Il convient à une radio live à faible latence, mais il rend un flux YouTube à la demande beaucoup plus sensible aux variations réseau.

## Correction
- conservation du profil FFmpeg historique pour les stations radio ;
- ajout d'un profil séparé pour les flux à la demande identifiés par les en-têtes HTTP fournis par `yt-dlp` ;
- suppression de `nobuffer` pour ces morceaux ;
- activation de la reconnexion FFmpeg en cas d'erreur réseau ou HTTP ;
- `reconnect_streamed=1`, délai maximum de reconnexion de 5 s ;
- augmentation de la file d'entrée FFmpeg avec `thread_queue_size 4096` ;
- suppression de `loudnorm` sur la lecture à la demande pour réduire le traitement inutile.

## Compatibilité
Aucun changement dans :
- les boutons radio ;
- les deux panneaux séparés ;
- la queue Music 2.0 ;
- le mécanisme pause/suivant ;
- la restauration automatique de la radio ;
- les URLs de stations.

## Tests
Ajout de tests garantissant que :
1. une radio continue d'utiliser le profil faible latence historique ;
2. un flux à la demande avec headers `yt-dlp` utilise bien le profil bufferisé/reconnectable et n'emploie plus `nobuffer`.

La branche est basée sur le `main` incluant les PR #538 et #539.