### PR TITLE
feat: migrate radio panel to Components V2

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -19,11 +19,12 @@ from config import DISABLED_COGS, GUILD_ID, LEVEL_FEED_CHANNEL_ID
 import cogs
 
 from storage.xp_store import xp_store
+from ui.radio_view import RadioView
 from utils.api_meter import api_meter
 from utils.channel_edit_manager import channel_edit_manager
 from utils.rename_manager import rename_manager
 from utils.rate_limit import GlobalRateLimiter, limiter as _limiter
-from view import PlayerTypeView, RadioView, StreamerTempVoiceView
+from view import PlayerTypeView, StreamerTempVoiceView
 from utils import level_feed
 
 

--- a/cogs/music2.py
+++ b/cogs/music2.py
@@ -21,8 +21,8 @@ from config import (
     ROCK_RADIO_STREAM_URL,
 )
 from storage.radio_store import RadioStore
+from ui.radio_view import RadioView
 from utils.voice import ensure_voice, play_stream
-from view import RadioView
 
 logger = logging.getLogger(__name__)
 
@@ -238,11 +238,9 @@ class Music2Cog(commands.Cog):
         try:
             message = await fetch(int(stored.get("message_id", 0)))
             await message.edit(
-                content=(
-                    "📻 Sélectionne ta radio !\n"
-                    "Clique sur un bouton ci-dessous pour changer de station."
-                ),
-                embed=None,
+                content=None,
+                embeds=[],
+                attachments=[],
                 view=RadioView(),
             )
         except (discord.NotFound, discord.Forbidden, discord.HTTPException, ValueError):

--- a/cogs/music2.py
+++ b/cogs/music2.py
@@ -225,6 +225,7 @@ class Music2Cog(commands.Cog):
         ensure = getattr(radio, "_ensure_radio_message", None) if radio else None
         if callable(ensure):
             await ensure(text_channel)
+            return
 
         stored = self.store.get_radio_message()
         if not stored or int(stored.get("channel_id", 0)) != RADIO_TEXT_CHANNEL_ID:

--- a/cogs/radio.py
+++ b/cogs/radio.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Optional
+from typing import Iterable, Optional
 
 import discord
 from discord.ext import commands
@@ -15,10 +15,41 @@ from config import (
     ROCK_RADIO_STREAM_URL,
 )
 from storage.radio_store import RadioStore
+from ui.radio_view import RadioView
 from utils.rename_manager import rename_manager
 from utils.voice import ensure_voice, play_stream
-from view import RadioView
+
 logger = logging.getLogger(__name__)
+
+RADIO_CUSTOM_IDS = frozenset(
+    {"radio_rap_fr", "radio_rap", "radio_rock", "radio_hiphop"}
+)
+
+
+def _collect_component_custom_ids(components: Iterable[object]) -> set[str]:
+    """Collect custom IDs from legacy or nested Components V2 trees."""
+    found: set[str] = set()
+    stack = list(components)
+    while stack:
+        component = stack.pop()
+        custom_id = getattr(component, "custom_id", None)
+        if isinstance(custom_id, str):
+            found.add(custom_id)
+
+        children = getattr(component, "children", None)
+        if children:
+            stack.extend(children)
+
+        accessory = getattr(component, "accessory", None)
+        if accessory is not None:
+            stack.append(accessory)
+    return found
+
+
+def _is_radio_message(message: discord.Message) -> bool:
+    """Identify both the legacy radio panel and its Components V2 replacement."""
+    custom_ids = _collect_component_custom_ids(getattr(message, "components", []))
+    return RADIO_CUSTOM_IDS.issubset(custom_ids)
 
 
 class RadioCog(commands.Cog):
@@ -82,37 +113,45 @@ class RadioCog(commands.Cog):
         await asyncio.sleep(5)
         await self._connect_and_play()
 
+    async def _render_radio_message(self, message: discord.Message) -> None:
+        """Upgrade or refresh one existing radio message without replacing it."""
+        await message.edit(
+            content=None,
+            embeds=[],
+            attachments=[],
+            view=RadioView(),
+        )
+
     async def _ensure_radio_message(
         self, channel: discord.abc.Messageable
     ) -> None:
         stored = self.store.get_radio_message()
         channel_id = getattr(channel, "id", 0)
 
