### PR TITLE
fix: restore Music 2.0 YouTube extraction

### DIFF
--- a/cogs/music2_youtube_fallback.py
+++ b/cogs/music2_youtube_fallback.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+from urllib.parse import urlparse
+
+import yt_dlp
+from discord.ext import commands
+
+
+logger = logging.getLogger(__name__)
+
+
+_YOUTUBE_HOSTS = {
+    "youtube.com",
+    "www.youtube.com",
+    "m.youtube.com",
+    "music.youtube.com",
+    "youtu.be",
+}
+_FALLBACK_PLAYER_CLIENTS = ["android_vr", "web_embedded"]
+
+
+def _is_youtube_target(target: str) -> bool:
+    parsed = urlparse(target)
+    if parsed.scheme not in {"http", "https"}:
+        # Music2 resolves plain text through ytsearch1, so a non-URL target is
+        # necessarily a YouTube search in the current implementation.
+        return True
+    return (parsed.hostname or "").lower() in _YOUTUBE_HOSTS
+
+
+def _extract_with_youtube_fallback(target: str) -> dict[str, Any]:
+    is_url = urlparse(target).scheme in {"http", "https"}
+    lookup = target if is_url else f"ytsearch1:{target}"
+    options: dict[str, Any] = {
+        "format": "bestaudio/best",
+        "quiet": True,
+        "no_warnings": True,
+        "noplaylist": True,
+        "skip_download": True,
+        "extractor_args": {
+            "youtube": {
+                "player_client": list(_FALLBACK_PLAYER_CLIENTS),
+            }
+        },
+    }
+
+    with yt_dlp.YoutubeDL(options) as ydl:
+        info = ydl.extract_info(lookup, download=False)
+        if info is None:
+            raise RuntimeError("Aucun résultat")
+        entries = info.get("entries") if hasattr(info, "get") else None
+        if entries is not None:
+            info = next((entry for entry in entries if entry), None)
+        if info is None or not hasattr(info, "get"):
+            raise RuntimeError("Aucun résultat exploitable")
+        return dict(info)
+
+
+class Music2YoutubeFallbackCog(commands.Cog):
+    """Retry failed Music2 YouTube extraction with resilient player clients."""
+
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+        self._music: Any | None = None
+        self._original_extract: Callable[[str], dict[str, Any]] | None = None
+        self._wrapped_extract: Callable[[str], dict[str, Any]] | None = None
+
+    async def cog_load(self) -> None:
+        self._install_if_possible()
+
+    def cog_unload(self) -> None:
+        self._restore_original()
+
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
+        self._install_if_possible()
+
+    def _install_if_possible(self) -> bool:
+        music = self.bot.get_cog("Music2Cog")
+        if music is None:
+            return False
+
+        current = getattr(music, "_extract_info_sync", None)
+        if not callable(current):
+            logger.warning("[music2-fallback] extracteur Music2 introuvable")
+            return False
+
+        if music is self._music and current is self._wrapped_extract:
+            return True
+
+        # If a Music2Cog instance was replaced during an extension reload,
+        # restore the previous instance before wrapping the new one.
+        self._restore_original()
+        original = current
+
+        def wrapped(target: str) -> dict[str, Any]:
+            try:
+                return original(target)
+            except Exception as first_error:
+                if not _is_youtube_target(target):
+                    raise
+                logger.warning(
+                    "[music2-fallback] extraction standard échouée (%s); "
+                    "nouvelle tentative via %s",
+                    first_error,
+                    ", ".join(_FALLBACK_PLAYER_CLIENTS),
+                )
+                try:
+                    return _extract_with_youtube_fallback(target)
+                except Exception as fallback_error:
+                    logger.warning(
+                        "[music2-fallback] extraction de secours échouée: %s",
+                        fallback_error,
+                    )
+                    raise fallback_error from first_error
+
+        music._extract_info_sync = wrapped
+        self._music = music
+        self._original_extract = original
+        self._wrapped_extract = wrapped
+        logger.info(
+            "[music2-fallback] fallback YouTube actif (%s)",
+            ", ".join(_FALLBACK_PLAYER_CLIENTS),
+        )
+        return True
+
+    def _restore_original(self) -> None:
+        if self._music is not None and self._original_extract is not None:
+            current = getattr(self._music, "_extract_info_sync", None)
+            if current is self._wrapped_extract:
+                self._music._extract_info_sync = self._original_extract
+        self._music = None
+        self._original_extract = None
+        self._wrapped_extract = None
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(Music2YoutubeFallbackCog(bot))

