### PR TITLE
feat: migrate feedback portal to Components V2

### DIFF
--- a/cogs/feedback_portal.py
+++ b/cogs/feedback_portal.py
@@ -13,6 +13,10 @@ from utils.interactions import safe_respond
 
 logger = logging.getLogger(__name__)
 
+PORTAL_TITLE = "📬 Centre de Retours & Support"
+PORTAL_CUSTOM_IDS = frozenset({"btn_suggestion", "btn_bug", "btn_avis"})
+PORTAL_ACCENT = discord.Color.gold()
+
 
 @dataclass(frozen=True)
 class FeedbackConfig:
@@ -65,43 +69,159 @@ def _disable_buttons(view: discord.ui.View) -> None:
             item.disabled = True
 
 
-class FeedbackPortalView(discord.ui.View):
+def _collect_component_custom_ids(components: Iterable[object]) -> set[str]:
+    """Collect custom IDs from legacy rows or nested Components V2 trees."""
+    found: set[str] = set()
+    stack = list(components)
+    while stack:
+        component = stack.pop()
+        custom_id = getattr(component, "custom_id", None)
+        if isinstance(custom_id, str):
+            found.add(custom_id)
+
+        children = getattr(component, "children", None)
+        if children:
+            stack.extend(children)
+
+        accessory = getattr(component, "accessory", None)
+        if accessory is not None:
+            stack.append(accessory)
+    return found
+
+
+def _is_portal_message(message: discord.Message) -> bool:
+    """Recognise the legacy Embed portal and the Components V2 replacement."""
+    custom_ids = _collect_component_custom_ids(getattr(message, "components", []))
+    if PORTAL_CUSTOM_IDS.issubset(custom_ids):
+        return True
+    embeds = getattr(message, "embeds", [])
+    return bool(embeds and getattr(embeds[0], "title", None) == PORTAL_TITLE)
+
+
+class FeedbackPortalButton(discord.ui.Button):
+    """Persistent accessory button for one feedback category."""
+
+    def __init__(
+        self,
+        *,
+        feedback_type: str,
+        label: str,
+        emoji: str,
+        style: discord.ButtonStyle,
+        custom_id: str,
+    ) -> None:
+        super().__init__(
+            label=label,
+            emoji=emoji,
+            style=style,
+            custom_id=custom_id,
+        )
+        self.feedback_type = feedback_type
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        view = self.view
+        if not isinstance(view, FeedbackPortalView):
+            return
+        await view.open_modal(interaction, self.feedback_type)
+
+
+class FeedbackPortalView(discord.ui.LayoutView):
+    """Portail public de retours basé sur Discord Components V2."""
+
     def __init__(self, cog: "FeedbackPortalCog") -> None:
         super().__init__(timeout=None)
         self.cog = cog
+        self.add_item(self._build_container())
 
-    @discord.ui.button(
-        label="Proposer une idée",
-        style=discord.ButtonStyle.success,
-        emoji="💡",
-        custom_id="btn_suggestion",
-    )
-    async def suggestion(
-        self, interaction: discord.Interaction, button: discord.ui.Button
-    ) -> None:
-        await interaction.response.send_modal(SuggestionModal(self.cog))
+    def _build_container(self) -> discord.ui.Container:
+        container = discord.ui.Container(accent_colour=PORTAL_ACCENT)
+        container.add_item(
+            discord.ui.TextDisplay(
+                "## 📬 CENTRE DE RETOURS & SUPPORT\n"
+                "Une idée, un problème ou simplement un avis ? Choisis la catégorie "
+                "qui correspond à ton retour pour ouvrir le formulaire adapté."
+            )
+        )
+        container.add_item(discord.ui.Separator())
 
