### PR TITLE
fix(music): bypass YouTube bot challenge with PO token provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && \
     curl \
     ca-certificates \
     unzip \
+    git \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # yt-dlp requiert désormais un runtime JavaScript externe pour une prise en
@@ -18,6 +19,19 @@ RUN apt-get update && \
 # défaut par yt-dlp.
 RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh && \
     deno --version
+
+# Installe le générateur de Proof-of-Origin tokens utilisé par le plugin
+# bgutil-ytdlp-pot-provider. Le mode script est adapté au volume du bot et
+# évite d'exposer un service HTTP supplémentaire. Le checkout doit rester à la
+# même version que le paquet Python déclaré dans requirements.txt.
+ARG BGUTIL_POT_PROVIDER_VERSION=1.3.1
+RUN git clone --depth 1 --single-branch \
+        --branch "${BGUTIL_POT_PROVIDER_VERSION}" \
+        https://github.com/Brainicism/bgutil-ytdlp-pot-provider.git \
+        /root/bgutil-ytdlp-pot-provider && \
+    cd /root/bgutil-ytdlp-pot-provider/server && \
+    deno install --allow-scripts=npm:canvas --frozen && \
+    rm -rf /root/bgutil-ytdlp-pot-provider/.git
 
 # Répertoire de travail dans le conteneur
 WORKDIR /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,7 @@ Pillow>=10.0,<13
 # Pinned to an upstream revision that includes YouTube player-client maintenance
 # from yt-dlp commit 69ea200 (visionos, android_vr, web defaults).
 yt-dlp[default] @ https://github.com/yt-dlp/yt-dlp/archive/5d6b8c8cd19785c3086ae3a9ec618c45e25eb3bc.tar.gz
+# Keep the plugin version aligned with the provider checkout installed in Docker.
+bgutil-ytdlp-pot-provider==1.3.1
 imageio-ffmpeg>=0.4,<1
 aiohttp>=3.8,<4

--- a/tests/test_dependency_requirements.py
+++ b/tests/test_dependency_requirements.py
@@ -31,14 +31,24 @@ def test_dev_requirements_extend_runtime_and_include_test_tools():
 def test_runtime_dependencies_have_breaking_change_guards():
     runtime = set(_requirements("requirements.txt"))
 
-    assert "discord.py[voice]>=2.4,<3" in runtime
+    assert "discord.py[voice]>=2.7,<3" in runtime
     assert "python-dotenv>=1.0,<2" in runtime
     assert "Pillow>=10.0,<13" in runtime
     assert "imageio-ffmpeg>=0.4,<1" in runtime
     assert "aiohttp>=3.8,<4" in runtime
 
 
-def test_yt_dlp_remains_updateable():
-    runtime = set(_requirements("requirements.txt"))
+def test_yt_dlp_uses_maintained_upstream_revision():
+    runtime = _requirements("requirements.txt")
 
-    assert "yt-dlp>=2024.7.1" in runtime
+    assert any(line.startswith("yt-dlp[default] @ https://github.com/yt-dlp/yt-dlp/archive/") for line in runtime)
+
+
+def test_youtube_po_token_provider_versions_stay_aligned():
+    runtime = set(_requirements("requirements.txt"))
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert "bgutil-ytdlp-pot-provider==1.3.1" in runtime
+    assert "ARG BGUTIL_POT_PROVIDER_VERSION=1.3.1" in dockerfile
+    assert "/root/bgutil-ytdlp-pot-provider/server" in dockerfile
+    assert "deno install --allow-scripts=npm:canvas --frozen" in dockerfile


### PR DESCRIPTION
Corrige l'échec `Sign in to confirm you're not a bot` rencontré par Music2 avec yt-dlp.

Changements :
- ajoute `bgutil-ytdlp-pot-provider==1.3.1` ;
- installe le générateur BgUtils 1.3.1 dans l'image Docker en mode script avec Deno ;
- garde explicitement plugin et provider sur la même version ;
- ajoute des tests de garde sur les dépendances et l'installation Docker ;
- remet à jour les assertions de versions déjà devenues obsolètes dans `test_dependency_requirements.py`.

Aucun cookie YouTube personnel n'est utilisé.