-        def is_radio_message(msg: discord.Message) -> bool:
-            return any(
-                getattr(comp, "custom_id", "") == "radio_hiphop"
-                for row in getattr(msg, "components", [])
-                for comp in getattr(row, "children", [])
-            )
-
-        # 1) Try using stored message id to avoid duplicates
+        # 1) Try using stored message id to avoid duplicates.
         if stored and int(stored.get("channel_id", 0)) == channel_id:
             fetch = getattr(channel, "fetch_message", None)
             if fetch:
                 try:
                     msg = await fetch(int(stored.get("message_id", 0)))
-                    if is_radio_message(msg):
-                        return  # Stored message is still valid
+                    if _is_radio_message(msg):
+                        try:
+                            await self._render_radio_message(msg)
+                        except Exception as e:  # pragma: no cover - network issues
+                            logger.warning(
+                                "Impossible de mettre à jour le panneau radio: %s", e
+                            )
+                        return
                 except Exception as e:  # pragma: no cover - network issues
                     logger.debug("Failed to fetch stored radio message: %s", e)
 
-        # 2) Search the history for an existing radio message
+        # 2) Search the history for an existing radio message.
         found = None
         try:
             async for msg in channel.history(limit=None):
                 if msg.author.id != self.bot.user.id:
                     continue
-                if not is_radio_message(msg):
+                if not _is_radio_message(msg):
                     continue
                 if found is None:
                     found = msg
@@ -128,16 +167,16 @@ class RadioCog(commands.Cog):
             return
 
         if found:
+            try:
+                await self._render_radio_message(found)
+            except Exception as e:  # pragma: no cover - best effort
+                logger.warning("Impossible de mettre à jour le panneau radio: %s", e)
             self.store.set_radio_message(channel_id, found.id)
             return
 
-        # 3) No message found -> create one
+        # 3) No message found -> create the Components V2 panel.
         try:
-            msg = await channel.send(
-                "📻 Sélectionne ta radio !\n"
-                "Clique sur un bouton ci-dessous pour changer de station.",
-                view=RadioView(),
-            )
+            msg = await channel.send(view=RadioView())
             self.store.set_radio_message(channel_id, msg.id)
         except Exception as e:
             logger.warning("Impossible d'envoyer le message radio: %s", e)

--- a/tests/test_radio_components_v2.py
+++ b/tests/test_radio_components_v2.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock
 import discord
 import pytest
 
+import cogs.music2 as music2
 from cogs.radio import RADIO_CUSTOM_IDS, RadioCog, _is_radio_message
 from ui.radio_view import RadioView
 
@@ -92,3 +93,16 @@ def test_radio_message_detection_requires_the_complete_control_contract() -> Non
     )
 
     assert not _is_radio_message(incomplete)
+
+
+@pytest.mark.asyncio
+async def test_music2_delegates_radio_panel_restore_to_radio_cog() -> None:
+    ensure = AsyncMock()
+    radio = SimpleNamespace(_ensure_radio_message=ensure)
+    cog = object.__new__(music2.Music2Cog)
+    cog.bot = SimpleNamespace(get_cog=lambda name: radio if name == "RadioCog" else None)
+    text_channel = SimpleNamespace()
+
+    await music2.Music2Cog._restore_radio_panel(cog, text_channel)
+
+    ensure.assert_awaited_once_with(text_channel)

--- a/tests/test_radio_components_v2.py
+++ b/tests/test_radio_components_v2.py
@@ -106,3 +106,33 @@ async def test_music2_delegates_radio_panel_restore_to_radio_cog() -> None:
     await music2.Music2Cog._restore_radio_panel(cog, text_channel)
 
     ensure.assert_awaited_once_with(text_channel)
+
+
+@pytest.mark.asyncio
+async def test_music2_fallback_restores_the_v2_radio_view() -> None:
+    message = SimpleNamespace(edit=AsyncMock())
+
+    class DummyChannel:
+        async def fetch_message(self, message_id: int):
+            assert message_id == 777
+            return message
+
+    cog = object.__new__(music2.Music2Cog)
+    cog.bot = SimpleNamespace(get_cog=lambda _name: None)
+    cog.store = SimpleNamespace(
+        get_radio_message=Mock(
+            return_value={
+                "channel_id": music2.RADIO_TEXT_CHANNEL_ID,
+                "message_id": 777,
+            }
+        )
+    )
+
+    await music2.Music2Cog._restore_radio_panel(cog, DummyChannel())
+
+    message.edit.assert_awaited_once()
+    kwargs = message.edit.await_args.kwargs
+    assert kwargs["content"] is None
+    assert kwargs["embeds"] == []
+    assert kwargs["attachments"] == []
+    assert isinstance(kwargs["view"], discord.ui.LayoutView)