-    @discord.ui.button(
-        label="Signaler un bug",
-        style=discord.ButtonStyle.danger,
-        emoji="🐛",
-        custom_id="btn_bug",
-    )
-    async def bug(
-        self, interaction: discord.Interaction, button: discord.ui.Button
-    ) -> None:
-        await interaction.response.send_modal(BugReportModal(self.cog))
+        container.add_item(
+            discord.ui.Section(
+                discord.ui.TextDisplay(
+                    "### 💡 Proposer une idée\n"
+                    "Partage une proposition pour améliorer le Refuge, ses salons ou ses fonctionnalités."
+                ),
+                accessory=FeedbackPortalButton(
+                    feedback_type="suggestion",
+                    label="Proposer une idée",
+                    emoji="💡",
+                    style=discord.ButtonStyle.success,
+                    custom_id="btn_suggestion",
+                ),
+            )
+        )
+        container.add_item(
+            discord.ui.Separator(spacing=discord.SeparatorSpacing.small)
+        )
+        container.add_item(
+            discord.ui.Section(
+                discord.ui.TextDisplay(
+                    "### 🐛 Signaler un bug\n"
+                    "Décris un dysfonctionnement afin que l'équipe puisse l'identifier et le reproduire."
+                ),
+                accessory=FeedbackPortalButton(
+                    feedback_type="bug",
+                    label="Signaler un bug",
+                    emoji="🐛",
+                    style=discord.ButtonStyle.danger,
+                    custom_id="btn_bug",
+                ),
+            )
+        )
+        container.add_item(
+            discord.ui.Separator(spacing=discord.SeparatorSpacing.small)
+        )
+        container.add_item(
+            discord.ui.Section(
+                discord.ui.TextDisplay(
+                    "### ⭐ Donner un avis\n"
+                    "Donne ton ressenti sur le serveur et aide l'équipe à comprendre ce qui fonctionne bien ou moins bien."
+                ),
+                accessory=FeedbackPortalButton(
+                    feedback_type="avis",
+                    label="Donner un avis",
+                    emoji="⭐",
+                    style=discord.ButtonStyle.primary,
+                    custom_id="btn_avis",
+                ),
+            )
+        )
 
