### PR TITLE
fix(music): actually run the YouTube PO token provider

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,10 @@ RUN curl -fsSL https://deno.land/install.sh | DENO_INSTALL=/usr/local sh && \
     deno --version
 
 # Installe le générateur de Proof-of-Origin tokens utilisé par le plugin
-# bgutil-ytdlp-pot-provider. Le mode script est adapté au volume du bot et
-# évite d'exposer un service HTTP supplémentaire. Le checkout doit rester à la
-# même version que le paquet Python déclaré dans requirements.txt.
+# bgutil-ytdlp-pot-provider. Le serveur HTTP local est lancé avec le bot par
+# docker-entrypoint.sh ; yt-dlp le détecte automatiquement sur 127.0.0.1:4416.
+# Le checkout doit rester à la même version que le paquet Python déclaré dans
+# requirements.txt.
 ARG BGUTIL_POT_PROVIDER_VERSION=1.3.1
 RUN git clone --depth 1 --single-branch \
         --branch "${BGUTIL_POT_PROVIDER_VERSION}" \
@@ -42,5 +43,5 @@ COPY . .
 # Installation des dépendances Python
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Lancement du bot
-CMD ["python", "main.py"]
+# Lance d'abord le provider PO Token local, puis le bot Discord.
+CMD ["sh", "/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -u
+
+PROVIDER_HOME="/root/bgutil-ytdlp-pot-provider/server"
+
+cd "$PROVIDER_HOME/node_modules"
+deno run \
+  --allow-env \
+  --allow-net \
+  --allow-ffi=. \
+  --allow-read=. \
+  ../src/main.ts &
+provider_pid=$!
+
+cleanup() {
+  kill "$provider_pid" 2>/dev/null || true
+  if [ "${bot_pid:-}" != "" ]; then
+    kill "$bot_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup INT TERM EXIT
+
+# Le provider doit rester vivant ; yt-dlp le détectera automatiquement sur
+# http://127.0.0.1:4416 et lui demandera les PO Tokens nécessaires.
+sleep 1
+if ! kill -0 "$provider_pid" 2>/dev/null; then
+  echo "bgutil PO token provider failed to start" >&2
+  wait "$provider_pid"
+  exit 1
+fi
+
+cd /app
+python main.py &
+bot_pid=$!
+wait "$bot_pid"
+bot_status=$?
+exit "$bot_status"

--- a/tests/test_music2_pot_runtime.py
+++ b/tests/test_music2_pot_runtime.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_docker_starts_music_through_entrypoint():
+    dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf-8")
+
+    assert 'CMD ["sh", "/app/docker-entrypoint.sh"]' in dockerfile
+
+
+def test_entrypoint_starts_bgutil_provider_before_bot():
+    entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
+
+    provider = "../src/main.ts"
+    bot = "python main.py"
+
+    assert "deno run" in entrypoint
+    assert "--allow-net" in entrypoint
+    assert provider in entrypoint
+    assert bot in entrypoint
+    assert entrypoint.index(provider) < entrypoint.index(bot)
+
+
+def test_entrypoint_fails_if_provider_dies_during_startup():
+    entrypoint = (ROOT / "docker-entrypoint.sh").read_text(encoding="utf-8")
+
+    assert 'kill -0 "$provider_pid"' in entrypoint
+    assert "bgutil PO token provider failed to start" in entrypoint


### PR DESCRIPTION
Le premier correctif installait bgutil-ytdlp-pot-provider et ses dépendances, mais le serveur HTTP local du provider n'était jamais lancé. Le bot continuait donc à recevoir `Sign in to confirm you’re not a bot`.

Ce correctif :
- lance le serveur BgUtils/Deno sur 127.0.0.1:4416 avant le bot ;
- utilise un entrypoint dédié pour garder le provider vivant pendant l'exécution ;
- fait échouer explicitement le démarrage si le provider meurt immédiatement ;
- ajoute des tests de garde sur le runtime Docker.

La méthode serveur est celle recommandée par la documentation bgutil pour un usage plus simple et plus fiable que le mode script implicite. Aucun cookie YouTube personnel n'est utilisé.