--- a/tests/test_radio_components_v2.py
+++ b/tests/test_radio_components_v2.py
@@ -1,0 +1,94 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import discord
+import pytest
+
+from cogs.radio import RADIO_CUSTOM_IDS, RadioCog, _is_radio_message
+from ui.radio_view import RadioView
+
+
+def _text(view: discord.ui.LayoutView) -> str:
+    return "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+
+
+def _buttons(view: discord.ui.LayoutView) -> list[discord.ui.Button]:
+    return [
+        item
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.Button)
+    ]
+
+
+def test_radio_panel_uses_components_v2_and_preserves_custom_ids() -> None:
+    view = RadioView()
+
+    assert isinstance(view, discord.ui.LayoutView)
+    assert "## 📻 RADIO DU REFUGE" in _text(view)
+    assert "### 🎚️ Stations disponibles" in _text(view)
+    assert {button.custom_id for button in _buttons(view)} == RADIO_CUSTOM_IDS
+
+
+def test_radio_message_detection_handles_nested_v2_sections() -> None:
+    view = RadioView()
+    message = SimpleNamespace(components=view.children)
+
+    assert _is_radio_message(message)
+
+
+@pytest.mark.asyncio
+async def test_stored_legacy_radio_message_is_upgraded_in_place() -> None:
+    legacy_row = SimpleNamespace(
+        children=[SimpleNamespace(custom_id=custom_id) for custom_id in RADIO_CUSTOM_IDS]
+    )
+    message = SimpleNamespace(
+        id=321,
+        components=[legacy_row],
+        edit=AsyncMock(),
+    )
+
+    class DummyChannel:
+        id = 123
+
+        async def fetch_message(self, message_id: int):
+            assert message_id == message.id
+            return message
+
+        send = AsyncMock()
+
+    channel = DummyChannel()
+    store = SimpleNamespace(
+        get_radio_message=Mock(
+            return_value={"channel_id": channel.id, "message_id": message.id}
+        ),
+        set_radio_message=Mock(),
+    )
+    cog = object.__new__(RadioCog)
+    cog.bot = SimpleNamespace(user=SimpleNamespace(id=999))
+    cog.store = store
+
+    await RadioCog._ensure_radio_message(cog, channel)
+
+    message.edit.assert_awaited_once()
+    kwargs = message.edit.await_args.kwargs
+    assert kwargs["content"] is None
+    assert kwargs["embeds"] == []
+    assert kwargs["attachments"] == []
+    assert isinstance(kwargs["view"], discord.ui.LayoutView)
+    channel.send.assert_not_awaited()
+
+
+def test_radio_message_detection_requires_the_complete_control_contract() -> None:
+    incomplete = SimpleNamespace(
+        components=[
+            SimpleNamespace(
+                children=[SimpleNamespace(custom_id="radio_hiphop")]
+            )
+        ]
+    )
+
+    assert not _is_radio_message(incomplete)

--- a/tests/test_radio_view_buttons.py
+++ b/tests/test_radio_view_buttons.py
@@ -1,13 +1,18 @@
 from types import SimpleNamespace
-from pathlib import Path
 from unittest.mock import AsyncMock
-import sys
+
+import discord
 import pytest
 
-# Permet d'importer "view.RadioView" depuis la racine du projet
-sys.path.append(str(Path(__file__).resolve().parents[1]))
+from ui.radio_view import RadioView
 
-from view import RadioView
+
+def _buttons(view: discord.ui.LayoutView) -> list[discord.ui.Button]:
+    return [
+        child
+        for child in view.walk_children()
+        if isinstance(child, discord.ui.Button)
+    ]
 
 
 @pytest.mark.asyncio