--- a/tests/test_music2_youtube_fallback.py
+++ b/tests/test_music2_youtube_fallback.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import cogs.music2_youtube_fallback as fallback
+
+
+class DummyBot:
+    def __init__(self, music=None) -> None:
+        self.music = music
+
+    def get_cog(self, name: str):
+        return self.music if name == "Music2Cog" else None
+
+
+def test_is_youtube_target_accepts_search_and_youtube_urls() -> None:
+    assert fallback._is_youtube_target("daft punk one more time") is True
+    assert fallback._is_youtube_target("https://www.youtube.com/watch?v=abc") is True
+    assert fallback._is_youtube_target("https://youtu.be/abc") is True
+    assert fallback._is_youtube_target("https://example.com/audio.mp3") is False
+
+
+def test_fallback_uses_resilient_youtube_player_clients(monkeypatch) -> None:
+    captured = {}
+
+    class FakeYoutubeDL:
+        def __init__(self, options):
+            captured["options"] = options
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def extract_info(self, target, download=False):
+            captured["target"] = target
+            captured["download"] = download
+            return {
+                "entries": [
+                    {
+                        "title": "Found",
+                        "webpage_url": "https://www.youtube.com/watch?v=abc",
+                        "url": "https://cdn.example.test/audio",
+                    }
+                ]
+            }
+
+    monkeypatch.setattr(fallback.yt_dlp, "YoutubeDL", FakeYoutubeDL)
+
+    info = fallback._extract_with_youtube_fallback("daft punk one more time")
+
+    assert captured["target"] == "ytsearch1:daft punk one more time"
+    assert captured["download"] is False
+    assert captured["options"]["format"] == "bestaudio/best"
+    assert captured["options"]["extractor_args"]["youtube"]["player_client"] == [
+        "android_vr",
+        "web_embedded",
+    ]
+    assert info["title"] == "Found"
+
+
+def test_wrapper_keeps_standard_extractor_when_it_succeeds(monkeypatch) -> None:
+    calls = []
+
+    def original(target: str):
+        calls.append(target)
+        return {"title": "Original"}
+
+    music = SimpleNamespace(_extract_info_sync=original)
+    cog = fallback.Music2YoutubeFallbackCog(DummyBot(music))
+    monkeypatch.setattr(
+        fallback,
+        "_extract_with_youtube_fallback",
+        lambda target: pytest.fail("fallback must not run"),
+    )
+
+    assert cog._install_if_possible() is True
+    result = music._extract_info_sync("test song")
+
+    assert result == {"title": "Original"}
+    assert calls == ["test song"]
+
+
+def test_wrapper_retries_youtube_after_standard_failure(monkeypatch) -> None:
+    def original(_target: str):
+        raise RuntimeError("standard failed")
+
+    music = SimpleNamespace(_extract_info_sync=original)
+    cog = fallback.Music2YoutubeFallbackCog(DummyBot(music))
+    fallback_calls = []
+
+    def fallback_extract(target: str):
+        fallback_calls.append(target)
+        return {"title": "Recovered"}
+
+    monkeypatch.setattr(fallback, "_extract_with_youtube_fallback", fallback_extract)
+
+    assert cog._install_if_possible() is True
+    result = music._extract_info_sync("https://youtube.com/watch?v=abc")
+
+    assert result == {"title": "Recovered"}
+    assert fallback_calls == ["https://youtube.com/watch?v=abc"]
+
+
+def test_wrapper_does_not_retry_non_youtube_url(monkeypatch) -> None:
+    def original(_target: str):
+        raise RuntimeError("standard failed")
+
+    music = SimpleNamespace(_extract_info_sync=original)
+    cog = fallback.Music2YoutubeFallbackCog(DummyBot(music))
+    monkeypatch.setattr(
+        fallback,
+        "_extract_with_youtube_fallback",
+        lambda target: pytest.fail("fallback must not run"),
+    )
+
+    assert cog._install_if_possible() is True
+    with pytest.raises(RuntimeError, match="standard failed"):
+        music._extract_info_sync("https://example.com/audio.mp3")
+
+
+def test_unload_restores_original_extractor() -> None:
+    def original(target: str):
+        return {"title": target}
+
+    music = SimpleNamespace(_extract_info_sync=original)
+    cog = fallback.Music2YoutubeFallbackCog(DummyBot(music))
+
+    assert cog._install_if_possible() is True
+    assert music._extract_info_sync is not original
+
+    cog.cog_unload()
+
+    assert music._extract_info_sync is original


### PR DESCRIPTION
## Constat
Après le merge de BOT-FEAT-005, l'ajout de musique personnalisée ne fonctionne plus en production alors que `music2.py` n'a pas été modifié et que le déploiement Railway démarre correctement.

## Diagnostic
La piste la plus probable est l'extraction YouTube/yt-dlp : la documentation yt-dlp 2026 indique un durcissement des formats/PO Tokens et certains clients par défaut peuvent ne plus fournir de flux audio exploitable.

## Correctif
- conserve l'extraction Music2 actuelle en priorité ;
- uniquement si elle échoue sur une recherche ou URL YouTube, retente avec les clients `android_vr` puis `web_embedded` ;
- ne modifie pas les URLs non-YouTube ;
- le fallback est isolé dans un cog et restaurable lors d'un reload ;
- BOT-FEAT-005 Écoute ensemble n'est pas modifié.

## Tests ajoutés
- détection cible YouTube ;
- options yt-dlp du fallback ;
- aucune utilisation du fallback quand l'extraction standard réussit ;
- retry après échec standard ;
- aucune tentative secondaire sur URL non-YouTube ;
- restauration de l'extracteur original au unload.

## Validation
Le diff contient uniquement le nouveau fallback et ses tests. Les tests n'ont pas été exécutés dans l'environnement ChatGPT, qui ne dispose pas des dépendances/runtime du dépôt.