### PR TITLE
feat: rename music voice channel from current artist

### DIFF
--- a/cogs/music2_dynamic_rename.py
+++ b/cogs/music2_dynamic_rename.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import re
+
+import discord
+from discord.ext import commands, tasks
+
+from config import RADIO_VC_ID
+from utils.rename_manager import rename_manager
+
+
+_RECORDING_PREFIX = "🔴・"
+_TOPIC_SUFFIX_RE = re.compile(r"\s*-\s*topic\s*$", re.IGNORECASE)
+_VEVO_SUFFIX_RE = re.compile(r"\s*vevo\s*$", re.IGNORECASE)
+_TITLE_SEPARATORS = (" - ", " – ", " — ")
+
+
+class Music2DynamicRenameCog(commands.Cog):
+    """Rename the shared radio voice channel while custom music is playing."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._last_requested_name: str | None = None
+
+    async def cog_load(self) -> None:
+        self.sync_name.start()
+
+    def cog_unload(self) -> None:
+        self.sync_name.cancel()
+
+    @staticmethod
+    def _clean_artist(value: str | None) -> str:
+        if not value:
+            return ""
+        artist = " ".join(str(value).split()).strip()
+        artist = _TOPIC_SUFFIX_RE.sub("", artist).strip()
+        artist = _VEVO_SUFFIX_RE.sub("", artist).strip()
+        return artist
+
+    @classmethod
+    def _artist_for_track(cls, track: object) -> str:
+        uploader = cls._clean_artist(getattr(track, "uploader", None))
+        if uploader:
+            return uploader
+
+        title = " ".join(str(getattr(track, "title", "") or "").split()).strip()
+        for separator in _TITLE_SEPARATORS:
+            if separator in title:
+                candidate = cls._clean_artist(title.split(separator, 1)[0])
+                if candidate:
+                    return candidate
+        return title or "Musique"
+
+    @classmethod
+    def _channel_name_for_track(cls, track: object) -> str:
+        artist = cls._artist_for_track(track)
+        max_artist_length = 100 - len(_RECORDING_PREFIX)
+        return f"{_RECORDING_PREFIX}{artist[:max_artist_length]}"
+
+    async def _sync_current_track_name(self) -> None:
+        music = self.bot.get_cog("Music2Cog")
+        radio = self.bot.get_cog("RadioCog")
+        if music is None or radio is None:
+            self._last_requested_name = None
+            return
+
+        track = getattr(music, "current", None)
+        if track is None or getattr(radio, "stream_url", None) is not None:
+            self._last_requested_name = None
+            return
+
+        voice = getattr(radio, "voice", None)
+        if voice is None or not (voice.is_playing() or voice.is_paused()):
+            return
+
+        channel = self.bot.get_channel(RADIO_VC_ID)
+        if not isinstance(channel, discord.VoiceChannel):
+            return
+
+        new_name = self._channel_name_for_track(track)
+        if new_name == self._last_requested_name and channel.name == new_name:
+            return
+
+        self._last_requested_name = new_name
+        await rename_manager.request(channel, new_name)
+
+    @tasks.loop(seconds=1.0)
+    async def sync_name(self) -> None:
+        await self._sync_current_track_name()
+
+    @sync_name.before_loop
+    async def before_sync_name(self) -> None:
+        await self.bot.wait_until_ready()
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Music2DynamicRenameCog(bot))

--- a/tests/test_music2_dynamic_rename.py
+++ b/tests/test_music2_dynamic_rename.py
@@ -1,0 +1,111 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import cogs.music2_dynamic_rename as dynamic_rename
+
+
+class DummyVoice:
+    def __init__(self, playing: bool = True, paused: bool = False) -> None:
+        self._playing = playing
+        self._paused = paused
+
+    def is_playing(self) -> bool:
+        return self._playing
+
+    def is_paused(self) -> bool:
+        return self._paused
+
+
+class DummyChannel:
+    def __init__(self, name: str = "📻・Radio-HipHop") -> None:
+        self.name = name
+        self.id = dynamic_rename.RADIO_VC_ID
+
+
+class DummyBot:
+    def __init__(self, *, music=None, radio=None, channel=None) -> None:
+        self.music = music
+        self.radio = radio
+        self.channel = channel
+
+    def get_cog(self, name: str):
+        if name == "Music2Cog":
+            return self.music
+        if name == "RadioCog":
+            return self.radio
+        return None
+
+    def get_channel(self, channel_id: int):
+        if channel_id == dynamic_rename.RADIO_VC_ID:
+            return self.channel
+        return None
+
+
+@pytest.mark.parametrize(
+    ("uploader", "expected"),
+    [
+        ("La Fouine - Topic", "La Fouine"),
+        ("StromaeVEVO", "Stromae"),
+        ("  Ninho   ", "Ninho"),
+    ],
+)
+def test_clean_artist_removes_youtube_channel_suffixes(uploader, expected):
+    assert dynamic_rename.Music2DynamicRenameCog._clean_artist(uploader) == expected
+
+
+def test_artist_falls_back_to_title_prefix():
+    track = SimpleNamespace(uploader=None, title="La Fouine - Du Ferme")
+
+    artist = dynamic_rename.Music2DynamicRenameCog._artist_for_track(track)
+
+    assert artist == "La Fouine"
+
+
+def test_channel_name_uses_recording_dot_and_stays_within_discord_limit():
+    track = SimpleNamespace(uploader="A" * 150, title="Ignored")
+
+    name = dynamic_rename.Music2DynamicRenameCog._channel_name_for_track(track)
+
+    assert name.startswith("🔴・")
+    assert len(name) == 100
+
+
+@pytest.mark.asyncio
+async def test_active_custom_track_requests_dynamic_channel_name(monkeypatch):
+    track = SimpleNamespace(uploader="La Fouine - Topic", title="Du Ferme")
+    music = SimpleNamespace(current=track)
+    radio = SimpleNamespace(stream_url=None, voice=DummyVoice(playing=True))
+    channel = DummyChannel()
+    bot = DummyBot(music=music, radio=radio, channel=channel)
+    cog = dynamic_rename.Music2DynamicRenameCog(bot)
+
+    request = AsyncMock()
+    monkeypatch.setattr(dynamic_rename.discord, "VoiceChannel", DummyChannel)
+    monkeypatch.setattr(dynamic_rename.rename_manager, "request", request)
+
+    await cog._sync_current_track_name()
+
+    request.assert_awaited_once_with(channel, "🔴・La Fouine")
+
+
+@pytest.mark.asyncio
+async def test_radio_mode_does_not_override_existing_station_name(monkeypatch):
+    track = SimpleNamespace(uploader="La Fouine", title="Du Ferme")
+    music = SimpleNamespace(current=track)
+    radio = SimpleNamespace(
+        stream_url="https://radio.example/live",
+        voice=DummyVoice(playing=True),
+    )
+    channel = DummyChannel("🟣・Radio-Rap-FR")
+    bot = DummyBot(music=music, radio=radio, channel=channel)
+    cog = dynamic_rename.Music2DynamicRenameCog(bot)
+
+    request = AsyncMock()
+    monkeypatch.setattr(dynamic_rename.discord, "VoiceChannel", DummyChannel)
+    monkeypatch.setattr(dynamic_rename.rename_manager, "request", request)
+
+    await cog._sync_current_track_name()
+
+    request.assert_not_awaited()


### PR DESCRIPTION
## Objectif
Faire évoluer automatiquement le nom du salon vocal radio/musique lorsqu'une piste personnalisée est en cours, tout en conservant les renames radio existants au repos.

## Comportement
- radio seule : aucun changement, les noms existants restent utilisés (`🟣・Radio-Rap-FR`, `🔘・Radio-Rap-US`, `☢️・Radio-Rock`, `📻・Radio-HipHop`) ;
- musique personnalisée en cours : le salon prend temporairement la forme `🔴・Artiste` ;
- exemple : `La Fouine - Topic` devient `🔴・La Fouine` ;
- si l'uploader/artiste n'est pas disponible, fallback sur la partie artiste du titre (`La Fouine - Du Ferme` → `La Fouine`) ;
- le nom respecte la limite Discord de 100 caractères ;
- à la fin de la file, Music 2.0 continue d'utiliser sa restauration radio existante, qui remet automatiquement le nom correspondant à la station précédente.

## Implémentation
Ajout d'un cog séparé `music2_dynamic_rename.py` qui :
- surveille la piste active ;
- ne renomme que lorsque `Music2Cog.current` existe, que `RadioCog.stream_url` est suspendu et que l'audio personnalisé joue réellement ;
- utilise le `rename_manager` existant pour conserver debounce, anti-spam et retries ;
- ne modifie pas `cogs/music2.py` ni `cogs/radio.py`.

## Tests ajoutés
- nettoyage des suffixes YouTube `- Topic` et `VEVO` ;
- fallback artiste depuis le titre ;
- limite de 100 caractères ;
- demande de rename `🔴・La Fouine` pendant une piste personnalisée ;
- absence de rename lorsque la radio est active.

La branche est basée sur le `main` contenant déjà la stabilisation YouTube de la PR #540.