@@ -20,9 +25,13 @@ async def test_radio_view_has_expected_buttons():
         "radio_hiphop": "Radio Hip-Hop",
     }
 
+    assert isinstance(view, discord.ui.LayoutView)
+    assert view.is_persistent()
+
+    buttons = _buttons(view)
     for custom_id, label in expected.items():
         button = next(
-            (child for child in view.children if getattr(child, "custom_id", None) == custom_id),
+            (child for child in buttons if getattr(child, "custom_id", None) == custom_id),
             None,
         )
         assert button is not None, f"Button with custom_id '{custom_id}' not found"
@@ -41,23 +50,20 @@ async def test_radio_view_buttons_call_methods():
         "radio_hiphop": "radio_hiphop",
     }
 
+    buttons = _buttons(view)
     for custom_id, cmd_name in mapping.items():
         button = next(
-            (child for child in view.children if getattr(child, "custom_id", None) == custom_id),
+            (child for child in buttons if getattr(child, "custom_id", None) == custom_id),
             None,
         )
         assert button is not None, f"Button with custom_id '{custom_id}' not found"
 
         mock = AsyncMock()
         cog = SimpleNamespace(**{cmd_name: mock})
-
-        # Interaction minimale pour le callback : .client.get_cog(...) doit renvoyer notre "cog"
         interaction = SimpleNamespace(
             client=SimpleNamespace(get_cog=lambda name, c=cog: c)
         )
 
-        # Exécute le callback du bouton
         await button.callback(interaction)
 
-        # Vérifie que la méthode du cog a bien été appelée
-        mock.assert_awaited_once()
+        mock.assert_awaited_once_with(interaction)

--- a/ui/radio_view.py
+++ b/ui/radio_view.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+
+
+RADIO_ACCENT = discord.Colour(0x8B5CF6)
+
+
+class RadioStationButton(discord.ui.Button):
+    """Persistent station button used by the Components V2 radio panel."""
+
+    def __init__(
+        self,
+        *,
+        label: str,
+        emoji: str,
+        custom_id: str,
+        command_name: str,
+    ) -> None:
+        super().__init__(
+            label=label,
+            emoji=emoji,
+            style=discord.ButtonStyle.primary,
+            custom_id=custom_id,
+        )
+        self.command_name = command_name
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, RadioView):
+            return
+        await view.dispatch_station(interaction, self.command_name)
+
+
+class RadioView(discord.ui.LayoutView):
+    """Panneau radio persistant basé sur Discord Components V2."""
+
+    STATIONS = (
+        {
+            "label": "Rap FR",
+            "emoji": "🟣",
+            "custom_id": "radio_rap_fr",
+            "command_name": "radio_rap_fr",
+            "description": "Rap francophone · sélection instantanée de la station.",
+        },
+        {
+            "label": "Rap US",
+            "emoji": "🔘",
+            "custom_id": "radio_rap",
+            "command_name": "radio_rap",
+            "description": "Rap US · bascule le flux vocal vers la station américaine.",
+        },
+        {
+            "label": "Rock",
+            "emoji": "☢️",
+            "custom_id": "radio_rock",
+            "command_name": "radio_rock",
+            "description": "Rock · une ambiance plus électrique dans le vocal du Refuge.",
+        },
+        {
+            "label": "Radio Hip-Hop",
+            "emoji": "📻",
+            "custom_id": "radio_hiphop",
+            "command_name": "radio_hiphop",
+            "description": "Hip-Hop · la station principale de la radio du Refuge.",
+        },
+    )
+
+    def __init__(self) -> None:
+        super().__init__(timeout=None)
+        self.add_item(self._build_container())
+
+    def _build_container(self) -> discord.ui.Container:
+        container = discord.ui.Container(accent_colour=RADIO_ACCENT)
+        container.add_item(
+            discord.ui.TextDisplay(
+                "## 📻 RADIO DU REFUGE\n"
+                "Choisis ton ambiance : la station sélectionnée prend immédiatement "
+                "le relais dans le salon vocal Radio."
+            )
+        )
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "### 🎚️ Stations disponibles\n"
+                "Chaque station possède son propre contrôle pour garder le panneau "
+                "clair sur ordinateur comme sur mobile."
+            )
+        )
+
+        for index, station in enumerate(self.STATIONS):
+            container.add_item(discord.ui.Separator(spacing=discord.SeparatorSpacing.small))
+            container.add_item(
+                discord.ui.Section(
+                    discord.ui.TextDisplay(
+                        f"### {station['emoji']} {station['label']}\n"
+                        f"{station['description']}"
+                    ),
+                    accessory=RadioStationButton(
+                        label=station["label"],
+                        emoji=station["emoji"],
+                        custom_id=station["custom_id"],
+                        command_name=station["command_name"],
+                    ),
+                )
+            )
+
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "### 🔁 Changement rapide\n"
+                "Rap FR, Rap US et Rock conservent le comportement existant : "
+                "si tu rappuies sur la station déjà active et qu'une station précédente "
+                "est disponible, le bot y revient."
+            )
+        )
+        container.add_item(
+            discord.ui.TextDisplay(
+                "-# La Radio Hip-Hop reste la station principale · Aucun réglage audio n'est modifié par ce panneau."
+            )
+        )
+        return container
+
+    async def dispatch_station(
+        self,
+        interaction: discord.Interaction,
+        command_name: str,
+    ) -> None:
+        """Dispatch to the existing RadioCog methods without changing radio logic."""
+        cog = interaction.client.get_cog("RadioCog")
+        if not cog:
+            await interaction.response.send_message(
+                "❌ Radio indisponible.", ephemeral=True
+            )
+            return
+
+        command = getattr(cog, command_name, None)
+        if command is None:
+            await interaction.response.send_message(
+                "❌ Radio indisponible.", ephemeral=True
+            )
+            return
+
+        if isinstance(command, app_commands.Command):
+            await command.callback(cog, interaction)
+        else:
+            await command(interaction)