-    @discord.ui.button(
-        label="Donner un avis",
-        style=discord.ButtonStyle.primary,
-        emoji="⭐",
-        custom_id="btn_avis",
-    )
-    async def avis(
-        self, interaction: discord.Interaction, button: discord.ui.Button
+        container.add_item(discord.ui.Separator())
+        container.add_item(
+            discord.ui.TextDisplay(
+                "### 🔒 Envoi encadré\n"
+                "Le bouton ouvre un formulaire adapté à ta demande. Une fois envoyé, "
+                "le retour est transmis à l'équipe de modération."
+            )
+        )
+        container.add_item(
+            discord.ui.TextDisplay(
+                "-# Merci de rester précis et constructif · Tout abus peut être sanctionné."
+            )
+        )
+        return container
+
+    async def open_modal(
+        self, interaction: discord.Interaction, feedback_type: str
     ) -> None:
-        await interaction.response.send_modal(OpinionModal(self.cog))
+        modal_factory = {
+            "suggestion": SuggestionModal,
+            "bug": BugReportModal,
+            "avis": OpinionModal,
+        }.get(feedback_type)
+        if modal_factory is None:
+            return
+        await interaction.response.send_modal(modal_factory(self.cog))
 
 
 class FeedbackStaffView(discord.ui.View):
@@ -255,6 +375,15 @@ class FeedbackPortalCog(commands.Cog):
         self._portal_checked = True
         await self.ensure_portal_message()
 
+    async def _render_portal_message(self, message: discord.Message) -> None:
+        """Upgrade the existing portal message in place to Components V2."""
+        await message.edit(
+            content=None,
+            embeds=[],
+            attachments=[],
+            view=FeedbackPortalView(self),
+        )
+
     async def ensure_portal_message(self) -> None:
         channel = self.bot.get_channel(FEEDBACK_PORTAL_CHANNEL_ID)
         if channel is None:
@@ -267,22 +396,22 @@ class FeedbackPortalCog(commands.Cog):
             logger.warning("[feedback] portal channel non compatible")
             return
 
-        target_title = "📬 Centre de Retours & Support"
+        target = None
         async for message in channel.history(limit=50):
             if message.author.id != self.bot.user.id:
                 continue
-            if message.embeds and message.embeds[0].title == target_title:
-                return
+            if _is_portal_message(message):
+                target = message
+                break
 
-        embed = discord.Embed(
-            title=target_title,
-            description=(
-                "Bienvenue avec l'equipe technique du refuge. Utilisez les boutons "
-                "ci-dessous pour interagir avec l'équipe. Tout abus sera sanctionné."
-            ),
-            color=discord.Color.gold(),
-        )
-        await channel.send(embed=embed, view=FeedbackPortalView(self))
+        if target is not None:
+            try:
+                await self._render_portal_message(target)
+            except discord.HTTPException:
+                logger.exception("[feedback] mise à jour du portail impossible")
+            return
+
+        await channel.send(view=FeedbackPortalView(self))
 
     async def handle_submission(
         self,

--- a/tests/test_feedback_portal_components_v2.py
+++ b/tests/test_feedback_portal_components_v2.py
@@ -1,0 +1,144 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+import cogs.feedback_portal as feedback
+
+
+def _buttons(view: discord.ui.LayoutView) -> list[discord.ui.Button]:
+    return [
+        item
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.Button)
+    ]
+
+
+def _text(view: discord.ui.LayoutView) -> str:
+    return "\n".join(
+        item.content
+        for item in view.walk_children()
+        if isinstance(item, discord.ui.TextDisplay)
+    )
+
+
+def test_feedback_portal_uses_components_v2_and_preserves_contract() -> None:
+    view = feedback.FeedbackPortalView(SimpleNamespace())
+
+    assert isinstance(view, discord.ui.LayoutView)
+    assert view.is_persistent()
+    assert "## 📬 CENTRE DE RETOURS & SUPPORT" in _text(view)
+    assert "### 💡 Proposer une idée" in _text(view)
+    assert "### 🐛 Signaler un bug" in _text(view)
+    assert "### ⭐ Donner un avis" in _text(view)
+
+    buttons = _buttons(view)
+    assert {button.custom_id for button in buttons} == feedback.PORTAL_CUSTOM_IDS
+    assert {button.custom_id: button.label for button in buttons} == {
+        "btn_suggestion": "Proposer une idée",
+        "btn_bug": "Signaler un bug",
+        "btn_avis": "Donner un avis",
+    }
+
+
+@pytest.mark.asyncio
+async def test_feedback_portal_buttons_open_existing_modals() -> None:
+    cog = SimpleNamespace()
+    view = feedback.FeedbackPortalView(cog)
+    buttons = {button.custom_id: button for button in _buttons(view)}
+
+    expected = {
+        "btn_suggestion": feedback.SuggestionModal,
+        "btn_bug": feedback.BugReportModal,
+        "btn_avis": feedback.OpinionModal,
+    }
+
+    for custom_id, modal_type in expected.items():
+        interaction = SimpleNamespace(
+            response=SimpleNamespace(send_modal=AsyncMock())
+        )
+        await buttons[custom_id].callback(interaction)
+        interaction.response.send_modal.assert_awaited_once()
+        modal = interaction.response.send_modal.await_args.args[0]
+        assert isinstance(modal, modal_type)
+        assert modal.cog is cog
+
+
+def test_feedback_portal_detection_supports_legacy_embed_and_nested_v2() -> None:
+    legacy = SimpleNamespace(
+        embeds=[discord.Embed(title=feedback.PORTAL_TITLE)],
+        components=[],
+    )
+    assert feedback._is_portal_message(legacy)
+
+    view = feedback.FeedbackPortalView(SimpleNamespace())
+    modern = SimpleNamespace(embeds=[], components=view.children)
+    assert feedback._is_portal_message(modern)
+
+    unrelated = SimpleNamespace(
+        embeds=[discord.Embed(title="Autre panneau")],
+        components=[],
+    )
+    assert not feedback._is_portal_message(unrelated)
+
+
+@pytest.mark.asyncio
+async def test_render_portal_message_migrates_in_place() -> None:
+    message = SimpleNamespace(edit=AsyncMock())
+    cog = object.__new__(feedback.FeedbackPortalCog)
+    cog.bot = SimpleNamespace()
+
+    await feedback.FeedbackPortalCog._render_portal_message(cog, message)
+
+    message.edit.assert_awaited_once()
+    kwargs = message.edit.await_args.kwargs
+    assert kwargs["content"] is None
+    assert kwargs["embeds"] == []
+    assert kwargs["attachments"] == []
+    assert isinstance(kwargs["view"], discord.ui.LayoutView)
+
+
+@pytest.mark.asyncio
+async def test_ensure_portal_upgrades_legacy_message_without_duplicate(monkeypatch) -> None:
+    legacy_message = SimpleNamespace(
+        author=SimpleNamespace(id=999),
+        embeds=[discord.Embed(title=feedback.PORTAL_TITLE)],
+        components=[],
+        edit=AsyncMock(),
+    )
+
+    class DummyChannel:
+        def __init__(self) -> None:
+            self.send = AsyncMock()
+
+        def history(self, *, limit: int):
+            assert limit == 50
+
+            async def iterator():
+                yield legacy_message
+
+            return iterator()
+
+    channel = DummyChannel()
+    monkeypatch.setattr(feedback.discord.abc, "Messageable", DummyChannel)
+
+    bot = SimpleNamespace(
+        user=SimpleNamespace(id=999),
+        get_channel=lambda _channel_id: channel,
+    )
+    cog = feedback.FeedbackPortalCog(bot)
+
+    await cog.ensure_portal_message()
+
+    legacy_message.edit.assert_awaited_once()
+    channel.send.assert_not_awaited()
+
+
+def test_feedback_staff_controls_are_unchanged() -> None:
+    view = feedback.FeedbackStaffView(SimpleNamespace())
+    assert {
+        item.custom_id
+        for item in view.children
+        if isinstance(item, discord.ui.Button)
+    } == {"staff_approve", "staff_reject", "staff_delete"}

--- a/tests/test_feedback_portal_new_message_v2.py
+++ b/tests/test_feedback_portal_new_message_v2.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import discord
+import pytest
+
+import cogs.feedback_portal as feedback
+
+
+@pytest.mark.asyncio
+async def test_ensure_portal_creates_v2_message_when_missing(monkeypatch) -> None:
+    class DummyChannel:
+        def __init__(self) -> None:
+            self.send = AsyncMock(return_value=SimpleNamespace(id=123))
+
+        def history(self, *, limit: int):
+            assert limit == 50
+
+            async def iterator():
+                if False:
+                    yield None
+
+            return iterator()
+
+    channel = DummyChannel()
+    monkeypatch.setattr(feedback.discord.abc, "Messageable", DummyChannel)
+
+    bot = SimpleNamespace(
+        user=SimpleNamespace(id=999),
+        get_channel=lambda _channel_id: channel,
+    )
+    cog = feedback.FeedbackPortalCog(bot)
+
+    await cog.ensure_portal_message()
+
+    channel.send.assert_awaited_once()
+    kwargs = channel.send.await_args.kwargs
+    assert set(kwargs) == {"view"}
+    assert isinstance(kwargs["view"], discord.ui.LayoutView)


### PR DESCRIPTION
## Objectif
Moderniser uniquement le panneau public **📬 Centre de Retours & Support** avec Discord Components V2, sans modifier les formulaires, le traitement des retours ni les actions staff.

## Modifications
- migration de `FeedbackPortalView` vers `discord.ui.LayoutView` ;
- nouveau `Container` doré avec trois sections : Idée, Bug et Avis ;
- chaque section conserve son bouton existant directement en accessoire ;
- conservation stricte des `custom_id` : `btn_suggestion`, `btn_bug`, `btn_avis` ;
- ouverture des mêmes `SuggestionModal`, `BugReportModal` et `OpinionModal` ;
- migration en place de l'ancien message Embed vers Components V2 avec nettoyage explicite de `content`, `embeds` et `attachments` ;
- détection du portail par ancien titre d'Embed ou par contrat complet des trois `custom_id` imbriqués ;
- si aucun portail n'existe, création directe en Components V2 ;
- aucun changement sur `FeedbackStaffView`, les embeds staff, les DM ou les actions Valider / Refuser / Supprimer.

## Logique explicitement inchangée
- champs et identifiants des trois modals ;
- envoi des retours vers le salon staff ;
- format des embeds staff ;
- validation/refus/suppression côté staff ;
- extraction de l'ID utilisateur et DM de suivi ;
- réponses éphémères.

## Validation ajoutée
- contrat `LayoutView` persistant ;
- trois labels et `custom_id` inchangés ;
- ouverture des trois modals existants ;
- reconnaissance de l'ancien Embed et du nouveau V2 imbriqué ;
- migration en place sans création d'un doublon ;
- création V2 directe quand aucun portail n'existe ;
- contrôle que les trois boutons staff restent inchangés.

## Contrôle manuel demandé avant merge
Vérifier sur Discord qu'il n'existe qu'un seul Centre de Retours & Support, contrôler le rendu mobile/desktop, puis tester Idée / Bug / Avis jusqu'à l'ouverture et l'envoi des formulaires. Vérifier enfin que les messages staff et leurs boutons restent identiques.