### PR TITLE
fix: pin Listen Together announcement channel

### DIFF
--- a/cogs/music2_listen_together.py
+++ b/cogs/music2_listen_together.py
@@ -2,30 +2,19 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
 from dataclasses import dataclass
 from typing import Any
 
 import discord
 from discord.ext import commands, tasks
 
-from config import LOBBY_TEXT_CHANNEL, RADIO_VC_ID
+from config import RADIO_VC_ID
 
 
 logger = logging.getLogger(__name__)
 
 
-def _env_channel_id(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, str(default)))
-    except (TypeError, ValueError):
-        return default
-
-
-LISTEN_TOGETHER_CHANNEL_ID = _env_channel_id(
-    "MUSIC_LISTEN_TOGETHER_CHANNEL_ID",
-    LOBBY_TEXT_CHANNEL,
-)
+LISTEN_TOGETHER_CHANNEL_ID = 1400552164979507263
 LISTEN_TOGETHER_CUSTOM_ID = "music2_listen_together_join"
 LISTEN_TOGETHER_TITLE = "🎧 Écoute ensemble"
 


### PR DESCRIPTION
## Correctif
Configure directement dans le code le salon d'annonce de **BOT-FEAT-005 — Écoute ensemble**.

## Changement
- `LISTEN_TOGETHER_CHANNEL_ID` est fixé à `1400552164979507263` ;
- suppression de `MUSIC_LISTEN_TOGETHER_CHANNEL_ID` ;
- suppression du fallback vers `LOBBY_TEXT_CHANNEL` ;
- aucune modification du moteur Music 2.0 ni du bouton `Rejoindre`.

## Impact
Les annonces d'écoute personnalisée seront toujours envoyées dans `<#1400552164979507263>` après déploiement, indépendamment des variables Railway.

## Validation
Diff limité à `cogs/music2_listen_together.py` (`+2 / -13`). Les tests n'ont pas été exécutés dans l'environnement ChatGPT car le checkout local ne peut pas résoudre `github.com`.