--- a/ui/radio_view.py
+++ b/ui/radio_view.py
@@ -89,8 +89,10 @@ class RadioView(discord.ui.LayoutView):
             )
         )
 
-        for index, station in enumerate(self.STATIONS):
-            container.add_item(discord.ui.Separator(spacing=discord.SeparatorSpacing.small))
+        for station in self.STATIONS:
+            container.add_item(
+                discord.ui.Separator(spacing=discord.SeparatorSpacing.small)
+            )
             container.add_item(
                 discord.ui.Section(
                     discord.ui.TextDisplay(


### PR DESCRIPTION
## Objectif
Moderniser uniquement le panneau permanent **Radio du Refuge** avec Discord Components V2, sans modifier la logique audio ni le comportement des stations.

## Modifications
- nouveau `ui/radio_view.py` basé sur `discord.ui.LayoutView` ;
- `Container` violet, titre, sections dédiées à Rap FR / Rap US / Rock / Hip-Hop, séparateurs et pied d'information ;
- chaque station conserve son bouton et son label existants, avec une présentation plus lisible et un emoji ;
- conservation stricte des `custom_id` existants : `radio_rap_fr`, `radio_rap`, `radio_rock`, `radio_hiphop` ;
- migration en place du message radio existant vers Components V2, sans recréer le panneau ni changer son `message_id` ;
- détection des anciens panneaux et des panneaux V2 imbriqués pour préserver la déduplication ;
- `bot.py` enregistre désormais la `LayoutView` persistante ;
- compatibilité Music 2.0 : lorsqu'il restaure le panneau Radio, il délègue désormais au gestionnaire Radio afin de ne pas réinjecter l'ancien rendu classique.

## Logique explicitement inchangée
- URLs et flux radio ;
- connexion/reconnexion vocale ;
- renommage du salon vocal ;
- comportement de retour à la station précédente ;
- réponses éphémères ;
- logique Music 2.0 et file musicale.

## Validation ajoutée
- contrat Components V2 et persistance ;
- labels et `custom_id` inchangés ;
- callbacks vers les méthodes Radio existantes ;
- détection d'un panneau V2 imbriqué ;
- migration en place d'un ancien panneau sans création d'un nouveau message ;
- compatibilité de restauration avec Music 2.0.

## Contrôle manuel demandé avant merge
Vérifier dans Discord le rendu desktop/mobile, confirmer qu'il n'existe qu'un seul panneau Radio, puis tester les quatre stations et le retour à la station précédente. Vérifier également qu'une utilisation de Music 2.0 ne remet pas l'ancien panneau Radio.
